### PR TITLE
Da/remove cap sigs

### DIFF
--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -187,7 +187,6 @@ async fn handle_kernel_request(
             };
 
             // check cap sigs & transform valid to unsigned to be plugged into procs
-            let pk = signature::UnparsedPublicKey::new(&signature::ED25519, keypair.public_key());
             let parent_caps: &HashMap<t::Capability, Vec<u8>> =
                 &process_map.get(&km.source.process).unwrap().capabilities;
             let mut valid_capabilities: HashMap<t::Capability, Vec<u8>> = HashMap::new();
@@ -200,7 +199,9 @@ async fn handle_kernel_request(
                 for cap in initial_capabilities {
                     match parent_caps.get(&cap) {
                         // NOTE: verifying sigs here would be unnecessary
-                        Some(sig) => valid_capabilities.insert(cap, sig.to_vec()),
+                        Some(sig) => {
+                            valid_capabilities.insert(cap, sig.to_vec());
+                        }
                         None => {
                             println!(
                                 "kernel: InitializeProcess caller {} doesn't have capability\r",

--- a/src/types.rs
+++ b/src/types.rs
@@ -959,6 +959,7 @@ pub enum KernelResponse {
 
 #[derive(Debug)]
 pub enum CapMessage {
+    /// root access: uncritically sign and add all `caps` to `on`
     Add {
         on: ProcessId,
         caps: Vec<Capability>,
@@ -970,17 +971,21 @@ pub enum CapMessage {
         cap: Capability,
         responder: tokio::sync::oneshot::Sender<bool>,
     },
+    /// does `on` have `cap` in its store?
     Has {
         // a bool is given in response here
         on: ProcessId,
         cap: Capability,
         responder: tokio::sync::oneshot::Sender<bool>,
     },
+    /// return all caps in `on`'s store
     GetAll {
         on: ProcessId,
         responder: tokio::sync::oneshot::Sender<Vec<(Capability, Vec<u8>)>>,
     },
-    GetSome {
+    /// before `on` sends a message, filter out any bogus caps it may have attached, sign any new
+    /// caps it may have created, and retreive the signature for the caps in its store.
+    FilterCaps {
         on: ProcessId,
         caps: Vec<Capability>,
         responder: tokio::sync::oneshot::Sender<Vec<(Capability, Vec<u8>)>>,


### PR DESCRIPTION
- removes all unnecessary signature verification from capabilities
- changes `CapMessage::GetSome` to `CapMessage::FilterCaps`
- re-signs all capabilities on boot to fix any issues with invalid caps when booting after a key reset
  - note that since we don't check local signatures, this doesn't matter in 99% of cases. But without doing this, we would risk sharing an outdated cap-signature with a foreign node. Since it doesn't change boot-time much, I just re-sign every local cap on boot
