### PR TITLE
app_store: fix `get_capability()` bug by using fixed process_lib

### DIFF
--- a/modules/app_store/app_store/Cargo.lock
+++ b/modules/app_store/app_store/Cargo.lock
@@ -190,8 +190,8 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "kinode_process_lib"
-version = "0.5.0"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?rev=9790c0f#9790c0fecc64572d1fbeecdf3724eb37b3d6d3fa"
+version = "0.5.4"
+source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?rev=437093e#437093e884deefc436a71978f5422a47bdddc5a5"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/app_store/app_store/Cargo.toml
+++ b/modules/app_store/app_store/Cargo.toml
@@ -15,7 +15,7 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.8"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "8d98e67" }
+kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "437093e" }
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
 
 [lib]

--- a/modules/app_store/app_store/Cargo.toml
+++ b/modules/app_store/app_store/Cargo.toml
@@ -15,7 +15,7 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.8"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "437093e" }
+kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", tag = "v0.5.5-alpha" }
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
 
 [lib]

--- a/modules/app_store/app_store/Cargo.toml
+++ b/modules/app_store/app_store/Cargo.toml
@@ -15,7 +15,7 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.8"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "9790c0f" }
+kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "8d98e67" }
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
 
 [lib]


### PR DESCRIPTION
Fix the app store by using https://github.com/uqbar-dao/process_lib/pull/33

I don't have the time to go through the codebase and check right now, but someone needs to be assigned to:

1. Check through all capabilities comparisons to make sure they are not doing same improper equality check as in https://github.com/uqbar-dao/process_lib/pull/33
2. Make sure https://github.com/uqbar-dao/process_lib/pull/33 is a fix we're comfortable with (there may [should?] be a better way to do it)
3. Check through all processes to make sure that if they are using `get_capability()` (and any other affected functions found in 3) that they are pointing to a new enough `process_lib`.