### PR TITLE
change ssh import to https

### DIFF
--- a/modules/app_store/app_store/Cargo.lock
+++ b/modules/app_store/app_store/Cargo.lock
@@ -191,7 +191,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "kinode_process_lib"
 version = "0.5.5"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?tag=v0.5.5-alpha#722f2dbfbcc4d1bf5da1fa5db137632a3cede44c"
+source = "git+https://github.com/uqbar-dao/process_lib.git?tag=v0.5.5-alpha#722f2dbfbcc4d1bf5da1fa5db137632a3cede44c"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/app_store/app_store/Cargo.toml
+++ b/modules/app_store/app_store/Cargo.toml
@@ -11,11 +11,11 @@ lto = true
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.3"
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", tag = "v0.5.5-alpha" }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.8"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", tag = "v0.5.5-alpha" }
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
 
 [lib]

--- a/modules/app_store/ft_worker/Cargo.lock
+++ b/modules/app_store/ft_worker/Cargo.lock
@@ -141,8 +141,8 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "kinode_process_lib"
-version = "0.5.0"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?tag=v0.5.3-alpha#8de14aa7132e6b7992c720c6aae24a64e108779d"
+version = "0.5.5"
+source = "git+https://github.com/uqbar-dao/process_lib.git?tag=v0.5.5-alpha#722f2dbfbcc4d1bf5da1fa5db137632a3cede44c"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/app_store/ft_worker/Cargo.toml
+++ b/modules/app_store/ft_worker/Cargo.toml
@@ -13,10 +13,10 @@ lto = true
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.3"
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", tag = "v0.5.5-alpha" }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", tag = "v0.5.3-alpha" }
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
 
 [lib]

--- a/modules/chess/chess/Cargo.lock
+++ b/modules/chess/chess/Cargo.lock
@@ -230,8 +230,8 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "kinode_process_lib"
-version = "0.5.0"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?rev=5305453#5305453c306e69ccdb4c0ac4b385d09e86a3b6e4"
+version = "0.5.5"
+source = "git+https://github.com/uqbar-dao/process_lib.git?tag=v0.5.5-alpha#722f2dbfbcc4d1bf5da1fa5db137632a3cede44c"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/chess/chess/Cargo.toml
+++ b/modules/chess/chess/Cargo.toml
@@ -12,11 +12,11 @@ lto = true
 anyhow = "1.0"
 base64 = "0.13"
 bincode = "1.3.3"
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", tag = "v0.5.5-alpha" }
 pleco = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 url = "*"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "5305453" }
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
 
 [lib]

--- a/modules/homepage/homepage/Cargo.lock
+++ b/modules/homepage/homepage/Cargo.lock
@@ -140,8 +140,8 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "kinode_process_lib"
-version = "0.5.0"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?tag=v0.5.3-alpha#8de14aa7132e6b7992c720c6aae24a64e108779d"
+version = "0.5.5"
+source = "git+https://github.com/uqbar-dao/process_lib.git?tag=v0.5.5-alpha#722f2dbfbcc4d1bf5da1fa5db137632a3cede44c"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/homepage/homepage/Cargo.toml
+++ b/modules/homepage/homepage/Cargo.toml
@@ -13,9 +13,9 @@ lto = true
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.3"
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", tag = "v0.5.5-alpha" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", tag = "v0.5.3-alpha" }
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
 
 [lib]

--- a/modules/kns_indexer/kns_indexer/Cargo.lock
+++ b/modules/kns_indexer/kns_indexer/Cargo.lock
@@ -1047,8 +1047,8 @@ dependencies = [
 
 [[package]]
 name = "kinode_process_lib"
-version = "0.5.0"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?tag=v0.5.3-alpha#8de14aa7132e6b7992c720c6aae24a64e108779d"
+version = "0.5.5"
+source = "git+https://github.com/uqbar-dao/process_lib.git?tag=v0.5.5-alpha#722f2dbfbcc4d1bf5da1fa5db137632a3cede44c"
 dependencies = [
  "alloy-rpc-types",
  "anyhow",

--- a/modules/kns_indexer/kns_indexer/Cargo.toml
+++ b/modules/kns_indexer/kns_indexer/Cargo.toml
@@ -17,10 +17,10 @@ alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy.git", rev = "3b1c31
 alloy-sol-types = "0.5.1"
 bincode = "1.3.3"
 hex = "0.4.3"
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", tag = "v0.5.5-alpha", features = ["eth"] }
 rmp-serde = "1.1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", tag = "v0.5.3-alpha", features = ["eth"] }
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
 
 [lib]

--- a/modules/terminal/cat/Cargo.lock
+++ b/modules/terminal/cat/Cargo.lock
@@ -140,7 +140,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "kinode_process_lib"
 version = "0.5.5"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
+source = "git+https://github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/terminal/cat/Cargo.toml
+++ b/modules/terminal/cat/Cargo.toml
@@ -10,7 +10,7 @@ lto = true
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }

--- a/modules/terminal/echo/Cargo.lock
+++ b/modules/terminal/echo/Cargo.lock
@@ -140,7 +140,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "kinode_process_lib"
 version = "0.5.5"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
+source = "git+https://github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/terminal/echo/Cargo.toml
+++ b/modules/terminal/echo/Cargo.toml
@@ -10,7 +10,7 @@ lto = true
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }

--- a/modules/terminal/hi/Cargo.lock
+++ b/modules/terminal/hi/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "kinode_process_lib"
 version = "0.5.5"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
+source = "git+https://github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/terminal/hi/Cargo.toml
+++ b/modules/terminal/hi/Cargo.toml
@@ -9,7 +9,7 @@ opt-level = "s"
 lto = true
 
 [dependencies]
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }

--- a/modules/terminal/m/Cargo.lock
+++ b/modules/terminal/m/Cargo.lock
@@ -129,7 +129,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "kinode_process_lib"
 version = "0.5.5"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
+source = "git+https://github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/terminal/m/Cargo.toml
+++ b/modules/terminal/m/Cargo.toml
@@ -10,7 +10,7 @@ lto = true
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }

--- a/modules/terminal/terminal/Cargo.lock
+++ b/modules/terminal/terminal/Cargo.lock
@@ -129,7 +129,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "kinode_process_lib"
 version = "0.5.5"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
+source = "git+https://github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/terminal/terminal/Cargo.toml
+++ b/modules/terminal/terminal/Cargo.toml
@@ -13,10 +13,10 @@ lto = true
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.3"
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
 
 [lib]

--- a/modules/terminal/top/Cargo.lock
+++ b/modules/terminal/top/Cargo.lock
@@ -129,7 +129,7 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 [[package]]
 name = "kinode_process_lib"
 version = "0.5.5"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
+source = "git+https://github.com/uqbar-dao/process_lib.git?rev=329c7a8#329c7a8314973c857db38c7b712318de9349eb6e"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/terminal/top/Cargo.toml
+++ b/modules/terminal/top/Cargo.toml
@@ -10,7 +10,7 @@ lto = true
 
 [dependencies]
 anyhow = "1.0"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }

--- a/modules/tester/test_runner/Cargo.lock
+++ b/modules/tester/test_runner/Cargo.lock
@@ -128,8 +128,8 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "kinode_process_lib"
-version = "0.5.0"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?rev=59da820#59da820e8468c1bab510536062828d4241528145"
+version = "0.5.5"
+source = "git+https://github.com/uqbar-dao/process_lib.git?tag=v0.5.5-alpha#722f2dbfbcc4d1bf5da1fa5db137632a3cede44c"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/tester/test_runner/Cargo.toml
+++ b/modules/tester/test_runner/Cargo.toml
@@ -13,7 +13,7 @@ lto = true
 [dependencies]
 anyhow = "1.0"
 bincode = "1.3.3"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", rev = "59da820" }
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", tag = "v0.5.5-alpha" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/modules/tester/tester/Cargo.lock
+++ b/modules/tester/tester/Cargo.lock
@@ -128,8 +128,8 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "kinode_process_lib"
-version = "0.5.0"
-source = "git+ssh://git@github.com/uqbar-dao/process_lib.git?tag=v0.5.3-alpha#8de14aa7132e6b7992c720c6aae24a64e108779d"
+version = "0.5.5"
+source = "git+https://github.com/uqbar-dao/process_lib.git?tag=v0.5.5-alpha#722f2dbfbcc4d1bf5da1fa5db137632a3cede44c"
 dependencies = [
  "anyhow",
  "bincode",

--- a/modules/tester/tester/Cargo.toml
+++ b/modules/tester/tester/Cargo.toml
@@ -14,10 +14,10 @@ lto = true
 anyhow = "1.0"
 bincode = "1.3.3"
 indexmap = "2.1"
+kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", tag = "v0.5.5-alpha" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-kinode_process_lib = { git = "ssh://git@github.com/uqbar-dao/process_lib.git", tag = "v0.5.3-alpha" }
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }
 
 [lib]


### PR DESCRIPTION
Inspired by https://github.com/uqbar-dao/kit/issues/46

There is no reason we need to use `ssh://` now that we're public and it won't work for users that don't have their git set up in a certain way. Therefore, use `https://`.