### PR TITLE
add python code runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ target.wasm
 world
 .env
 src/bootstrapped_processes.rs
+src/python_includes.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,6 +2758,7 @@ dependencies = [
  "uuid 1.4.1",
  "walkdir",
  "warp",
+ "wasi-common",
  "wasmtime",
  "wasmtime-wasi",
  "zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ repository = "https://github.com/uqbar-dao/kinode"
 license = "Apache-2.0"
 
 [build-dependencies]
+anyhow = "1.0.71"
 reqwest = { version = "0.11.22", features = ["blocking"] }
 sha2 = "0.10"
+tokio = { version = "1.28", features = ["macros"] }
 walkdir = "2.4"
 zip = "0.6"
 
@@ -70,6 +72,7 @@ tokio-tungstenite = "0.20.1"
 url = "2.4.1"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 warp = "0.3.5"
+wasi-common = "15.0.1"
 wasmtime = "15.0.1"
 wasmtime-wasi = "15.0.1"
 zip = "0.6"

--- a/build.rs
+++ b/build.rs
@@ -183,9 +183,8 @@ async fn main() -> anyhow::Result<()> {
     // Get python.wasm & include it
     let mut python_includes =
         fs::File::create(format!("{}/src/python_includes.rs", pwd.display())).unwrap();
-    let python_wasm_file_path = get_python_wasm(
-        &format!("{}/{}", PYTHON_WASM_URL, PYTHON_WASM_FILE_NAME)
-    ).await?;
+    let python_wasm_file_path =
+        get_python_wasm(&format!("{}/{}", PYTHON_WASM_URL, PYTHON_WASM_FILE_NAME)).await?;
     writeln!(
         python_includes,
         "pub static PYTHON_WASM: &[u8] = include_bytes!(\"{}\");",

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,9 @@ use std::{
     io::{Read, Write},
 };
 
+const PYTHON_WASM_FILE_NAME: &str = "python-3.12.0.wasm";
+const PYTHON_WASM_URL: &str = "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.12.0%2B20231211-040d5a6";
+
 fn run_command(cmd: &mut Command) -> io::Result<()> {
     let status = cmd.status()?;
     if status.success() {
@@ -31,6 +34,22 @@ where
         // output file not found, we are outdated
         Ok(true)
     }
+}
+
+async fn get_python_wasm(url: &str) -> anyhow::Result<String> {
+    let pwd = std::env::current_dir().unwrap();
+    let path = format!("{}/target/{}", pwd.display(), PYTHON_WASM_FILE_NAME);
+    if !std::path::Path::new(&path).exists() {
+        let response = reqwest::get(url).await?;
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!("couldn't get python.wasm"));
+        } else {
+            let content = response.bytes().await?;
+            let mut file = fs::File::create(&path)?;
+            file.write_all(&content)?;
+        }
+    }
+    Ok(path)
 }
 
 fn build_app(target_path: &str, name: &str, parent_pkg_path: Option<&str>) {
@@ -127,10 +146,11 @@ fn build_app(target_path: &str, name: &str, parent_pkg_path: Option<&str>) {
     );
 }
 
-fn main() {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     if std::env::var("SKIP_BUILD_SCRIPT").is_ok() {
         println!("Skipping build script");
-        return;
+        return Ok(());
     }
 
     let pwd = std::env::current_dir().unwrap();
@@ -160,9 +180,22 @@ fn main() {
     .unwrap();
     run_command(Command::new("touch").args([&format!("{}/world", pwd.display())])).unwrap();
 
+    // Get python.wasm & include it
+    let mut python_includes =
+        fs::File::create(format!("{}/src/python_includes.rs", pwd.display())).unwrap();
+    let python_wasm_file_path = get_python_wasm(
+        &format!("{}/{}", PYTHON_WASM_URL, PYTHON_WASM_FILE_NAME)
+    ).await?;
+    writeln!(
+        python_includes,
+        "pub static PYTHON_WASM: &[u8] = include_bytes!(\"{}\");",
+        python_wasm_file_path,
+    )
+    .unwrap();
+
     // Build wasm32-wasi apps, zip, and add to bootstrapped_processes.rs
     let mut bootstrapped_processes =
-        fs::File::create(format!("{}/src/bootstrapped_processes.rs", pwd.display(),)).unwrap();
+        fs::File::create(format!("{}/src/bootstrapped_processes.rs", pwd.display())).unwrap();
     writeln!(
         bootstrapped_processes,
         "pub static BOOTSTRAPPED_PROCESSES: &[(&str, &[u8])] = &[",
@@ -227,4 +260,6 @@ fn main() {
         .unwrap();
     }
     writeln!(bootstrapped_processes, "];").unwrap();
+
+    Ok(())
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,0 +1,159 @@
+use wasi_common::pipe::{ReadPipe, WritePipe};
+use wasmtime::{Config, Engine, Linker, Module, Store};
+use wasmtime_wasi::WasiCtxBuilder;
+
+use crate::types::{Address, KernelMessage, LazyLoadBlob, Message, MessageReceiver, MessageSender, PythonRequest, PythonResponse, Request, Response, PYTHON_PROCESS_ID};
+
+include!("python_includes.rs");
+
+pub async fn python(
+    our_node: String,
+    send_to_loop: MessageSender,
+    mut recv_from_loop: MessageReceiver,
+) -> anyhow::Result<()> {
+    loop {
+        let km = recv_from_loop.recv().await.unwrap();
+        let KernelMessage { id, source, rsvp, message, lazy_load_blob, .. } = km;
+        if our_node != source.node {
+            println!(
+                "python: Request must come from our_node={}, got: {}\r",
+                our_node,
+                source.node,
+            );
+            continue;
+        }
+        let Message::Request(Request { ref body, .. }) = message else {
+            println!("python: got a non-Request\r");
+            continue;
+        };
+        let Ok(PythonRequest::Run) = serde_json::from_slice(body) else {
+            println!("python: got a non-Run Request\r");
+            continue;
+        };
+        let Some(lazy_load_blob) = lazy_load_blob else {
+            println!("python: Run Request must contain a lazy_load_blob\r");
+            continue;
+        };
+        let Ok(code) = String::from_utf8(lazy_load_blob.bytes) else {
+            println!("python: got a bad `code` in `blob` (must be utf-8)\r");
+            continue;
+        };
+        let target = rsvp.unwrap_or_else(|| source);
+
+        let our_node = our_node.clone();
+        let send_to_loop = send_to_loop.clone();
+        tokio::spawn(async move {
+            let message = match run_python(&code).await {
+                Ok(output) => make_output_message(our_node, id, target, output),
+                Err(e) => make_error_message(our_node, id, target, format!("{:?}", e)),
+            };
+            let _ = send_to_loop
+                .send(message)
+                .await;
+        });
+    }
+}
+
+async fn run_python(code: &str) -> anyhow::Result<Vec<u8>> {
+    let wasi_stdin = ReadPipe::from(code);
+    let wasi_stdout = WritePipe::new_in_memory();
+
+    {
+        // Define the WASI functions globally on the `Config`.
+        let mut config = Config::new();
+        config.async_support(true);
+        let engine = Engine::new(&config)?;
+        let mut linker = Linker::new(&engine);
+        wasmtime_wasi::add_to_linker(&mut linker, |s| s)?;
+
+        // uncomment to bring in non-stdlib libs (except those containing C code)
+        // let dir = cap_std::fs::Dir::open_ambient_dir(
+        //     "venv",
+        //     cap_std::ambient_authority(),
+        // ).unwrap();
+
+        // Create a WASI context and put it in a Store; all instances in the store
+        // share this context. `WasiCtxBuilder` provides a number of ways to
+        // configure what the target program will have access to.
+        let wasi = WasiCtxBuilder::new()
+            // uncomment to bring in non-stdlib libs (except those containing C code)
+            // .preopened_dir(dir, "/venv")?
+            // .env("PYTHONPATH", "/venv/lib/python3.12/site-packages")?
+            .stdin(Box::new(wasi_stdin.clone()))
+            .stdout(Box::new(wasi_stdout.clone()))
+            .build();
+        let mut store = Store::new(&engine, wasi);
+
+        // Instantiate our module with the imports we've created, and run it.
+        let module = Module::from_binary(&engine, PYTHON_WASM)?;
+        linker.module_async(&mut store, "", &module).await?;
+        linker
+            .get_default(&mut store, "")?
+            .typed::<(), ()>(&store)?
+            .call_async(&mut store, ()).await?;
+    }
+
+    let contents: Vec<u8> = wasi_stdout
+        .try_into_inner()
+        .expect("sole remaining reference to WritePipe")
+        .into_inner();
+
+    Ok(contents)
+}
+
+fn make_output_message(
+    our_node: String,
+    id: u64,
+    target: Address,
+    output: Vec<u8>,
+) -> KernelMessage {
+    KernelMessage {
+        id,
+        source: Address {
+            node: our_node,
+            process: PYTHON_PROCESS_ID.clone(),
+        },
+        target,
+        rsvp: None,
+        message: Message::Response((
+            Response {
+                inherit: false,
+                body: serde_json::to_vec(&PythonResponse::Run).unwrap(),
+                metadata: None,
+                capabilities: vec![],
+            },
+            None,
+        )),
+        lazy_load_blob: Some(LazyLoadBlob {
+            mime: None,
+            bytes: output,
+        }),
+    }
+}
+
+fn make_error_message(
+    our_node: String,
+    id: u64,
+    target: Address,
+    error: String,
+) -> KernelMessage {
+    KernelMessage {
+        id,
+        source: Address {
+            node: our_node,
+            process: PYTHON_PROCESS_ID.clone(),
+        },
+        target,
+        rsvp: None,
+        message: Message::Response((
+            Response {
+                inherit: false,
+                body: serde_json::to_vec(&PythonResponse::Err(error)).unwrap(),
+                metadata: None,
+                capabilities: vec![],
+            },
+            None,
+        )),
+        lazy_load_blob: None,
+    }
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -105,18 +105,14 @@ async fn run_python(code: &str) -> anyhow::Result<Vec<u8>> {
     };
 
     let contents: Vec<u8> = match result {
-        Ok(_) => {
-            wasi_stdout
-                .try_into_inner()
-                .expect("sole remaining reference to WritePipe")
-                .into_inner()
-        }
-        Err(_) => {
-            wasi_stderr
-                .try_into_inner()
-                .expect("sole remaining reference to WritePipe")
-                .into_inner()
-        }
+        Ok(_) => wasi_stdout
+            .try_into_inner()
+            .expect("sole remaining reference to WritePipe")
+            .into_inner(),
+        Err(_) => wasi_stderr
+            .try_into_inner()
+            .expect("sole remaining reference to WritePipe")
+            .into_inner(),
     };
 
     Ok(contents)

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,6 +15,7 @@ lazy_static::lazy_static! {
     pub static ref STATE_PROCESS_ID: ProcessId = ProcessId::new(Some("state"), "distro", "sys");
     pub static ref KV_PROCESS_ID: ProcessId = ProcessId::new(Some("kv"), "distro", "sys");
     pub static ref SQLITE_PROCESS_ID: ProcessId = ProcessId::new(Some("sqlite"), "distro", "sys");
+    pub static ref PYTHON_PROCESS_ID: ProcessId = ProcessId::new(Some("python"), "distro", "sys");
 }
 
 //
@@ -1337,4 +1338,17 @@ pub enum SqliteError {
     RusqliteError { error: String },
     #[error("sqlite: input bytes/json/key error: {error}")]
     InputError { error: String },
+}
+
+// python Requests and Responses encode the Request `code`
+//  and the Response `output` in the `lazy_load_blob`
+#[derive(Debug, Serialize, Deserialize)]
+pub enum PythonRequest {
+    Run,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum PythonResponse {
+    Run,
+    Err(String),
 }

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -73,8 +73,9 @@ pub async fn vfs(
                         )
                         .await
                         {
+                            let target = km.rsvp.unwrap_or_else(|| km.source);
                             let _ = send_to_loop
-                                .send(make_error_message(our_node.clone(), km.id, km.source, e))
+                                .send(make_error_message(our_node.clone(), km.id, target, e))
                                 .await;
                         }
                     }
@@ -781,7 +782,7 @@ fn get_file_type(metadata: &std::fs::Metadata) -> FileType {
 fn make_error_message(
     our_node: String,
     id: u64,
-    source: Address,
+    target: Address,
     error: VfsError,
 ) -> KernelMessage {
     KernelMessage {
@@ -790,7 +791,7 @@ fn make_error_message(
             node: our_node,
             process: VFS_PROCESS_ID.clone(),
         },
-        target: source,
+        target,
         rsvp: None,
         message: Message::Response((
             Response {


### PR DESCRIPTION
# Goal

Enable an AI-assisted workflow for developing vanilla python code that looks like
1. Prompt LLM, e.g., "write a program that computes the fibonacci sequence",
2. LLM generates python code,
3. Run python code,
4. Take result and iterate python code until it is correct.

This PR enables 3. In particular, it is important that the python be sandboxed from the rest of the system, since it may be faulty and may even be malicious (in the case of prompt injection to the LLM). Note that this code correctly handles & returns error output from the python interpreter, which is vitally important for the proposed workflow.

# API

API is very simple:

https://github.com/uqbar-dao/kinode/blob/ae9fd4254860373cb4e00cacf2b080b3203295ab/src/types.rs#L1343-L1354

1. Send a `"Run"` `Request` with utf-8 bytes in the blob: those bytes are the python code.
6. Receive a `"Run"` `Response` with utf-8 bytes in the blob: those bytes are the stdout/stderr of the python code being run.

# Usage

Usage looks like:

https://twitter.com/nick1udwig/status/1750037861750210942

# Notes

We `include_bytes!()` the `python.wasm` in the runtime. This adds roughly 20MB to the size of the runtime. There are two ways we could reduce this:
1. Compress the `.wasm` before including it. This roughly halves the size.
2. Fetch the `.wasm` at runtime and store it in memory. This would probably look to the user like an initial "startup" period of the `python` runtime module.