### PR TITLE
Da/m response

### DIFF
--- a/modules/terminal/m/Cargo.lock
+++ b/modules/terminal/m/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,10 +258,17 @@ dependencies = [
  "anyhow",
  "clap",
  "kinode_process_lib",
+ "regex",
  "serde",
  "serde_json",
  "wit-bindgen",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "mime"
@@ -329,6 +345,35 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ryu"

--- a/modules/terminal/m/Cargo.lock
+++ b/modules/terminal/m/Cargo.lock
@@ -3,6 +3,54 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +82,39 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "equivalent"
@@ -166,6 +247,7 @@ name = "m"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "kinode_process_lib",
  "serde",
  "serde_json",
@@ -307,6 +389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +494,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +565,72 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "wit-bindgen"

--- a/modules/terminal/m/Cargo.toml
+++ b/modules/terminal/m/Cargo.toml
@@ -12,6 +12,7 @@ lto = true
 anyhow = "1.0"
 clap = "4.4.18"
 kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
+regex = "1.10.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "efcc759" }

--- a/modules/terminal/m/Cargo.toml
+++ b/modules/terminal/m/Cargo.toml
@@ -10,6 +10,7 @@ lto = true
 
 [dependencies]
 anyhow = "1.0"
+clap = "4.4.18"
 kinode_process_lib = { git = "https://github.com/uqbar-dao/process_lib.git", rev = "329c7a8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/modules/terminal/m/src/lib.rs
+++ b/modules/terminal/m/src/lib.rs
@@ -37,16 +37,21 @@ fn init(_our: Address) {
 
     println!("{:?}", args);
 
-    let parsed = Command::new("m")
+    let Ok(parsed) = Command::new("m")
         .disable_help_flag(true)
         .arg(Arg::new("target").index(1).required(true))
         .arg(Arg::new("body").index(2).required(true))
         .arg(
             Arg::new("await")
                 .short('a')
+                .long("await")
                 .value_parser(clap::value_parser!(u64)),
         )
-        .get_matches_from(args);
+        .try_get_matches_from(args)
+    else {
+        println!("m: failed to parse args");
+        return;
+    };
 
     let Some(target) = parsed.get_one::<String>("target") else {
         println!("m: no target");

--- a/modules/terminal/m/src/lib.rs
+++ b/modules/terminal/m/src/lib.rs
@@ -35,8 +35,6 @@ fn init(_our: Address) {
 
     args.insert(0, "m".to_string());
 
-    println!("{:?}", args);
-
     let Ok(parsed) = Command::new("m")
         .disable_help_flag(true)
         .arg(Arg::new("target").index(1).required(true))
@@ -73,17 +71,12 @@ fn init(_our: Address) {
     match parsed.get_one::<u64>("await") {
         Some(s) => {
             println!("m: awaiting response for {}s", s);
-            match req.send_and_await_response(*s) {
-                Ok(res) => match res {
-                    Ok(res) => {
-                        println!("m: {:?}", res);
-                    }
-                    Err(e) => {
-                        println!("m: SendError: {:?}", e.kind);
-                    }
-                },
-                Err(_) => {
-                    println!("m: unexpected error sending request");
+            match req.send_and_await_response(*s).unwrap() {
+                Ok(res) => {
+                    println!("m: {:?}", res);
+                }
+                Err(e) => {
+                    println!("m: SendError: {:?}", e.kind);
                 }
             }
         }

--- a/modules/terminal/m/src/lib.rs
+++ b/modules/terminal/m/src/lib.rs
@@ -1,3 +1,4 @@
+use clap::{Arg, Command};
 use kinode_process_lib::{await_next_request_body, call_init, println, Address, Request};
 
 wit_bindgen::generate!({
@@ -11,32 +12,64 @@ wit_bindgen::generate!({
 call_init!(init);
 
 fn init(_our: Address) {
-    let Ok(args) = await_next_request_body() else {
+    let Ok(body) = await_next_request_body() else {
         println!("m: failed to get args, aborting");
         return;
     };
+    let body_string = String::from_utf8(body).unwrap();
 
-    let tail = String::from_utf8(args).unwrap();
+    let mut args: Vec<&str> = body_string.split_whitespace().collect();
+    args.insert(0, "m");
 
-    let (target, body) = match tail.split_once(" ") {
-        Some((a, p)) => (a, p),
-        None => {
-            println!("m: invalid command, please provide an address and json message");
-            return;
+    println!("{:?}", args);
+
+    let parsed = Command::new("m")
+        .disable_help_flag(true)
+        .arg(Arg::new("target").index(1).required(true))
+        .arg(Arg::new("body").index(2).required(true))
+        .arg(
+            Arg::new("await")
+                .short('a')
+                .value_parser(clap::value_parser!(u64)),
+        )
+        .get_matches_from(args);
+
+    let Some(target) = parsed.get_one::<String>("target") else {
+        println!("m: no target");
+        return;
+    };
+
+    let Ok(target) = target.parse::<Address>() else {
+        println!("invalid address: \"{target}\"");
+        return;
+    };
+
+    let Some(body) = parsed.get_one::<String>("body") else {
+        println!("m: no body");
+        return;
+    };
+
+    let req = Request::new().target(target).body(body.as_bytes().to_vec());
+
+    match parsed.get_one::<u64>("await") {
+        Some(s) => {
+            println!("m: awaiting response for {}s", s);
+            match req.send_and_await_response(*s) {
+                Ok(res) => match res {
+                    Ok(res) => {
+                        println!("m: {:?}", res);
+                    }
+                    Err(e) => {
+                        println!("m: SendError: {:?}", e.kind);
+                    }
+                },
+                Err(_) => {
+                    println!("m: unexpected error sending request");
+                }
+            }
         }
-    };
-    // TODO aliasing logic...maybe we can read from terminal state since we have root?
-    let target = match target.parse::<Address>() {
-        Ok(t) => t,
-        Err(_) => {
-            println!("invalid address: \"{target}\"");
-            return;
-        } // match state.aliases.get(target) {
-          //     Some(pid) => Address::new("our", pid.clone()),
-          //     None => {
-          //         return Err(anyhow!("invalid address: \"{target}\""));
-          //     }
-          // },
-    };
-    let _ = Request::new().target(target).body(body).send().unwrap();
+        None => {
+            let _ = req.send().unwrap();
+        }
+    }
 }


### PR DESCRIPTION
fixes the issues addressed in #208 
`m` now has the `-a` flag, which stands for `--await`
`m -a our@foo:bar:baz '{"some": "data"}'`