### PR TITLE
Da/grant-caps

### DIFF
--- a/kinode/packages/app_store/app_store/src/lib.rs
+++ b/kinode/packages/app_store/app_store/src/lib.rs
@@ -473,13 +473,6 @@ fn handle_install(our: &Address, package: &PackageId) -> anyhow::Result<()> {
             format!("/{}", entry.process_wasm_path)
         };
         let wasm_path = format!("{}{}", drive_path, wasm_path);
-        // build initial caps
-        let mut initial_capabilities: HashSet<kt::Capability> = HashSet::new();
-        if entry.request_networking {
-            initial_capabilities.insert(kt::de_wit_capability(networking_cap.clone()));
-        }
-        initial_capabilities.insert(kt::de_wit_capability(read_cap.clone()));
-        initial_capabilities.insert(kt::de_wit_capability(write_cap.clone()));
         let process_id = format!("{}:{}", entry.process_name, package);
         let Ok(parsed_new_process_id) = process_id.parse::<ProcessId>() else {
             return Err(anyhow::anyhow!("app store: invalid process id!"));
@@ -499,17 +492,37 @@ fn handle_install(our: &Address, package: &PackageId) -> anyhow::Result<()> {
                 action: vfs::VfsAction::Read,
             })?)
             .send_and_await_response(5)??;
+
+        Request::new()
+            .target(("our", "kernel", "distro", "sys"))
+            .body(serde_json::to_vec(&kt::KernelCommand::InitializeProcess {
+                id: parsed_new_process_id.clone(),
+                wasm_bytes_handle: wasm_path,
+                wit_version: None,
+                on_exit: entry.on_exit.clone(),
+                initial_capabilities: HashSet::new(),
+                public: entry.public,
+            })?)
+            .inherit(true)
+            .send_and_await_response(5)??;
+        // build initial caps
+        let mut requested_capabilities: Vec<kt::Capability> = vec![];
         for value in &entry.request_capabilities {
-            let mut capability = None;
             match value {
                 serde_json::Value::String(process_name) => {
                     if let Ok(parsed_process_id) = process_name.parse::<ProcessId>() {
-                        capability = get_capability(
-                            &Address {
+                        requested_capabilities.push(kt::Capability {
+                            issuer: Address {
                                 node: our.node.clone(),
                                 process: parsed_process_id.clone(),
                             },
-                            "\"messaging\"".into(),
+                            params: "\"messaging\"".into(),
+                        });
+                    } else {
+                        println!(
+                            "app-store: invalid cap: {} for {} to request!",
+                            value.to_string(),
+                            package
                         );
                     }
                 }
@@ -521,12 +534,18 @@ fn handle_install(our: &Address, package: &PackageId) -> anyhow::Result<()> {
                             .parse::<ProcessId>()
                         {
                             if let Some(params) = map.get("params") {
-                                capability = get_capability(
-                                    &Address {
+                                requested_capabilities.push(kt::Capability {
+                                    issuer: Address {
                                         node: our.node.clone(),
                                         process: parsed_process_id.clone(),
                                     },
-                                    &params.to_string(),
+                                    params: params.to_string(),
+                                });
+                            } else {
+                                println!(
+                                    "app-store: invalid cap: {} for {} to request!",
+                                    value.to_string(),
+                                    package
                                 );
                             }
                         }
@@ -536,27 +555,18 @@ fn handle_install(our: &Address, package: &PackageId) -> anyhow::Result<()> {
                     continue;
                 }
             }
-            if let Some(cap) = capability {
-                initial_capabilities.insert(kt::de_wit_capability(cap));
-            } else {
-                println!(
-                    "app-store: no cap: {} for {} to request!",
-                    value.to_string(),
-                    package
-                );
-            }
         }
+        if entry.request_networking {
+            requested_capabilities.push(kt::de_wit_capability(networking_cap.clone()));
+        }
+        requested_capabilities.push(kt::de_wit_capability(read_cap.clone()));
+        requested_capabilities.push(kt::de_wit_capability(write_cap.clone()));
         Request::new()
             .target(("our", "kernel", "distro", "sys"))
-            .body(serde_json::to_vec(&kt::KernelCommand::InitializeProcess {
-                id: parsed_new_process_id.clone(),
-                wasm_bytes_handle: wasm_path,
-                wit_version: None,
-                on_exit: entry.on_exit.clone(),
-                initial_capabilities,
-                public: entry.public,
+            .body(serde_json::to_vec(&kt::KernelCommand::GrantCapabilities {
+                target: parsed_new_process_id.clone(),
+                capabilities: requested_capabilities,
             })?)
-            .inherit(true)
             .send_and_await_response(5)??;
     }
     // THEN, *after* all processes have been initialized, grant caps in manifest

--- a/kinode/packages/terminal/pkg/scripts.json
+++ b/kinode/packages/terminal/pkg/scripts.json
@@ -52,7 +52,7 @@
     },
     "m.wasm": {
         "root": true,
-        "public": false,
+        "public": true,
         "request_networking": true
     }
 }

--- a/kinode/packages/terminal/terminal/src/lib.rs
+++ b/kinode/packages/terminal/terminal/src/lib.rs
@@ -298,15 +298,12 @@ fn handle_run(
             },
         ),
     );
-    let _ = Request::new()
+    Request::new()
         .target(("our", "kernel", "distro", "sys"))
-        .body(
-            serde_json::to_vec(&kt::KernelCommand::GrantCapabilities {
-                target: parsed_new_process_id.clone(),
-                capabilities: requested_caps,
-            })
-            .unwrap(),
-        )
+        .body(serde_json::to_vec(&kt::KernelCommand::GrantCapabilities {
+            target: parsed_new_process_id.clone(),
+            capabilities: requested_caps,
+        })?)
         .send()?;
     if let Some(to_grant) = &entry.grant_capabilities {
         for value in to_grant {


### PR DESCRIPTION
- verbosity level 1 printout added for starting a script (so that you can inspect it's caps)
- `m` script is public (other processes can message it back)
- Moved both `app_store` and `terminal` over to using `GrantCaps` over `initial_capabilities`
  - Fixes a bug where you cannot `request_capabilities` from `scripts.json`/`manifest.json` if `terminal`/`app_store` didn't already have that cap