### PR TITLE
hotfix: bump curve-dalek dep that breaks builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3115,6 +3115,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "curve25519-dalek",
  "dashmap",
  "digest 0.10.7",
  "elliptic-curve",

--- a/kinode/Cargo.toml
+++ b/kinode/Cargo.toml
@@ -37,6 +37,7 @@ chacha20poly1305 = "0.10.1"
 chrono = "0.4.31"
 clap = { version = "4.4", features = ["derive"] }
 crossterm = { version = "0.26.1", features = ["event-stream", "bracketed-paste"] }
+curve25519-dalek = "^4.1.2"
 dashmap = "5.5.3"
 digest = "0.10"
 elliptic-curve = { version = "0.13.8", features = ["ecdh"] }


### PR DESCRIPTION
https://github.com/dalek-cryptography/curve25519-dalek/pull/619 via
https://github.com/mcginty/snow/blob/main/Cargo.toml#L48

Requires devs to be using latest `nightly` Rust. We should have all devs who need to build core run

```
rustup self update
rustup update stable
rustup update nightly
```