### PR TITLE
build-release: use `uname -m` instead of `-p`

### DIFF
--- a/scripts/build-release.py
+++ b/scripts/build-release.py
@@ -8,7 +8,7 @@ import zipfile
 def get_system_info():
     # Get OS and architecture information
     os_info = subprocess.run(["uname"], capture_output=True, text=True, check=True).stdout.strip().lower()
-    arch_info = subprocess.run(["uname", "-p"], capture_output=True, text=True, check=True).stdout.strip().lower()
+    arch_info = subprocess.run(["uname", "-m"], capture_output=True, text=True, check=True).stdout.strip().lower()
 
     if os_info == "linux":
         os_info = "unknown-linux-gnu"


### PR DESCRIPTION
## Problem

https://github.com/kinode-dao/kit/issues/49

## Solution

Here and in `kit` (https://github.com/kinode-dao/kit/pull/82) replace `uname -p` with `uname -m`.

## Docs Update

N/A

## Notes

Will require some amount of backwards compatibility for Mac x86_64 / i386 since some users may use an older kit that uses `-p` and others may use this version that uses `-m`.