### PR TITLE
terminal: color changes and print provenance

### DIFF
--- a/kinode/packages/app_store/app_store/src/types.rs
+++ b/kinode/packages/app_store/app_store/src/types.rs
@@ -108,7 +108,7 @@ impl State {
     /// To create a new state, we populate the downloaded_packages map
     /// with all packages parseable from our filesystem.
     pub fn new(contract_address: String) -> anyhow::Result<Self> {
-        crate::print_to_terminal(1, "app store: producing new state");
+        crate::print_to_terminal(1, "producing new state");
         let mut state = State {
             contract_address,
             last_saved_block: 1,
@@ -361,7 +361,7 @@ impl State {
         self.downloaded_packages.remove(package_id);
         crate::set_state(&bincode::serialize(self)?);
 
-        println!("app store: uninstalled {package_id}");
+        println!("uninstalled {package_id}");
         Ok(())
     }
 
@@ -373,7 +373,7 @@ impl State {
     ) -> anyhow::Result<()> {
         let block_number: u64 = log
             .block_number
-            .ok_or(anyhow::anyhow!("app store: got log with no block number"))?
+            .ok_or(anyhow::anyhow!("got log with no block number"))?
             .try_into()?;
 
         // let package_hash: alloy_primitives::U256 = log.topics[1].into();
@@ -398,15 +398,11 @@ impl State {
                 if generate_package_hash(&package_name, publisher_dnswire.as_slice())
                     != package_hash
                 {
-                    return Err(anyhow::anyhow!(
-                        "app store: got log with mismatched package hash"
-                    ));
+                    return Err(anyhow::anyhow!("got log with mismatched package hash"));
                 }
 
                 let Ok(publisher_name) = dnswire_decode(publisher_dnswire.as_slice()) else {
-                    return Err(anyhow::anyhow!(
-                        "app store: got log with invalid publisher name"
-                    ));
+                    return Err(anyhow::anyhow!("got log with invalid publisher name"));
                 };
 
                 let metadata = fetch_metadata(&metadata_url, &metadata_hash).ok();
@@ -414,7 +410,7 @@ impl State {
                 if let Some(metadata) = &metadata {
                     if metadata.properties.publisher != publisher_name {
                         return Err(anyhow::anyhow!(format!(
-                            "app store: metadata publisher name mismatch: got {}, expected {}",
+                            "metadata publisher name mismatch: got {}, expected {}",
                             metadata.properties.publisher, publisher_name
                         )));
                     }
@@ -454,25 +450,20 @@ impl State {
 
                 let current_listing = self
                     .get_listing_with_hash_mut(&package_hash.to_string())
-                    .ok_or(anyhow::anyhow!(
-                        "app store: got log with no matching listing"
-                    ))?;
+                    .ok_or(anyhow::anyhow!("got log with no matching listing"))?;
 
                 let metadata = match fetch_metadata(&metadata_url, &metadata_hash) {
                     Ok(metadata) => {
                         if metadata.properties.publisher != current_listing.publisher {
                             return Err(anyhow::anyhow!(format!(
-                                "app store: metadata publisher name mismatch: got {}, expected {}",
+                                "metadata publisher name mismatch: got {}, expected {}",
                                 metadata.properties.publisher, current_listing.publisher
                             )));
                         }
                         Some(metadata)
                     }
                     Err(e) => {
-                        crate::print_to_terminal(
-                            1,
-                            &format!("app store: failed to fetch metadata: {e:?}"),
-                        );
+                        crate::print_to_terminal(1, &format!("failed to fetch metadata: {e:?}"));
                         None
                     }
                 };
@@ -490,9 +481,7 @@ impl State {
                         if let Some(mirrored_from) = &package_state.mirrored_from {
                             crate::print_to_terminal(
                                 1,
-                                &format!(
-                                    "app store: auto-updating package {package_id} from {mirrored_from}"
-                                ),
+                                &format!("auto-updating package {package_id} from {mirrored_from}"),
                             );
                             Request::to(our)
                                 .body(serde_json::to_vec(&LocalRequest::Download {
@@ -542,11 +531,9 @@ impl State {
                     self.delete_listing(&package_hash);
                 } else {
                     crate::print_to_terminal(1, "transferring listing");
-                    let current_listing =
-                        self.get_listing_with_hash_mut(&package_hash)
-                            .ok_or(anyhow::anyhow!(
-                                "app store: got log with no matching listing"
-                            ))?;
+                    let current_listing = self
+                        .get_listing_with_hash_mut(&package_hash)
+                        .ok_or(anyhow::anyhow!("got log with no matching listing"))?;
                     current_listing.owner = to.to_string();
                 }
             }

--- a/kinode/packages/chess/chess/src/lib.rs
+++ b/kinode/packages/chess/chess/src/lib.rs
@@ -189,7 +189,7 @@ fn handle_request(our: &Address, message: &Message, state: &mut ChessState) -> a
                             None,
                             "Service Unavailable".to_string().as_bytes().to_vec(),
                         );
-                        Err(anyhow::anyhow!("chess: error handling http request: {e:?}"))
+                        Err(anyhow::anyhow!("error handling http request: {e:?}"))
                     }
                 }
             }
@@ -228,7 +228,7 @@ fn handle_chess_request(
     state: &mut ChessState,
     action: &ChessRequest,
 ) -> anyhow::Result<()> {
-    println!("chess: handling action from {source_node}: {action:?}");
+    println!("handling action from {source_node}: {action:?}");
 
     // For simplicity's sake, we'll just use the node we're playing with as the game id.
     // This limits us to one active game per partner.

--- a/kinode/packages/homepage/homepage/src/lib.rs
+++ b/kinode/packages/homepage/homepage/src/lib.rs
@@ -21,7 +21,7 @@ impl Guest for Component {
         match main(our) {
             Ok(_) => {}
             Err(e) => {
-                println!("homepage: ended with error: {:?}", e);
+                println!("ended with error: {:?}", e);
             }
         }
     }
@@ -61,7 +61,7 @@ fn main(our: Address) -> anyhow::Result<()> {
 
     loop {
         let Ok(ref message) = await_message() else {
-            println!("homepage: got network error??");
+            println!("got network error??");
             continue;
         };
         if let Message::Response { source, body, .. } = message
@@ -69,12 +69,12 @@ fn main(our: Address) -> anyhow::Result<()> {
         {
             match serde_json::from_slice::<Result<(), HttpServerError>>(&body) {
                 Ok(Ok(())) => continue,
-                Ok(Err(e)) => println!("homepage: got error from http_server: {e}"),
-                Err(_e) => println!("homepage: got malformed message from http_server!"),
+                Ok(Err(e)) => println!("got error from http_server: {e}"),
+                Err(_e) => println!("got malformed message from http_server!"),
             }
         } else {
-            println!("homepage: got message: {message:?}");
-            //println!("homepage: got message from {source:?}: {message:?}");
+            println!("got message: {message:?}");
+            //println!("got message from {source:?}: {message:?}");
         }
     }
 }

--- a/kinode/packages/terminal/alias/src/lib.rs
+++ b/kinode/packages/terminal/alias/src/lib.rs
@@ -23,11 +23,11 @@ call_init!(init);
 
 fn init(_our: Address) {
     let Ok(args) = await_next_request_body() else {
-        println!("alias: failed to get args, aborting");
+        println!("failed to get args, aborting");
         return;
     };
 
-    let line = String::from_utf8(args).unwrap_or("alias: error".into());
+    let line = String::from_utf8(args).unwrap_or("error".into());
     if line.is_empty() {
         println!("Change alias for a process");
         println!("\x1b[1mUsage:\x1b[0m alias <alias_name> <process_id>");
@@ -37,7 +37,7 @@ fn init(_our: Address) {
     let (alias, process) = line.split_once(" ").unwrap_or((&line, ""));
 
     if alias.is_empty() {
-        println!("alias: no alias given");
+        println!("no alias given");
         return;
     }
 
@@ -67,7 +67,7 @@ fn init(_our: Address) {
                     .send();
             }
             Err(_) => {
-                println!("alias: invalid process id");
+                println!("invalid process id");
             }
         }
     }

--- a/kinode/packages/terminal/cat/src/lib.rs
+++ b/kinode/packages/terminal/cat/src/lib.rs
@@ -14,12 +14,12 @@ call_init!(init);
 
 fn init(_our: Address) {
     let Ok(args) = await_next_request_body() else {
-        println!("cat: failed to get args, aborting");
+        println!("failed to get args, aborting");
         return;
     };
 
     let Ok(file_path) = String::from_utf8(args) else {
-        println!("cat: bad args, aborting");
+        println!("bad args, aborting");
         return;
     };
 

--- a/kinode/packages/terminal/echo/src/lib.rs
+++ b/kinode/packages/terminal/echo/src/lib.rs
@@ -12,7 +12,7 @@ call_init!(init);
 
 fn init(_our: Address) {
     let Ok(args) = await_next_request_body() else {
-        println!("echo: failed to get args, aborting");
+        println!("failed to get args, aborting");
         return;
     };
 

--- a/kinode/packages/terminal/hi/src/lib.rs
+++ b/kinode/packages/terminal/hi/src/lib.rs
@@ -14,7 +14,7 @@ call_init!(init);
 
 fn init(our: Address) {
     let Ok(args) = await_next_request_body() else {
-        println!("hi: failed to get args, aborting");
+        println!("failed to get args, aborting");
         return;
     };
 
@@ -28,7 +28,7 @@ fn init(our: Address) {
     let (node_id, message) = match tail.split_once(" ") {
         Some((s, t)) => (s, t),
         None => {
-            println!("hi: invalid command, please provide a message");
+            println!("invalid command, please provide a message");
             return;
         }
     };
@@ -48,12 +48,10 @@ fn init(our: Address) {
         }
         Err(SendError { kind, .. }) => match kind {
             SendErrorKind::Timeout => {
-                println!("hi: message to {node_id} timed out");
-                return;
+                println!("message to {node_id} timed out");
             }
             SendErrorKind::Offline => {
-                println!("hi: {node_id} is offline or does not exist");
-                return;
+                println!("{node_id} is offline or does not exist");
             }
         },
     }

--- a/kinode/packages/terminal/m/src/lib.rs
+++ b/kinode/packages/terminal/m/src/lib.rs
@@ -16,7 +16,7 @@ call_init!(init);
 
 fn init(_our: Address) {
     let Ok(body) = await_next_request_body() else {
-        println!("m: failed to get args, aborting");
+        println!("failed to get args, aborting");
         return;
     };
     let body_string = String::from_utf8(body).unwrap();
@@ -54,12 +54,12 @@ fn init(_our: Address) {
         )
         .try_get_matches_from(args)
     else {
-        println!("m: failed to parse args");
+        println!("failed to parse args");
         return;
     };
 
     let Some(target) = parsed.get_one::<String>("target") else {
-        println!("m: no target");
+        println!("no target");
         return;
     };
 
@@ -69,7 +69,7 @@ fn init(_our: Address) {
     };
 
     let Some(body) = parsed.get_one::<String>("body") else {
-        println!("m: no body");
+        println!("no body");
         return;
     };
 
@@ -77,14 +77,14 @@ fn init(_our: Address) {
 
     match parsed.get_one::<u64>("await") {
         Some(s) => {
-            println!("m: awaiting response for {}s", s);
+            println!("awaiting response for {}s", s);
             match req.send_and_await_response(*s).unwrap() {
                 Ok(res) => {
                     println!("{}", String::from_utf8(res.body().to_vec()).unwrap());
                 }
                 Err(e) => {
                     println!(
-                        "m: {}",
+                        "{}",
                         match e.kind {
                             SendErrorKind::Timeout =>
                                 "target did not send Response in time, try increasing the await time",

--- a/kinode/packages/terminal/terminal/src/lib.rs
+++ b/kinode/packages/terminal/terminal/src/lib.rs
@@ -92,7 +92,7 @@ impl Guest for Component {
             let (source, message) = match wit::receive() {
                 Ok((source, message)) => (source, message),
                 Err((error, _context)) => {
-                    println!("terminal: net error: {:?}!", error.kind);
+                    println!("net error: {:?}!", error.kind);
                     continue;
                 }
             };
@@ -104,25 +104,25 @@ impl Guest for Component {
                             std::str::from_utf8(&body).unwrap_or_default(),
                         ) {
                             Ok(()) => continue,
-                            Err(e) => println!("terminal: {e}"),
+                            Err(e) => println!("{e}"),
                         }
                     } else if state.our.node == source.node
                         && state.our.package() == source.package()
                     {
                         let Ok(action) = serde_json::from_slice::<TerminalAction>(&body) else {
-                            println!("terminal: failed to parse action from: {}", source);
+                            println!("failed to parse action from: {}", source);
                             continue;
                         };
                         match action {
                             TerminalAction::EditAlias { alias, process } => {
                                 match handle_alias_change(&mut state, alias, process) {
                                     Ok(()) => continue,
-                                    Err(e) => println!("terminal: {e}"),
+                                    Err(e) => println!("{e}"),
                                 };
                             }
                         }
                     } else {
-                        println!("terminal: ignoring message from: {}", source);
+                        println!("ignoring message from: {}", source);
                         continue;
                     }
                 }
@@ -154,7 +154,7 @@ fn handle_run(our: &Address, process: &ProcessId, args: String) -> anyhow::Resul
     // build initial caps
     let process_id = format!("{}:{}", rand::random::<u64>(), package); // all scripts are given random process IDs
     let Ok(parsed_new_process_id) = process_id.parse::<ProcessId>() else {
-        return Err(anyhow::anyhow!("terminal: invalid process id!"));
+        return Err(anyhow::anyhow!("invalid process id!"));
     };
 
     let _bytes_response = Request::new()
@@ -337,18 +337,18 @@ fn handle_alias_change(
         Some(process) => {
             // first check to make sure the script is actually a script
             let Ok(_) = get_entry(&process) else {
-                return Err(anyhow!("terminal: process {} not found", process));
+                return Err(anyhow!("process {} not found", process));
             };
 
             state.aliases.insert(alias.clone(), process.clone());
-            println!("terminal: alias {} set to {}", alias, process);
+            println!("alias {} set to {}", alias, process);
         }
         None => {
             if state.aliases.contains_key(&alias) {
                 state.aliases.remove(&alias);
-                println!("terminal: alias {} removed", alias);
+                println!("alias {} removed", alias);
             } else {
-                println!("terminal: alias {} not found", alias);
+                println!("alias {} not found", alias);
             }
         }
     }

--- a/kinode/packages/terminal/top/src/lib.rs
+++ b/kinode/packages/terminal/top/src/lib.rs
@@ -15,12 +15,12 @@ call_init!(init);
 
 fn init(_our: Address) {
     let Ok(args) = await_next_request_body() else {
-        println!("top: failed to get args, aborting");
+        println!("failed to get args, aborting");
         return;
     };
 
     let Ok(proc_id) = String::from_utf8(args) else {
-        println!("top: failed to stringify arguments");
+        println!("failed to stringify arguments");
         return;
     };
 
@@ -41,8 +41,7 @@ fn init(_our: Address) {
                     .send();
             }
             Err(_) => {
-                println!("top: invalid process id");
-                return;
+                println!("invalid process id");
             }
         }
     }

--- a/kinode/packages/tester/tester/src/lib.rs
+++ b/kinode/packages/tester/tester/src/lib.rs
@@ -59,7 +59,7 @@ fn handle_message(
                     test_timeout,
                     ..
                 } => {
-                    println!("tester: got Run");
+                    println!("got Run");
 
                     assert!(input_node_names.len() >= 1);
                     *node_names = input_node_names.clone();

--- a/kinode/src/kernel/standard_host.rs
+++ b/kinode/src/kernel/standard_host.rs
@@ -26,10 +26,20 @@ impl StandardHost for process::ProcessWasi {
     // system utils:
     //
 
+    /// Print a message to the runtime terminal. Add the name of the process to the
+    /// beginning of the string, so user can verify source.
     async fn print_to_terminal(&mut self, verbosity: u8, content: String) -> Result<()> {
         self.process
             .send_to_terminal
-            .send(t::Printout { verbosity, content })
+            .send(t::Printout {
+                verbosity,
+                content: format!(
+                    "{}:{}: {}",
+                    self.process.metadata.our.process.package(),
+                    self.process.metadata.our.process.publisher(),
+                    content
+                ),
+            })
             .await
             .map_err(|e| anyhow::anyhow!("fatal: couldn't send to terminal: {e:?}"))
     }

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -249,9 +249,7 @@ async fn main() {
         {
             ip
         } else {
-            println!(
-                "\x1b[38;5;196mfailed to find public IPv4 address: booting as a routed node\x1b[0m"
-            );
+            println!("failed to find public IPv4 address: booting as a routed node");
             std::net::Ipv4Addr::LOCALHOST
         }
     };
@@ -586,7 +584,7 @@ async fn main() {
     let quit_msg: String = tokio::select! {
         Some(Ok(res)) = tasks.join_next() => {
             format!(
-                "\x1b[38;5;196muh oh, a kernel process crashed -- this should never happen: {:?}\x1b[0m",
+                "uh oh, a kernel process crashed -- this should never happen: {:?}",
                 res
             )
         }
@@ -641,6 +639,8 @@ async fn main() {
         stdout,
         crossterm::event::DisableBracketedPaste,
         crossterm::terminal::SetTitle(""),
+        crossterm::style::SetForegroundColor(crossterm::style::Color::Red),
+        crossterm::style::Print(format!("\r\n{quit_msg}")),
+        crossterm::style::ResetColor,
     );
-    println!("\r\n\x1b[38;5;196m{}\x1b[0m", quit_msg);
 }

--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -6,7 +6,7 @@ use crossterm::{
         DisableBracketedPaste, EnableBracketedPaste, Event, EventStream, KeyCode, KeyEvent,
         KeyModifiers,
     },
-    execute,
+    execute, style,
     style::Print,
     terminal::{self, disable_raw_mode, enable_raw_mode, ClearType},
 };
@@ -64,9 +64,10 @@ pub async fn terminal(
     let (mut win_cols, mut win_rows) = terminal::size().unwrap();
     // print initial splash screen, large if there's room, small otherwise
     if win_cols >= 90 {
-        println!(
-            "\x1b[38;5;128m{}\x1b[0m",
-            format_args!(
+        execute!(
+            stdout,
+            style::SetForegroundColor(style::Color::Magenta),
+            Print(format!(
                 r#"
  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⡠⠖⠉
  ⠁⠶⣤⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⠔⠋⠀⠀⠀888    d8P  d8b                        888
@@ -86,7 +87,7 @@ pub async fn terminal(
  ⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⠟⠀⡸⠁⠀⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
  ⠀⠀⠀⠀⠀⠀⠀⢀⠔⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
  networking public key: {}
-                "#,
+                    "#,
                 our.name,
                 if our.ws_routing.is_some() {
                     "direct"
@@ -95,12 +96,14 @@ pub async fn terminal(
                 },
                 version,
                 our.networking_key,
-            )
-        );
+            )),
+            style::ResetColor
+        )?;
     } else {
-        println!(
-            "\x1b[38;5;128m{}\x1b[0m",
-            format_args!(
+        execute!(
+            stdout,
+            style::SetForegroundColor(style::Color::Magenta),
+            Print(format!(
                 r#"
  888    d8P  d8b                        888
  888   d8P   Y8P                        888
@@ -115,7 +118,7 @@ pub async fn terminal(
  version {}
  a general purpose sovereign cloud computer
  net pubkey: {}
-                "#,
+                    "#,
                 our.name,
                 if our.ws_routing.is_some() {
                     "direct"
@@ -124,8 +127,9 @@ pub async fn terminal(
                 },
                 version,
                 our.networking_key,
-            )
-        );
+            )),
+            style::ResetColor
+        )?;
     }
 
     let _raw_mode = if is_detached {
@@ -202,24 +206,24 @@ pub async fn terminal(
                     stdout,
                     cursor::MoveTo(0, win_rows - 1),
                     terminal::Clear(ClearType::CurrentLine),
-                    Print(format!("{}{} {}/{} {:02}:{:02} ",
-                                   match printout.verbosity {
-                                       0 => "",
-                                       1 => "1️⃣  ",
-                                       2 => "2️⃣  ",
-                                       _ => "3️⃣  ",
-                                   },
+                    Print(format!("{} {:02}:{:02} ",
                                    now.weekday(),
-                                   now.month(),
-                                   now.day(),
                                    now.hour(),
                                    now.minute(),
                                  )),
                 )?;
+                let color = match printout.verbosity {
+                        0 => style::Color::Black,
+                        1 => style::Color::Green,
+                        2 => style::Color::Magenta,
+                        _ => style::Color::Red,
+                };
                 for line in printout.content.lines() {
                     execute!(
                         stdout,
-                        Print(format!("\x1b[38;5;238m{}\x1b[0m\r\n", line)),
+                        style::SetForegroundColor(color),
+                        Print(format!("{}\r\n", line)),
+                        style::ResetColor,
                     )?;
                 }
                 execute!(


### PR DESCRIPTION
## Problem

Terminal color stuff was hacky; make it a little less so.

Processes had to label their own prints, and could lie about it (or at least be able to fool users reading terminal)

## Solution

- use `crossterm` colors
- add the PackageID to all prints coming from Processes
- adjust existing distro apps to not label themselves

## Docs Update

N/A

## Notes

N/A
