### PR TITLE
HTTP server: add `Unbind` actions

### DIFF
--- a/lib/src/http/server_types.rs
+++ b/lib/src/http/server_types.rs
@@ -90,6 +90,8 @@ pub enum HttpServerAction {
         /// lazy_load_blob bytes and serve them as the response to any request to this path.
         cache: bool,
     },
+    /// Unbind a previously-bound HTTP path
+    Unbind { path: String },
     /// Bind a path to receive incoming WebSocket connections.
     /// Doesn't need a cache since does not serve assets.
     WebSocketBind {
@@ -107,6 +109,8 @@ pub enum HttpServerAction {
         encrypted: bool,
         extension: bool,
     },
+    /// Unbind a previously-bound WebSocket path
+    WebSocketUnbind { path: String },
     /// Processes will RECEIVE this kind of request when a client connects to them.
     /// If a process does not want this websocket open, they should issue a *request*
     /// containing a [`type@HttpServerAction::WebSocketClose`] message and this channel ID.


### PR DESCRIPTION
## Problem

The HTTP server runtime module does not have a way to remove HTTP and WS path bindings! This went unnoticed because most apps want to always have the same paths bound. But it's important to have this ability for completeness' sake and generality.

## Solution

Added `Unbind` and `WebSocketUnbind` actions to the `HttpServerAction` struct. Synced these across process_lib and runtime [(process_lib PR)](https://github.com/kinode-dao/process_lib/pull/64)

## Docs Update

[Corresponding docs PR](https://github.com/kinode-dao/kinode-book/pull/145)