### PR TITLE
fix: kernel: do not reboot persisted processes if their OnExit behavior is `None`

### DIFF
--- a/kinode/src/kernel/mod.rs
+++ b/kinode/src/kernel/mod.rs
@@ -468,12 +468,6 @@ async fn handle_kernel_request(
                     return;
                 }
             };
-            let _ = send_to_terminal
-                .send(t::Printout {
-                    verbosity: 2,
-                    content: format!("killing process {process_id}"),
-                })
-                .await;
             process_handle.abort();
             process_map.remove(&process_id);
             caps_oracle
@@ -484,6 +478,12 @@ async fn handle_kernel_request(
                 .await
                 .expect("event loop: fatal: sender died");
             if request.expects_response.is_none() {
+                let _ = send_to_terminal
+                    .send(t::Printout {
+                        verbosity: 2,
+                        content: format!("killing process {process_id}"),
+                    })
+                    .await;
                 return;
             }
             let _ = send_to_terminal

--- a/kinode/src/kernel/process.rs
+++ b/kinode/src/kernel/process.rs
@@ -646,6 +646,9 @@ pub async fn make_process_loop(
     // the process has completed, time to perform cleanup
     //
 
+    // update metadata to what was mutated by process in store
+    let metadata = store.data().process.metadata.to_owned();
+
     let our_kernel = t::Address {
         node: metadata.our.node.clone(),
         process: KERNEL_PROCESS_ID.clone(),

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -483,6 +483,14 @@ impl OnExit {
         }
     }
 
+    pub fn is_none(&self) -> bool {
+        match self {
+            OnExit::None => true,
+            OnExit::Restart => false,
+            OnExit::Requests(_) => false,
+        }
+    }
+
     pub fn en_wit(&self) -> wit::OnExit {
         match self {
             OnExit::None => wit::OnExit::None,


### PR DESCRIPTION
## Problem

Kernel currently restarts all persisted processes, which is confusing for developers given that a process exits when the node is shut down. This is a draft at reworking process exit behavior to be clearer and simpler

## Solution

1. On boot, only restart processes with OnExit::Restart or OnExit::Requests (TODO maybe only Restart?)
2. Preserve a process' selected OnExit behavior by fixing bug

## Docs Update

I'll just have to rework this whole section of docs when we get a good solution here

