### PR TITLE
hotfix: use kit --features flag to pass simulation-mode and fix kit s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "kinode"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aes-gcm",
  "alloy-primitives",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "kinode_lib"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lib",
 ]
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "kinode_process_lib"
 version = "0.6.0"
-source = "git+https://github.com/kinode-dao/process_lib.git?tag=v0.6.0#ccf9db2493ec1e112f9146994f852b7bb119dbb6"
+source = "git+https://github.com/kinode-dao/process_lib?tag=v0.6.0#ccf9db2493ec1e112f9146994f852b7bb119dbb6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -2674,6 +2674,7 @@ dependencies = [
 [[package]]
 name = "kit"
 version = "0.2.0"
+source = "git+https://github.com/kinode-dao/kit?rev=1bd7bec#1bd7bec195f4d6878d553a8568b0f2fa1240168a"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2737,7 +2738,7 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "lib"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "alloy-rpc-types",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ name = "alias"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -423,7 +423,7 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "bincode",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -900,7 +900,7 @@ name = "cat"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -962,7 +962,7 @@ dependencies = [
  "anyhow",
  "base64 0.13.1",
  "bincode",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "pleco",
  "serde",
  "serde_json",
@@ -1606,7 +1606,7 @@ name = "download"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -1637,7 +1637,7 @@ name = "echo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -1837,7 +1837,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1982,7 +1982,7 @@ dependencies = [
 name = "get_block"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -2157,7 +2157,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 name = "hi"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -2187,7 +2187,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -2413,7 +2413,7 @@ name = "install"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "kinode_process_lib"
 version = "0.6.0"
-source = "git+https://github.com/kinode-dao/process_lib?tag=v0.6.0#ccf9db2493ec1e112f9146994f852b7bb119dbb6"
+source = "git+https://github.com/kinode-dao/process_lib.git?tag=v0.6.0#ccf9db2493ec1e112f9146994f852b7bb119dbb6"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -2672,26 +2672,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "kinode_process_lib"
-version = "0.6.0"
-source = "git+https://github.com/kinode-dao/process_lib.git?rev=9d185e1#9d185e1e264c93af53d004ba32520fd5d046e7e5"
-dependencies = [
- "anyhow",
- "bincode",
- "http 1.0.0",
- "mime_guess",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "thiserror",
- "url",
- "wit-bindgen",
-]
-
-[[package]]
 name = "kit"
-version = "0.1.0"
-source = "git+https://github.com/kinode-dao/kit?rev=0e39c93#0e39c93d994e2955efd5655fb3ae0831c38865d0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2700,7 +2682,7 @@ dependencies = [
  "futures-util",
  "git2",
  "hex",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib.git?rev=9d185e1)",
+ "kinode_process_lib",
  "nix",
  "regex",
  "reqwest",
@@ -2728,7 +2710,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "hex",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -2908,7 +2890,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "regex",
  "serde",
  "serde_json",
@@ -3040,7 +3022,7 @@ dependencies = [
 name = "namehash_to_name"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "rmp-serde",
  "serde",
  "wit-bindgen",
@@ -3068,7 +3050,7 @@ dependencies = [
 name = "net_diagnostics"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "rmp-serde",
  "serde",
  "wit-bindgen",
@@ -3351,7 +3333,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 name = "peer"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "rmp-serde",
  "serde",
  "wit-bindgen",
@@ -3361,7 +3343,7 @@ dependencies = [
 name = "peers"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "rmp-serde",
  "serde",
  "wit-bindgen",
@@ -4539,7 +4521,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "state"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -4693,7 +4675,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -4707,7 +4689,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "thiserror",
@@ -4721,7 +4703,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "indexmap",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "thiserror",
@@ -4961,7 +4943,7 @@ name = "top"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -5247,7 +5229,7 @@ name = "uninstall"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.6.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.6.0)",
+ "kinode_process_lib",
  "serde",
  "serde_json",
  "wit-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kinode_lib"
 authors = ["KinodeDAO"]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "A general-purpose sovereign cloud computing platform"
 homepage = "https://kinode.org"

--- a/kinode/Cargo.toml
+++ b/kinode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kinode"
 authors = ["KinodeDAO"]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "A general-purpose sovereign cloud computing platform"
 homepage = "https://kinode.org"

--- a/kinode/Cargo.toml
+++ b/kinode/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 
 [build-dependencies]
 anyhow = "1.0.71"
-kit = { git = "https://github.com/kinode-dao/kit", rev = "0e39c93" }
+kit = { git = "https://github.com/kinode-dao/kit", rev = "1bd7bec" }
 rayon = "1.8.1"
 sha2 = "0.10"
 tokio = "1.28"

--- a/kinode/build.rs
+++ b/kinode/build.rs
@@ -10,9 +10,10 @@ fn get_features() -> String {
     let mut features = "".to_string();
     for (key, _) in std::env::vars() {
         if key.starts_with("CARGO_FEATURE_") {
-            let feature = key.trim_start_matches("CARGO_FEATURE_")
-                             .to_lowercase()
-                             .replace("_", "-");
+            let feature = key
+                .trim_start_matches("CARGO_FEATURE_")
+                .to_lowercase()
+                .replace("_", "-");
             features.push_str(&feature);
             //println!("cargo:rustc-cfg=feature=\"{}\"", feature);
             //println!("- {}", feature);
@@ -81,7 +82,11 @@ fn main() -> anyhow::Result<()> {
         .par_iter()
         .map(|entry_path| {
             let parent_pkg_path = entry_path.join("pkg");
-            build_and_zip_package(entry_path.clone(), parent_pkg_path.to_str().unwrap(), &features)
+            build_and_zip_package(
+                entry_path.clone(),
+                parent_pkg_path.to_str().unwrap(),
+                &features,
+            )
         })
         .collect();
 

--- a/kinode/build.rs
+++ b/kinode/build.rs
@@ -6,13 +6,29 @@ use std::{
 };
 use zip::write::FileOptions;
 
+fn get_features() -> String {
+    let mut features = "".to_string();
+    for (key, _) in std::env::vars() {
+        if key.starts_with("CARGO_FEATURE_") {
+            let feature = key.trim_start_matches("CARGO_FEATURE_")
+                             .to_lowercase()
+                             .replace("_", "-");
+            features.push_str(&feature);
+            //println!("cargo:rustc-cfg=feature=\"{}\"", feature);
+            //println!("- {}", feature);
+        }
+    }
+    features
+}
+
 fn build_and_zip_package(
     entry_path: PathBuf,
     parent_pkg_path: &str,
+    features: &str,
 ) -> anyhow::Result<(String, String, Vec<u8>)> {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
-        kit::build::execute(&entry_path, false, false, true).await?;
+        kit::build::execute(&entry_path, false, false, true, features).await?;
 
         let mut writer = Cursor::new(Vec::new());
         let options = FileOptions::default()
@@ -59,11 +75,13 @@ fn main() -> anyhow::Result<()> {
         .map(|entry| entry.unwrap().path())
         .collect();
 
+    let features = get_features();
+
     let results: Vec<anyhow::Result<(String, String, Vec<u8>)>> = entries
         .par_iter()
         .map(|entry_path| {
             let parent_pkg_path = entry_path.join("pkg");
-            build_and_zip_package(entry_path.clone(), parent_pkg_path.to_str().unwrap())
+            build_and_zip_package(entry_path.clone(), parent_pkg_path.to_str().unwrap(), &features)
         })
         .collect();
 

--- a/kinode/packages/app_store/app_store/Cargo.toml
+++ b/kinode/packages/app_store/app_store/Cargo.toml
@@ -3,6 +3,8 @@ name = "app_store"
 version = "0.3.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 alloy-primitives = "0.6.2"

--- a/kinode/packages/app_store/app_store/src/lib.rs
+++ b/kinode/packages/app_store/app_store/src/lib.rs
@@ -82,8 +82,11 @@ fn fetch_logs(eth_provider: &eth::Provider, filter: &eth::Filter) -> Vec<eth::Lo
             }
         }
     }
+    #[cfg(feature = "simulation-mode")]
+    vec![]
 }
 
+#[allow(unused_variables)]
 fn subscribe_to_logs(eth_provider: &eth::Provider, filter: eth::Filter) {
     #[cfg(not(feature = "simulation-mode"))]
     loop {

--- a/kinode/packages/app_store/download/Cargo.toml
+++ b/kinode/packages/app_store/download/Cargo.toml
@@ -3,6 +3,8 @@ name = "download"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/app_store/ft_worker/Cargo.toml
+++ b/kinode/packages/app_store/ft_worker/Cargo.toml
@@ -3,6 +3,8 @@ name = "ft_worker"
 version = "0.2.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/app_store/install/Cargo.toml
+++ b/kinode/packages/app_store/install/Cargo.toml
@@ -3,6 +3,8 @@ name = "install"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/app_store/uninstall/Cargo.toml
+++ b/kinode/packages/app_store/uninstall/Cargo.toml
@@ -3,6 +3,8 @@ name = "uninstall"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/chess/chess/Cargo.toml
+++ b/kinode/packages/chess/chess/Cargo.toml
@@ -3,6 +3,8 @@ name = "chess"
 version = "0.2.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/homepage/homepage/Cargo.toml
+++ b/kinode/packages/homepage/homepage/Cargo.toml
@@ -3,6 +3,8 @@ name = "homepage"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/kns_indexer/get_block/Cargo.toml
+++ b/kinode/packages/kns_indexer/get_block/Cargo.toml
@@ -3,6 +3,8 @@ name = "get_block"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.6.0" }

--- a/kinode/packages/kns_indexer/kns_indexer/Cargo.toml
+++ b/kinode/packages/kns_indexer/kns_indexer/Cargo.toml
@@ -3,6 +3,8 @@ name = "kns_indexer"
 version = "0.2.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
+++ b/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
@@ -200,6 +200,7 @@ fn main(our: Address, mut state: State) -> anyhow::Result<()> {
     let eth_provider = eth::Provider::new(state.chain_id, 60);
 
     // if block in state is < current_block, get logs from that part.
+    #[cfg(not(feature = "simulation-mode"))]
     if state.block < eth_provider.get_block_number().unwrap_or(u64::MAX) {
         loop {
             match eth_provider.get_logs(&filter) {

--- a/kinode/packages/kns_indexer/state/Cargo.toml
+++ b/kinode/packages/kns_indexer/state/Cargo.toml
@@ -3,6 +3,8 @@ name = "state"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.6.0" }

--- a/kinode/packages/terminal/alias/Cargo.toml
+++ b/kinode/packages/terminal/alias/Cargo.toml
@@ -3,6 +3,8 @@ name = "alias"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/terminal/cat/Cargo.toml
+++ b/kinode/packages/terminal/cat/Cargo.toml
@@ -3,6 +3,8 @@ name = "cat"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/terminal/echo/Cargo.toml
+++ b/kinode/packages/terminal/echo/Cargo.toml
@@ -3,6 +3,8 @@ name = "echo"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/terminal/hi/Cargo.toml
+++ b/kinode/packages/terminal/hi/Cargo.toml
@@ -3,6 +3,8 @@ name = "hi"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.6.0" }

--- a/kinode/packages/terminal/m/Cargo.toml
+++ b/kinode/packages/terminal/m/Cargo.toml
@@ -3,6 +3,8 @@ name = "m"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/terminal/namehash_to_name/Cargo.toml
+++ b/kinode/packages/terminal/namehash_to_name/Cargo.toml
@@ -3,6 +3,8 @@ name = "namehash_to_name"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.6.0" }

--- a/kinode/packages/terminal/net_diagnostics/Cargo.toml
+++ b/kinode/packages/terminal/net_diagnostics/Cargo.toml
@@ -3,6 +3,8 @@ name = "net_diagnostics"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.6.0" }

--- a/kinode/packages/terminal/peer/Cargo.toml
+++ b/kinode/packages/terminal/peer/Cargo.toml
@@ -3,6 +3,8 @@ name = "peer"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.6.0" }

--- a/kinode/packages/terminal/peers/Cargo.toml
+++ b/kinode/packages/terminal/peers/Cargo.toml
@@ -3,6 +3,8 @@ name = "peers"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.6.0" }

--- a/kinode/packages/terminal/terminal/Cargo.toml
+++ b/kinode/packages/terminal/terminal/Cargo.toml
@@ -3,6 +3,8 @@ name = "terminal"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/terminal/top/Cargo.toml
+++ b/kinode/packages/terminal/top/Cargo.toml
@@ -3,6 +3,8 @@ name = "top"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/tester/test_runner/Cargo.toml
+++ b/kinode/packages/tester/test_runner/Cargo.toml
@@ -3,6 +3,8 @@ name = "test_runner"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/kinode/packages/tester/tester/Cargo.toml
+++ b/kinode/packages/tester/tester/Cargo.toml
@@ -3,6 +3,8 @@ name = "tester"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lib"
 authors = ["KinodeDAO"]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "A general-purpose sovereign cloud computing platform"
 homepage = "https://kinode.org"


### PR DESCRIPTION
## Problem

https://github.com/kinode-dao/kit/issues/101

## Solution

@dr-frmr s solution was halfway there. Just needed to propagate the simulation-mode feature flag into the packages. This PR modifies `build.rs` to use the new kit flag which is added in https://github.com/kinode-dao/kit/pull/107

## Docs Update

TODO: update the flags discussion in build & build_and_start.

## Notes

Please take over this PR and the corresponding kit one https://github.com/kinode-dao/kit/pull/107 @dr-frmr 

This is a hotfix and so should be merged directly to main. It bumps to 0.6.1.

Oh, one big note here: there may be weirdness wrt the merge because I branched off of https://github.com/kinode-dao/kinode/commit/61ff56f117a2683099cb946f25355bc3b9b58c40, not HEAD (which is https://github.com/kinode-dao/kinode/commit/fccff76023f2f2a029e54ad06961a628e62ba22d). Please confirm in merge that app_store has the feature flags in it!