### PR TITLE
fix: enforce ws-routing port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "kinode"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "aes-gcm",
  "alloy-primitives",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "kinode_lib"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "lib",
 ]
@@ -2738,7 +2738,7 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "lib"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "alloy-rpc-types",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kinode_lib"
 authors = ["KinodeDAO"]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "A general-purpose sovereign cloud computing platform"
 homepage = "https://kinode.org"

--- a/kinode/Cargo.toml
+++ b/kinode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kinode"
 authors = ["KinodeDAO"]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "A general-purpose sovereign cloud computing platform"
 homepage = "https://kinode.org"

--- a/kinode/src/eth/mod.rs
+++ b/kinode/src/eth/mod.rs
@@ -251,7 +251,7 @@ async fn handle_network_error(
     // if we hold active subscriptions for the remote node that this error refers to,
     // close them here -- they will need to resubscribe
     // TODO is this necessary?
-    if let Some(sub_map) = active_subscriptions.get(&wrapped_error.error.target) {
+    if let Some((_who, sub_map)) = active_subscriptions.remove(&wrapped_error.error.target) {
         for (_sub_id, sub) in sub_map.iter() {
             if let ActiveSub::Local(handle) = sub {
                 verbose_print(

--- a/kinode/src/http/utils.rs
+++ b/kinode/src/http/utils.rs
@@ -100,18 +100,18 @@ pub fn deserialize_headers(hashmap: HashMap<String, String>) -> HeaderMap {
     header_map
 }
 
-pub async fn find_open_port(start_at: u16, end_at: u16) -> Option<u16> {
+pub async fn find_open_port(start_at: u16, end_at: u16) -> Option<TcpListener> {
     for port in start_at..end_at {
         let bind_addr = format!("0.0.0.0:{}", port);
-        if is_port_available(&bind_addr).await {
-            return Some(port);
+        if let Some(bound) = is_port_available(&bind_addr).await {
+            return Some(bound);
         }
     }
     None
 }
 
-pub async fn is_port_available(bind_addr: &str) -> bool {
-    TcpListener::bind(bind_addr).await.is_ok()
+pub async fn is_port_available(bind_addr: &str) -> Option<TcpListener> {
+    TcpListener::bind(bind_addr).await.ok()
 }
 
 pub fn _binary_encoded_string_to_bytes(s: &str) -> Vec<u8> {

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -44,6 +44,7 @@ const DEFAULT_PROVIDERS_MAINNET: &str = include_str!("eth/default_providers_main
 async fn serve_register_fe(
     home_directory_path: &str,
     our_ip: String,
+    ws_networking_port: Option<u16>,
     http_server_port: u16,
     testnet: bool,
 ) -> (Identity, Vec<u8>, Keyfile) {
@@ -66,7 +67,7 @@ async fn serve_register_fe(
 
     let (tx, mut rx) = mpsc::channel::<(Identity, Keyfile, Vec<u8>)>(1);
     let (our, decoded_keyfile, encoded_keyfile) = tokio::select! {
-        _ = register::register(tx, kill_rx, our_ip, http_server_port, disk_keyfile, testnet) => {
+        _ = register::register(tx, kill_rx, our_ip, ws_networking_port, http_server_port, disk_keyfile, testnet) => {
             panic!("registration failed")
         }
         Some((our, decoded_keyfile, encoded_keyfile)) = rx.recv() => {
@@ -98,6 +99,10 @@ async fn main() {
                 .value_parser(value_parser!(u16)),
         )
         .arg(
+            arg!(--"ws-port" <PORT> "Kinode internal WebSockets protocol port [default: first unbound at or above 9000]")
+                .value_parser(value_parser!(u16)),
+        )
+        .arg(
             arg!(--testnet "If set, use Sepolia testnet")
                 .default_value("false")
                 .value_parser(value_parser!(bool)),
@@ -119,11 +124,6 @@ async fn main() {
         .arg(arg!(--password <PASSWORD> "Networking password"))
         .arg(arg!(--"fake-node-name" <NAME> "Name of fake node to boot"))
         .arg(
-            arg!(--"network-router-port" <PORT> "Network router port")
-                .default_value("9001")
-                .value_parser(value_parser!(u16)),
-        )
-        .arg(
             arg!(--detached <IS_DETACHED> "Run in detached mode (don't accept input)")
                 .action(clap::ArgAction::SetTrue),
         );
@@ -131,21 +131,16 @@ async fn main() {
     let matches = app.get_matches();
 
     let home_directory_path = matches.get_one::<String>("home").unwrap();
-    let (port, port_flag_used) = match matches.get_one::<u16>("port") {
-        Some(port) => (*port, true),
-        None => (8080, false),
-    };
     let on_testnet = *matches.get_one::<bool>("testnet").unwrap();
+
+    let http_port = matches.get_one::<u16>("port");
+    let ws_networking_port = matches.get_one::<u16>("ws-port");
 
     #[cfg(not(feature = "simulation-mode"))]
     let is_detached = false;
     #[cfg(feature = "simulation-mode")]
-    let (password, network_router_port, fake_node_name, is_detached) = (
+    let (password, fake_node_name, is_detached) = (
         matches.get_one::<String>("password"),
-        matches
-            .get_one::<u16>("network-router-port")
-            .unwrap()
-            .clone(),
         matches.get_one::<String>("fake-node-name"),
         *matches.get_one::<bool>("detached").unwrap(),
     );
@@ -262,15 +257,15 @@ async fn main() {
         }
     };
 
-    let http_server_port = if port_flag_used {
-        match http::utils::find_open_port(port, port + 1).await {
+    let http_server_port = if let Some(port) = http_port {
+        match http::utils::find_open_port(*port, port + 1).await {
             Some(port) => port,
             None => {
                 println!(
                     "error: couldn't bind {}; first available port found was {}. \
                     Set an available port with `--port` and try again.",
                     port,
-                    http::utils::find_open_port(port, port + 1000)
+                    http::utils::find_open_port(*port, port + 1000)
                         .await
                         .expect("no ports found in range"),
                 );
@@ -278,13 +273,12 @@ async fn main() {
             }
         }
     } else {
-        match http::utils::find_open_port(port, port + 1000).await {
+        match http::utils::find_open_port(8080, 8999).await {
             Some(port) => port,
             None => {
                 println!(
-                    "error: couldn't bind any ports between {port} and {}. \
-                    Set an available port with `--port` and try again.",
-                    port + 1000,
+                    "error: couldn't bind any ports between 8080 and 8999. \
+                    Set an available port with `--port` and try again."
                 );
                 panic!();
             }
@@ -300,6 +294,7 @@ async fn main() {
     let (our, encoded_keyfile, decoded_keyfile) = serve_register_fe(
         home_directory_path,
         our_ip.to_string(),
+        ws_networking_port.copied(),
         http_server_port,
         on_testnet, // true if testnet mode
     )
@@ -313,7 +308,8 @@ async fn main() {
                     serve_register_fe(
                         &home_directory_path,
                         our_ip.to_string(),
-                        http_server_port.clone(),
+                        ws_networking_port.copied(),
+                        http_server_port,
                         on_testnet, // true if testnet mode
                     )
                     .await

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -100,6 +100,7 @@ async fn main() {
         )
         .arg(
             arg!(--"ws-port" <PORT> "Kinode internal WebSockets protocol port [default: first unbound at or above 9000]")
+                .alias("network-router-port")
                 .value_parser(value_parser!(u16)),
         )
         .arg(
@@ -510,7 +511,7 @@ async fn main() {
     ));
     #[cfg(feature = "simulation-mode")]
     tasks.spawn(net::mock_client(
-        network_router_port,
+        *ws_networking_port.unwrap_or(&9000),
         our.name.clone(),
         kernel_message_sender.clone(),
         net_message_receiver,

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -44,7 +44,7 @@ const DEFAULT_PROVIDERS_MAINNET: &str = include_str!("eth/default_providers_main
 async fn serve_register_fe(
     home_directory_path: &str,
     our_ip: String,
-    ws_networking_port: Option<u16>,
+    ws_networking: (tokio::net::TcpListener, bool),
     http_server_port: u16,
     testnet: bool,
 ) -> (Identity, Vec<u8>, Keyfile) {
@@ -67,7 +67,7 @@ async fn serve_register_fe(
 
     let (tx, mut rx) = mpsc::channel::<(Identity, Keyfile, Vec<u8>)>(1);
     let (our, decoded_keyfile, encoded_keyfile) = tokio::select! {
-        _ = register::register(tx, kill_rx, our_ip, ws_networking_port, http_server_port, disk_keyfile, testnet) => {
+        _ = register::register(tx, kill_rx, our_ip, ws_networking, http_server_port, disk_keyfile, testnet) => {
             panic!("registration failed")
         }
         Some((our, decoded_keyfile, encoded_keyfile)) = rx.recv() => {
@@ -260,7 +260,7 @@ async fn main() {
 
     let http_server_port = if let Some(port) = http_port {
         match http::utils::find_open_port(*port, port + 1).await {
-            Some(port) => port,
+            Some(bound) => bound.local_addr().unwrap().port(),
             None => {
                 println!(
                     "error: couldn't bind {}; first available port found was {}. \
@@ -268,14 +268,17 @@ async fn main() {
                     port,
                     http::utils::find_open_port(*port, port + 1000)
                         .await
-                        .expect("no ports found in range"),
+                        .expect("no ports found in range")
+                        .local_addr()
+                        .unwrap()
+                        .port(),
                 );
                 panic!();
             }
         }
     } else {
         match http::utils::find_open_port(8080, 8999).await {
-            Some(port) => port,
+            Some(bound) => bound.local_addr().unwrap().port(),
             None => {
                 println!(
                     "error: couldn't bind any ports between 8080 and 8999. \
@@ -284,6 +287,28 @@ async fn main() {
                 panic!();
             }
         }
+    };
+
+    // if the --ws-port flag is used, bind to that port right away.
+    // if the flag is not used, find the first available port between 9000 and 65535.
+    // NOTE: if the node has a different port specified in its onchain (direct) id,
+    // booting will fail if the flag was used to select a different port.
+    // if the flag was not used, the bound port will be dropped in favor of the onchain port.
+
+    let (ws_tcp_handle, flag_used) = if let Some(port) = ws_networking_port {
+        (
+            http::utils::find_open_port(*port, port + 1)
+                .await
+                .expect("ws-port selected with flag could not be bound"),
+            true,
+        )
+    } else {
+        (
+            http::utils::find_open_port(9000, 65535)
+                .await
+                .expect("no ports found in range 9000-65535 for websocket server"),
+            false,
+        )
     };
 
     println!(
@@ -295,7 +320,7 @@ async fn main() {
     let (our, encoded_keyfile, decoded_keyfile) = serve_register_fe(
         home_directory_path,
         our_ip.to_string(),
-        ws_networking_port.copied(),
+        (ws_tcp_handle, flag_used),
         http_server_port,
         on_testnet, // true if testnet mode
     )
@@ -309,7 +334,7 @@ async fn main() {
                     serve_register_fe(
                         &home_directory_path,
                         our_ip.to_string(),
-                        ws_networking_port.copied(),
+                        (ws_tcp_handle, flag_used),
                         http_server_port,
                         on_testnet, // true if testnet mode
                     )

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lib"
 authors = ["KinodeDAO"]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "A general-purpose sovereign cloud computing platform"
 homepage = "https://kinode.org"


### PR DESCRIPTION
## Problem

Described in issue #281, the runtime was not properly enforcing that a direct node boots on its specified port for the ws-networking protocol. It was also impossible to specify this port at node-registration-time.

## Solution

This PR adds a `--ws-port` flag so that users can specify a desired ws-networking port at registration time. If this port is not available, the binary exits with a helpful error.

Separately, the registration/login flow now enforces that the runtime can bind to and use the port specified in a node's onchain networking data if it is a direct node.

## Docs Update

N/A
