### PR TITLE
app store and build fixes redux

### DIFF
--- a/kinode/build.rs
+++ b/kinode/build.rs
@@ -1,5 +1,6 @@
 use rayon::prelude::*;
 use std::{
+    collections::HashSet,
     fs::{self, File},
     io::{Cursor, Read, Write},
     path::{Path, PathBuf},
@@ -20,6 +21,24 @@ fn get_features() -> String {
         }
     }
     features
+}
+
+fn output_reruns(dir: &Path, rerun_files: &HashSet<String>) {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+            if path.is_dir() {
+                // If the entry is a directory, recursively walk it
+                output_reruns(&path, rerun_files);
+            } else if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
+                // Check if the current file is in our list of interesting files
+                if rerun_files.contains(filename) {
+                    // If so, print a `cargo:rerun-if-changed=PATH` line for it
+                    println!("cargo:rerun-if-changed={}", path.display());
+                }
+            }
+        }
+    }
 }
 
 fn build_and_zip_package(
@@ -75,6 +94,13 @@ fn main() -> anyhow::Result<()> {
     let entries: Vec<_> = fs::read_dir(packages_dir)?
         .map(|entry| entry.unwrap().path())
         .collect();
+
+    let rerun_files: HashSet<String> = HashSet::from([
+        "Cargo.lock".to_string(),
+        "Cargo.toml".to_string(),
+        "src/".to_string(),
+    ]);
+    output_reruns(&parent_dir, &rerun_files);
 
     let features = get_features();
 

--- a/kinode/packages/app_store/app_store/src/lib.rs
+++ b/kinode/packages/app_store/app_store/src/lib.rs
@@ -693,7 +693,7 @@ pub fn handle_install(
                     action: vfs::VfsAction::Read,
                 })?)
                 .send_and_await_response(5)??
-                .body()
+                .body(),
         ) {
             return Err(anyhow::anyhow!("failed to read process file"));
         };
@@ -711,7 +711,7 @@ pub fn handle_install(
                 })?)
                 .inherit(true)
                 .send_and_await_response(5)??
-                .body()
+                .body(),
         ) else {
             return Err(anyhow::anyhow!("failed to initialize process"));
         };
@@ -845,7 +845,7 @@ pub fn handle_install(
                     parsed_new_process_id,
                 ))?)
                 .send_and_await_response(5)??
-                .body()
+                .body(),
         ) else {
             return Err(anyhow::anyhow!("failed to start process"));
         };

--- a/kinode/packages/app_store/app_store/src/lib.rs
+++ b/kinode/packages/app_store/app_store/src/lib.rs
@@ -686,25 +686,35 @@ pub fn handle_install(
             ))?)
             .send()?;
 
-        let _bytes_response = Request::to(("our", "vfs", "distro", "sys"))
-            .body(serde_json::to_vec(&vfs::VfsRequest {
-                path: wasm_path.clone(),
-                action: vfs::VfsAction::Read,
-            })?)
-            .send_and_await_response(5)??;
+        if let Ok(vfs::VfsResponse::Err(_)) = serde_json::from_slice(
+            Request::to(("our", "vfs", "distro", "sys"))
+                .body(serde_json::to_vec(&vfs::VfsRequest {
+                    path: wasm_path.clone(),
+                    action: vfs::VfsAction::Read,
+                })?)
+                .send_and_await_response(5)??
+                .body()
+        ) {
+            return Err(anyhow::anyhow!("failed to read process file"));
+        };
 
-        Request::new()
-            .target(("our", "kernel", "distro", "sys"))
-            .body(serde_json::to_vec(&kt::KernelCommand::InitializeProcess {
-                id: parsed_new_process_id.clone(),
-                wasm_bytes_handle: wasm_path,
-                wit_version: None,
-                on_exit: entry.on_exit.clone(),
-                initial_capabilities: HashSet::new(),
-                public: entry.public,
-            })?)
-            .inherit(true)
-            .send_and_await_response(5)??;
+        let Ok(kt::KernelResponse::InitializedProcess) = serde_json::from_slice(
+            Request::new()
+                .target(("our", "kernel", "distro", "sys"))
+                .body(serde_json::to_vec(&kt::KernelCommand::InitializeProcess {
+                    id: parsed_new_process_id.clone(),
+                    wasm_bytes_handle: wasm_path,
+                    wit_version: None,
+                    on_exit: entry.on_exit.clone(),
+                    initial_capabilities: HashSet::new(),
+                    public: entry.public,
+                })?)
+                .inherit(true)
+                .send_and_await_response(5)??
+                .body()
+        ) else {
+            return Err(anyhow::anyhow!("failed to initialize process"));
+        };
         // build initial caps
         let mut requested_capabilities: Vec<kt::Capability> = vec![];
         for value in &entry.request_capabilities {
@@ -829,11 +839,16 @@ pub fn handle_install(
                 }
             }
         }
-        Request::to(("our", "kernel", "distro", "sys"))
-            .body(serde_json::to_vec(&kt::KernelCommand::RunProcess(
-                parsed_new_process_id,
-            ))?)
-            .send_and_await_response(5)??;
+        let Ok(kt::KernelResponse::StartedProcess) = serde_json::from_slice(
+            Request::to(("our", "kernel", "distro", "sys"))
+                .body(serde_json::to_vec(&kt::KernelCommand::RunProcess(
+                    parsed_new_process_id,
+                ))?)
+                .send_and_await_response(5)??
+                .body()
+        ) else {
+            return Err(anyhow::anyhow!("failed to start process"));
+        };
     }
     // finally set the package as installed
     state.update_downloaded_package(package_id, |package_state| {


### PR DESCRIPTION
## Problem

1. Core packages are not rebuilt properly when they are changed,
2. `app_store` does not properly return a failure for certain obvious fail cases.

## Solution

1. Output the required `rerun-if-changed` in `build.rs`,
2. Handle the `Response`s.

## Docs Update

N/A

## Notes

Redo of #291