### PR TITLE
Enable sign/verify for apps using node's networking key

### DIFF
--- a/kinode/src/net/utils.rs
+++ b/kinode/src/net/utils.rs
@@ -260,6 +260,18 @@ pub async fn create_passthrough(
     ))
 }
 
+pub fn validate_signature(from: &str, signature: &[u8], message: &[u8], pki: &OnchainPKI) -> bool {
+    if let Some(peer_id) = pki.get(from) {
+        let their_networking_key = signature::UnparsedPublicKey::new(
+            &signature::ED25519,
+            hex::decode(strip_0x(&peer_id.networking_key)).unwrap_or_default(),
+        );
+        their_networking_key.verify(message, signature).is_ok()
+    } else {
+        false
+    }
+}
+
 pub fn validate_routing_request(
     our_name: &str,
     buf: &[u8],

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -1557,7 +1557,7 @@ pub enum NetAction {
     Verify {
         from: Address,
         signature: Vec<u8>,
-    }
+    },
 }
 
 /// For now, only sent in response to a ConnectionRequest.

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -1546,6 +1546,18 @@ pub enum NetAction {
     GetName(String),
     /// get a user-readable diagnostics string containing networking inforamtion
     GetDiagnostics,
+    /// sign the attached blob payload, sign with our node's networking key.
+    /// **only accepted from our own node**
+    /// **the source [`Address`] will always be prepended to the payload**
+    Sign,
+    /// given a message in blob payload, verify the message is signed by
+    /// the given source. if the signer is not in our representation of
+    /// the PKI, will not verify.
+    /// **the `from` [`Address`] will always be prepended to the payload**
+    Verify {
+        from: Address,
+        signature: Vec<u8>,
+    }
 }
 
 /// For now, only sent in response to a ConnectionRequest.
@@ -1560,8 +1572,15 @@ pub enum NetResponse {
     Peer(Option<Identity>),
     /// response to [`NetAction::GetName`]
     Name(Option<String>),
-    /// response to [`NetAction::GetDiagnostics`]. A user-readable string.
+    /// response to [`NetAction::GetDiagnostics`]. a user-readable string.
     Diagnostics(String),
+    /// response to [`NetAction::Sign`]. contains the signature in blob
+    Signed,
+    /// response to [`NetAction::Verify`]. boolean indicates whether
+    /// the signature was valid or not. note that if the signer node
+    /// cannot be found in our representation of PKI, this will return false,
+    /// because we cannot find the networking public key to verify with.
+    Verified(bool),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Problem

Apps need a way to produce signatures on messages so other nodes can verify their source, outside of the standard networking protocol. Apps must also be able to verify these signatures from other nodes against the PKI

## Solution

The `net:distro:sys` module now has signing and verifying in its core request-response API. Any app with messaging capabilities to `net:distro:sys` can send a `Sign` or `Verify` request with the relevant data and get a response. There is a matching PR in process_lib to expose this functionality cleanly: https://github.com/kinode-dao/process_lib/pull/68

## Docs Update

[Corresponding docs PR](https://github.com/kinode-dao/kinode-book/pull/152)
