### PR TITLE
Da/unpublish

### DIFF
--- a/kinode/packages/app_store/ui/src/App.tsx
+++ b/kinode/packages/app_store/ui/src/App.tsx
@@ -63,6 +63,7 @@ function App() {
 
   useEffect(() => {
     provider?.getNetwork().then(network => {
+      // TODO: don't have this fire 20 times on load
       if (network.chainId === ChainId.OPTIMISM) {
         setPackageAbi(PackageStore__factory.connect(
           PACKAGE_STORE_ADDRESSES[ChainId.OPTIMISM],

--- a/kinode/packages/app_store/ui/src/index.css
+++ b/kinode/packages/app_store/ui/src/index.css
@@ -4,17 +4,17 @@
 
 @font-face {
   font-family: 'Futura';
-  src: url('./fonts/Futura-Heavy.ttf');
+  src: url('/main:app_store:sys/assets/fonts/Futura-Heavy.ttf');
 }
 
 @font-face {
   font-family: 'OpenSans';
-  src: url('./fonts/OpenSans-CondBold.ttf');
+  src: url('/main:app_store:sys/assets/fonts/OpenSans-CondBold.ttf');
 }
 
 @font-face {
   font-family: 'Barlow';
-  src: url('./fonts/BarlowCondensed-Black.ttf');
+  src: url('/main:app_store:sys/assets/fonts/BarlowCondensed-Black.ttf');
 }
 
 body {
@@ -84,7 +84,7 @@ button[type="submit"],
 }
 
 body {
-  @apply bg-[url('./background.jpg')] bg-cover bg-no-repeat bg-center bg-fixed text-white;
+  @apply bg-[url('/main:app_store:sys/assets/background.jpg')] bg-cover bg-no-repeat bg-center bg-fixed text-white;
 }
 
 input {

--- a/kinode/packages/app_store/ui/src/pages/PublishPage.tsx
+++ b/kinode/packages/app_store/ui/src/pages/PublishPage.tsx
@@ -209,10 +209,9 @@ export default function PublishPage({
 
   return (
     <div className="max-w-[900px] w-full">
-      <h1>fOOOO</h1>
       <SearchHeader hideSearch onBack={showMetadataForm ? () => setShowMetadataForm(false) : undefined} />
       <div className="flex justify-between items-center my-2">
-        <h4>Publish Packages</h4>
+        <h4>Publish Package</h4>
         {Boolean(account) && <div className="card flex items-center">
           <span>Publishing as:</span>
           <Jazzicon address={account!} className="mx-2" />

--- a/kinode/packages/app_store/ui/src/pages/PublishPage.tsx
+++ b/kinode/packages/app_store/ui/src/pages/PublishPage.tsx
@@ -330,7 +330,7 @@ export default function PublishPage({
         </form>
       )}
 
-      <div className="flex flex-col my-2">
+      <div className="flex flex-col my-2 mt-4">
         <h4>Packages You Own</h4>
         {myPublishedApps.length > 0 ? (
           <div className="flex flex-col">

--- a/kinode/packages/app_store/ui/vite.config.ts
+++ b/kinode/packages/app_store/ui/vite.config.ts
@@ -19,7 +19,6 @@ This must match the process name from pkg/manifest.json + pkg/metadata.json
 The format is "/" + "process_name:package_name:publisher_node"
 */
 const BASE_URL = `/main:app_store:sys`;
-// const BASE_URL = `/${manifest[0].process_name}:${metadata.package}:${metadata.publisher}`;
 
 // This is the proxy URL, it must match the node you are developing against
 const PROXY_URL = (process.env.VITE_NODE_URL || 'http://127.0.0.1:8080').replace('localhost', '127.0.0.1');
@@ -79,7 +78,7 @@ export default defineConfig({
         rewrite: (path) => path.replace(BASE_URL, ''),
       },
       // This route will match all other HTTP requests to the backend
-      [`^${BASE_URL}/(?!(@vite/client|src/.*|node_modules/.*|@react-refresh|$))`]: {
+      [`^${BASE_URL}/(?!(@vite/client|src/.*|node_modules/.*|@react-refresh|__uno.css|$))`]: {
         target: PROXY_URL,
         changeOrigin: true,
       },


### PR DESCRIPTION
## Problem
app_store UI did not have an unpublish feature

## Solution
Now it appears in a list of packages that your current connected wallet owns

NOTE: we could reorganize this screen into two new ones: "publish new package" and "manage existing packages". I think that's coming eventually but maybe not today

<img width="949" alt="Screenshot 2024-04-15 at 5 51 19 PM" src="https://github.com/kinode-dao/kinode/assets/43223192/7a0c77e0-5a31-41f0-88f8-3aa0413c9ec0">

