### PR TITLE
fix: use process_lib dnswire_decode with error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ name = "alias"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -585,7 +585,7 @@ dependencies = [
  "alloy-sol-types 0.7.0",
  "anyhow",
  "bincode",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?rev=1ea6eda)",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1096,7 +1096,7 @@ name = "cat"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -1159,7 +1159,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.0",
  "bincode",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "pleco",
  "serde",
  "serde_json",
@@ -1871,7 +1871,7 @@ name = "download"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -1902,7 +1902,7 @@ name = "echo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -2122,7 +2122,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -2282,7 +2282,7 @@ dependencies = [
 name = "get_block"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -2482,7 +2482,7 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 name = "hi"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -2512,7 +2512,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "bincode",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -2823,7 +2823,7 @@ name = "install"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -3126,6 +3126,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "kinode_process_lib"
+version = "0.7.0"
+source = "git+https://github.com/kinode-dao/process_lib?rev=1ea6eda#1ea6edad610b02a6fecb307c67dfa51fba0fb0de"
+dependencies = [
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cad7935)",
+ "alloy-primitives 0.7.0",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cad7935)",
+ "alloy-transport 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=cad7935)",
+ "anyhow",
+ "bincode",
+ "http 1.1.0",
+ "mime_guess",
+ "rand 0.8.5",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "url",
+ "wit-bindgen",
+]
+
+[[package]]
 name = "kit"
 version = "0.3.1"
 source = "git+https://github.com/kinode-dao/kit?rev=659f59e#659f59ec9b8a503e4998e1bbe4b991429fa7ff33"
@@ -3168,7 +3190,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "hex",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?rev=1ea6eda)",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -3369,7 +3391,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "regex",
  "serde",
  "serde_json",
@@ -3501,7 +3523,7 @@ dependencies = [
 name = "namehash_to_name"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "rmp-serde",
  "serde",
  "wit-bindgen",
@@ -3529,7 +3551,7 @@ dependencies = [
 name = "net_diagnostics"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "rmp-serde",
  "serde",
  "wit-bindgen",
@@ -3822,7 +3844,7 @@ dependencies = [
 name = "peer"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "rmp-serde",
  "serde",
  "wit-bindgen",
@@ -3832,7 +3854,7 @@ dependencies = [
 name = "peers"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "rmp-serde",
  "serde",
  "wit-bindgen",
@@ -5060,7 +5082,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 name = "state"
 version = "0.1.0"
 dependencies = [
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -5226,7 +5248,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "bincode",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "rand 0.8.5",
  "regex",
  "serde",
@@ -5240,7 +5262,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "thiserror",
@@ -5254,7 +5276,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "indexmap",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "thiserror",
@@ -5495,7 +5517,7 @@ name = "top"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -5817,7 +5839,7 @@ name = "uninstall"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "kinode_process_lib 0.7.0",
+ "kinode_process_lib 0.7.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.7.0)",
  "serde",
  "serde_json",
  "wit-bindgen",

--- a/kinode/packages/app_store/app_store/Cargo.toml
+++ b/kinode/packages/app_store/app_store/Cargo.toml
@@ -11,7 +11,7 @@ alloy-primitives = "0.7.0"
 alloy-sol-types = "0.7.0"
 anyhow = "1.0"
 bincode = "1.3.3"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.7.0" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "1ea6eda" }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/kinode/packages/app_store/app_store/src/types.rs
+++ b/kinode/packages/app_store/app_store/src/types.rs
@@ -392,14 +392,11 @@ impl State {
                     ),
                 );
 
-                if generate_package_hash(&package_name, publisher_dnswire.to_vec().as_slice())
-                    != package_hash
-                {
+                if generate_package_hash(&package_name, &publisher_dnswire) != package_hash {
                     return Err(anyhow::anyhow!("got log with mismatched package hash"));
                 }
 
-                let Ok(publisher_name) = dnswire_decode(publisher_dnswire.to_vec().as_slice())
-                else {
+                let Ok(publisher_name) = net::dnswire_decode(&publisher_dnswire) else {
                     return Err(anyhow::anyhow!("got log with invalid publisher name"));
                 };
 
@@ -526,35 +523,6 @@ impl State {
             crate::set_state(&bincode::serialize(self)?);
         }
         Ok(())
-    }
-}
-
-/// take a DNSwire-formatted node ID from chain and convert it to a String
-fn dnswire_decode(wire_format_bytes: &[u8]) -> Result<String, std::string::FromUtf8Error> {
-    let mut i = 0;
-    let mut result = Vec::new();
-
-    while i < wire_format_bytes.len() {
-        let len = wire_format_bytes[i] as usize;
-        if len == 0 {
-            break;
-        }
-        let end = i + len + 1;
-        let mut span = wire_format_bytes[i + 1..end].to_vec();
-        span.push('.' as u8);
-        result.push(span);
-        i = end;
-    }
-
-    let flat: Vec<_> = result.into_iter().flatten().collect();
-
-    let name = String::from_utf8(flat)?;
-
-    // Remove the trailing '.' if it exists (it should always exist)
-    if name.ends_with('.') {
-        Ok(name[0..name.len() - 1].to_string())
-    } else {
-        Ok(name)
     }
 }
 

--- a/kinode/packages/homepage/homepage/src/lib.rs
+++ b/kinode/packages/homepage/homepage/src/lib.rs
@@ -40,7 +40,7 @@ wit_bindgen::generate!({
 
 call_init!(init);
 fn init(our: Address) {
-    let mut app_data: BTreeMap<ProcessId, HomepageApp> = BTreeMap::new();
+    let mut app_data: BTreeMap<String, HomepageApp> = BTreeMap::new();
 
     serve_ui(&our, "ui", true, false, vec!["/"]).expect("failed to serve ui");
 
@@ -102,7 +102,7 @@ fn init(our: Address) {
                         );
                     }
                     HomepageRequest::Remove => {
-                        app_data.remove(&message.source().process);
+                        app_data.remove(&message.source().process.to_string());
                     }
                 }
             } else if let Ok(request) = serde_json::from_slice::<HttpServerRequest>(message.body())
@@ -131,7 +131,7 @@ fn init(our: Address) {
                         } else {
                             send_response(
                                 StatusCode::OK,
-                                Some(HashMap::new()),
+                                Some(std::collections::HashMap::new()),
                                 "yes hello".as_bytes().to_vec(),
                             );
                         }

--- a/kinode/packages/homepage/homepage/src/process_lib.rs
+++ b/kinode/packages/homepage/homepage/src/process_lib.rs
@@ -1,1 +1,0 @@
-../../../src/process_lib.rs

--- a/kinode/packages/kns_indexer/kns_indexer/Cargo.toml
+++ b/kinode/packages/kns_indexer/kns_indexer/Cargo.toml
@@ -12,7 +12,7 @@ alloy-primitives = "0.7.0"
 alloy-sol-types = "0.7.0"
 bincode = "1.3.3"
 hex = "0.4.3"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.7.0" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "1ea6eda" }
 rmp-serde = "1.1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
+++ b/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
@@ -1,14 +1,13 @@
 use alloy_sol_types::{sol, SolEvent};
 use kinode_process_lib::{
-    await_message, call_init, eth, get_typed_state, println, set_state, Address, Message, Request,
-    Response,
+    await_message, call_init, eth, get_typed_state, net, println, set_state, Address, Message,
+    Request, Response,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{
     hash_map::{Entry, HashMap},
     BTreeMap,
 };
-use std::string::FromUtf8Error;
 
 wit_bindgen::generate!({
     path: "wit",
@@ -449,33 +448,5 @@ fn get_name(log: &eth::Log) -> anyhow::Result<String> {
             "got event other than NodeRegistered without knowing about existing node name"
         )
     })?;
-    dnswire_decode(decoded.name.to_vec()).map_err(|e| anyhow::anyhow!(e))
-}
-
-fn dnswire_decode(wire_format_bytes: Vec<u8>) -> Result<String, FromUtf8Error> {
-    let mut i = 0;
-    let mut result = Vec::new();
-
-    while i < wire_format_bytes.len() {
-        let len = wire_format_bytes[i] as usize;
-        if len == 0 {
-            break;
-        }
-        let end = i + len + 1;
-        let mut span = wire_format_bytes[i + 1..end].to_vec();
-        span.push('.' as u8);
-        result.push(span);
-        i = end;
-    }
-
-    let flat: Vec<_> = result.into_iter().flatten().collect();
-
-    let name = String::from_utf8(flat)?;
-
-    // Remove the trailing '.' if it exists (it should always exist)
-    if name.ends_with('.') {
-        Ok(name[0..name.len() - 1].to_string())
-    } else {
-        Ok(name)
-    }
+    net::dnswire_decode(&decoded.name).map_err(|e| anyhow::anyhow!(e))
 }


### PR DESCRIPTION
## Problem

`dnswire_decode` function in app_store and kns_indexer can crash if the wire is somehow formatted illegally. We had this occur, and this makes that error get handled gracefully.

## Solution

Move function to process_lib so it never needs to be re-implemented. Use `get` on slice to handle out of range indices.

## Docs Update

N/A

