### PR TITLE
native-tls so that wss:// type urls will work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5507,7 +5507,9 @@ checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite 0.21.0",
 ]
 
@@ -5801,6 +5803,7 @@ dependencies = [
  "http 1.1.0",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.8.5",
  "sha1",
  "thiserror",

--- a/kinode/Cargo.toml
+++ b/kinode/Cargo.toml
@@ -84,7 +84,7 @@ snow = { version = "0.9.5", features = ["ring-resolver"] }
 static_dir = "0.2.0"
 thiserror = "1.0"
 tokio = { version = "1.28", features = ["fs", "macros", "rt-multi-thread", "signal", "sync"] }
-tokio-tungstenite = "0.21.0"
+tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
 url = "2.4.1"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }
 warp = "0.3.5"

--- a/kinode/src/http/client.rs
+++ b/kinode/src/http/client.rs
@@ -218,7 +218,8 @@ async fn connect_websocket(
     // Connect the WebSocket
     let ws_stream = match connect_async(req).await {
         Ok((ws_stream, _)) => ws_stream,
-        Err(_) => {
+        Err(e) => {
+            println!("{e:?}");
             return Err(HttpClientError::WsOpenFailed {
                 url: url.to_string(),
             });

--- a/kinode/src/http/client.rs
+++ b/kinode/src/http/client.rs
@@ -219,7 +219,13 @@ async fn connect_websocket(
     let ws_stream = match connect_async(req).await {
         Ok((ws_stream, _)) => ws_stream,
         Err(e) => {
-            println!("{e:?}");
+            let _ = print_tx
+                .send(Printout {
+                    verbosity: 1,
+                    content: format!("http_client: underlying lib connection error {e:?}"),
+                })
+                .await;
+
             return Err(HttpClientError::WsOpenFailed {
                 url: url.to_string(),
             });


### PR DESCRIPTION
## Problem

couldn't connect to holium's staging comfyui server via websockets lib because it needed wss:// instead of ws:// (tls)

## Solution

include tls in the binary
```
