### PR TITLE
dont `kit::build` `.DS_Store`

### DIFF
--- a/kinode/build.rs
+++ b/kinode/build.rs
@@ -119,13 +119,17 @@ fn main() -> anyhow::Result<()> {
 
     let results: Vec<anyhow::Result<(String, String, Vec<u8>)>> = entries
         .par_iter()
-        .map(|entry_path| {
+        .filter_map(|entry_path| {
             let parent_pkg_path = entry_path.join("pkg");
-            build_and_zip_package(
+            if parent_pkg_path.exists() {
+                // don't run on, e.g., `.DS_Store`
+                return None;
+            }
+            Some(build_and_zip_package(
                 entry_path.clone(),
                 parent_pkg_path.to_str().unwrap(),
                 &features,
-            )
+            ))
         })
         .collect();
 


### PR DESCRIPTION
## Problem

MacOS sometimes puts `.DS_Store` in random places. This can break our `build.rs`. https://github.com/kinode-dao/kit/issues/147

## Solution

Don't try to build `.DS_Store`, or other non-package dirs, if they exist in the `packages/` dir.

## Testing

```
cargo +nightly build -p kinode```

## Docs Update

None

## Notes

FYI @jurij-jukic 