### PR TITLE
feat: secure subdomains for settings, improvements to server and login

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,6 +3155,28 @@ dependencies = [
 [[package]]
 name = "kinode_process_lib"
 version = "0.8.0"
+source = "git+https://github.com/kinode-dao/process_lib?rev=7820481#78204816d1a2d5213555655c796950a32403eac6"
+dependencies = [
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy.git?rev=cad7935)",
+ "alloy-primitives 0.7.0",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy.git?rev=cad7935)",
+ "alloy-transport 0.1.0 (git+https://github.com/alloy-rs/alloy.git?rev=cad7935)",
+ "anyhow",
+ "bincode",
+ "http 1.1.0",
+ "mime_guess",
+ "rand 0.8.5",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "url",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "kinode_process_lib"
+version = "0.8.0"
 source = "git+https://github.com/kinode-dao/process_lib.git?rev=7eb3a04#7eb3a04f9be79d1cc3a52fa460faeea7ba3008ed"
 dependencies = [
  "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy.git?rev=cad7935)",
@@ -4922,7 +4944,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.0",
  "bincode",
- "kinode_process_lib 0.8.0 (git+https://github.com/kinode-dao/process_lib?rev=830a86c)",
+ "kinode_process_lib 0.8.0 (git+https://github.com/kinode-dao/process_lib?rev=7820481)",
  "rmp-serde",
  "serde",
  "serde_json",

--- a/kinode/packages/settings/pkg/ui/script.js
+++ b/kinode/packages/settings/pkg/ui/script.js
@@ -22,6 +22,9 @@ function api_call(body) {
 
 function shutdown() {
     api_call("Shutdown");
+    setTimeout(() => {
+        window.location.reload();
+    }, 1000);
 }
 
 function populate(data) {

--- a/kinode/packages/settings/settings/Cargo.toml
+++ b/kinode/packages/settings/settings/Cargo.toml
@@ -10,7 +10,7 @@ simulation-mode = []
 anyhow = "1.0"
 base64 = "0.22.0"
 bincode = "1.3.3"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "830a86c" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "7820481" }
 rmp-serde = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/kinode/packages/settings/settings/src/lib.rs
+++ b/kinode/packages/settings/settings/src/lib.rs
@@ -157,9 +157,9 @@ fn initialize(our: Address) {
         .unwrap();
 
     // Serve the index.html and other UI files found in pkg/ui at the root path.
-    http::serve_ui(&our, "ui", true, false, vec!["/"]).unwrap();
-    http::bind_http_path("/ask", true, false).unwrap();
-    http::bind_ws_path("/", true, false).unwrap();
+    http::secure_serve_ui(&our, "ui", vec!["/"]).unwrap();
+    http::secure_bind_http_path("/ask").unwrap();
+    http::secure_bind_ws_path("/", false).unwrap();
 
     // Grab our state, then enter the main event loop.
     let mut state: SettingsState = SettingsState::new(our);

--- a/kinode/src/http/login.html
+++ b/kinode/src/http/login.html
@@ -1168,7 +1168,7 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
         </svg>
       </div>
       <form id="signup-form" class="flex flex-col">
-        <h3 class="flex flex-col ml-2 text-lg"> ${node} </h3>
+        <h3 id="node-and-domain" class="flex flex-col ml-2 text-lg"></h3>
         <div class="flex mt-2 mb-2"> Enter Password </div>
         <input autofocus type="password" id="password" required="" minlength="6" name="password" placeholder="Password"
           oninput="document.getElementById('password-err').style.display = 'none';" value="" class="self-stretch mb-2">
@@ -1193,6 +1193,10 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
       document.getElementById("fake-or-not").innerHTML = "To change your networking info, please restart your node.";
     }
 
+    const host = window.location.host;
+    const firstSubdomain = host.split('.')[0];
+    document.getElementById("node-and-domain").innerText = "${node}: " + firstSubdomain;
+
     async function login(password) {
       document.getElementById("signup-form").style.display = "none";
       document.getElementById("loading").style.display = "flex";
@@ -1207,7 +1211,8 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
       });
 
       if (result.status == 200) {
-        window.location.href = "/";
+        // reload page
+        window.location.reload();
       } else {
         document.getElementById("signup-form").style.display = "flex";
         document.getElementById("loading").style.display = "none";

--- a/kinode/src/http/login.html
+++ b/kinode/src/http/login.html
@@ -1193,9 +1193,8 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
       document.getElementById("fake-or-not").innerHTML = "To change your networking info, please restart your node.";
     }
 
-    const host = window.location.host;
-    const firstSubdomain = host.split('.')[0];
-    document.getElementById("node-and-domain").innerText = "${node}: " + firstSubdomain;
+    const firstPathItem = window.location.pathname.split('/')[1];
+    document.getElementById("node-and-domain").innerText = "${node} " + firstPathItem;
 
     async function login(password) {
       document.getElementById("signup-form").style.display = "none";
@@ -1207,7 +1206,7 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
       const result = await fetch("/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ password_hash: hashHex }),
+        body: JSON.stringify({ password_hash: hashHex, subdomain: firstPathItem }),
       });
 
       if (result.status == 200) {

--- a/kinode/src/http/server.rs
+++ b/kinode/src/http/server.rs
@@ -193,7 +193,7 @@ pub async fn http_server(
     let rpc_bound_path = BoundPath {
         app: Some(ProcessId::new(Some("rpc"), "distro", "sys")),
         path: path.clone(),
-        secure_subdomain: None, // TODO maybe RPC should have subdomain?
+        secure_subdomain: None, // TODO maybe RPC *should* have subdomain?
         authenticated: false,
         local_only: true,
         static_content: None,
@@ -278,14 +278,18 @@ async fn serve(
     let fake_node = "false";
 
     // filter to receive and handle login requests
-    let login_html: &'static str = LOGIN_HTML
-        .replace("${node}", &our)
-        .replace("${fake}", fake_node)
-        .leak();
+    let login_html: Arc<String> = Arc::new(
+        LOGIN_HTML
+            .replace("${node}", &our)
+            .replace("${fake}", fake_node),
+    );
     let cloned_our = our.clone();
+    let cloned_login_html: &'static str = login_html.to_string().leak();
     let login = warp::path("login").and(warp::path::end()).and(
         warp::get()
-            .map(move || warp::reply::with_status(warp::reply::html(login_html), StatusCode::OK))
+            .map(move || {
+                warp::reply::with_status(warp::reply::html(cloned_login_html), StatusCode::OK)
+            })
             .or(warp::post()
                 .and(warp::body::content_length_limit(1024 * 16))
                 .and(warp::body::json())
@@ -308,6 +312,7 @@ async fn serve(
         .and(warp::any().map(move || jwt_secret_bytes.clone()))
         .and(warp::any().map(move || send_to_loop.clone()))
         .and(warp::any().map(move || print_tx.clone()))
+        .and(warp::any().map(move || login_html.clone()))
         .and_then(http_handler);
 
     let filter_with_ws = ws_route.or(login).or(filter);
@@ -318,7 +323,6 @@ async fn serve(
 
 /// handle non-GET requests on /login. if POST, validate password
 /// and return auth token, which will be stored in a cookie.
-/// then redirect to wherever they were trying to go.
 async fn login_handler(
     info: LoginInfo,
     our: Arc<String>,
@@ -381,7 +385,7 @@ async fn ws_handler(
     send_to_loop: MessageSender,
     print_tx: PrintSender,
 ) -> Result<impl warp::Reply, warp::Rejection> {
-    let original_path = normalize_path(path.as_str());
+    let original_path = normalize_path(path.as_str()).to_string();
     let _ = print_tx
         .send(Printout {
             verbosity: 2,
@@ -479,6 +483,7 @@ async fn http_handler(
     jwt_secret_bytes: Arc<Vec<u8>>,
     send_to_loop: MessageSender,
     print_tx: PrintSender,
+    login_html: Arc<String>,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     // trim trailing "/"
     let original_path = normalize_path(path.as_str());
@@ -524,17 +529,12 @@ async fn http_handler(
             })
             .await;
         return Ok(warp::http::Response::builder()
-            .status(StatusCode::TEMPORARY_REDIRECT)
-            .header(
-                "Location",
-                format!(
-                    "http://{}/login",
-                    host.unwrap_or(warp::host::Authority::from_static("localhost"))
-                ),
-            )
-            .body(vec![])
+            .status(StatusCode::OK)
+            .body(login_html.to_string())
             .into_response());
     }
+
+    let host = host.unwrap_or(warp::host::Authority::from_static("localhost"));
 
     if let Some(ref subdomain) = bound_path.secure_subdomain {
         let _ = print_tx
@@ -545,15 +545,33 @@ async fn http_handler(
                 ),
             })
             .await;
-        // assert that host matches what this app wants it to be
-        if host.is_none() {
-            return Ok(warp::reply::with_status(vec![], StatusCode::UNAUTHORIZED).into_response());
-        }
-        let host = host.as_ref().unwrap();
-        // parse out subdomain from host (there can only be one)
         let request_subdomain = host.host().split('.').next().unwrap_or("");
+        // assert that host matches what this app wants it to be
+        if request_subdomain.is_empty() {
+            return Ok(warp::reply::with_status(
+                "attempted to access secure subdomain without host",
+                StatusCode::UNAUTHORIZED,
+            )
+            .into_response());
+        }
         if request_subdomain != subdomain {
-            return Ok(warp::reply::with_status(vec![], StatusCode::UNAUTHORIZED).into_response());
+            return Ok(warp::http::Response::builder()
+                .status(StatusCode::TEMPORARY_REDIRECT)
+                .header(
+                    "Location",
+                    format!(
+                        "{}://{}.{}{}",
+                        match headers.get("X-Forwarded-Proto") {
+                            Some(proto) => proto.to_str().unwrap_or("http"),
+                            None => "http",
+                        },
+                        subdomain,
+                        host,
+                        original_path,
+                    ),
+                )
+                .body(vec![])
+                .into_response());
         }
     }
 
@@ -618,8 +636,8 @@ async fn http_handler(
                         source_socket_addr: socket_addr.map(|addr| addr.to_string()),
                         method: method.to_string(),
                         url: format!(
-                            "http://{}{}",
-                            host.unwrap_or(warp::host::Authority::from_static("localhost")),
+                            "http://{}{}", // note that protocol is being lost here
+                            host.host(),
                             original_path
                         ),
                         bound_path: bound_path.path.clone(),
@@ -657,7 +675,7 @@ async fn http_handler(
     }
 
     let (response_sender, response_receiver) = tokio::sync::oneshot::channel();
-    http_response_senders.insert(id, (original_path, response_sender));
+    http_response_senders.insert(id, (original_path.to_string(), response_sender));
 
     match send_to_loop.send(message).await {
         Ok(_) => {}
@@ -1126,19 +1144,13 @@ async fn handle_app_message(
             };
             match message {
                 HttpServerAction::Bind {
-                    mut path,
+                    path,
                     authenticated,
                     local_only,
                     cache,
                 } => {
+                    let path = format_path_with_process(&km.source.process, &path);
                     let mut path_bindings = path_bindings.write().await;
-                    if km.source.process != "homepage:homepage:sys" {
-                        path = if path.starts_with('/') {
-                            format!("/{}{}", km.source.process, path)
-                        } else {
-                            format!("/{}/{}", km.source.process, path)
-                        };
-                    }
                     let _ = print_tx
                         .send(Printout {
                             verbosity: 2,
@@ -1157,7 +1169,7 @@ async fn handle_app_message(
                     if !cache {
                         // trim trailing "/"
                         path_bindings.add(
-                            &normalize_path(&path),
+                            &path,
                             BoundPath {
                                 app: Some(km.source.process.clone()),
                                 path: path.clone(),
@@ -1180,7 +1192,7 @@ async fn handle_app_message(
                         };
                         // trim trailing "/"
                         path_bindings.add(
-                            &normalize_path(&path),
+                            &path,
                             BoundPath {
                                 app: Some(km.source.process.clone()),
                                 path: path.clone(),
@@ -1193,18 +1205,21 @@ async fn handle_app_message(
                     }
                 }
                 HttpServerAction::SecureBind { path, cache } => {
-                    // the process ID is hashed to generate a unique subdomain
-                    // only the first 32 chars, or 128 bits are used.
-                    // we hash because the process ID can contain many more than
-                    // simply alphanumeric characters that will cause issues as a subdomain.
-                    let process_id_hash =
-                        format!("{:x}", Sha256::digest(km.source.process.to_string()));
-                    let subdomain = process_id_hash.split_at(32).0.to_owned();
+                    let path = format_path_with_process(&km.source.process, &path);
+                    let subdomain = generate_secure_subdomain(&km.source.process);
                     let mut path_bindings = path_bindings.write().await;
+                    let _ = print_tx
+                        .send(Printout {
+                            verbosity: 2,
+                            content: format!(
+                                "http: binding subdomain {subdomain} with path {path}, {}",
+                                if cache { "cached" } else { "dynamic" },
+                            ),
+                        })
+                        .await;
                     if !cache {
-                        // trim trailing "/"
                         path_bindings.add(
-                            &normalize_path(&path),
+                            &path,
                             BoundPath {
                                 app: Some(km.source.process.clone()),
                                 path: path.clone(),
@@ -1227,7 +1242,7 @@ async fn handle_app_message(
                         };
                         // trim trailing "/"
                         path_bindings.add(
-                            &normalize_path(&path),
+                            &path,
                             BoundPath {
                                 app: Some(km.source.process.clone()),
                                 path: path.clone(),
@@ -1239,17 +1254,11 @@ async fn handle_app_message(
                         );
                     }
                 }
-                HttpServerAction::Unbind { mut path } => {
+                HttpServerAction::Unbind { path } => {
+                    let path = format_path_with_process(&km.source.process, &path);
                     let mut path_bindings = path_bindings.write().await;
-                    if km.source.process != "homepage:homepage:sys" {
-                        path = if path.starts_with('/') {
-                            format!("/{}{}", km.source.process, path)
-                        } else {
-                            format!("/{}/{}", km.source.process, path)
-                        };
-                    }
                     path_bindings.add(
-                        &normalize_path(&path),
+                        &path,
                         BoundPath {
                             app: None,
                             path: path.clone(),
@@ -1261,19 +1270,15 @@ async fn handle_app_message(
                     );
                 }
                 HttpServerAction::WebSocketBind {
-                    mut path,
+                    path,
                     authenticated,
                     encrypted,
                     extension,
                 } => {
-                    path = if path.starts_with('/') {
-                        format!("/{}{}", km.source.process, path)
-                    } else {
-                        format!("/{}/{}", km.source.process, path)
-                    };
+                    let path = format_path_with_process(&km.source.process, &path);
                     let mut ws_path_bindings = ws_path_bindings.write().await;
                     ws_path_bindings.add(
-                        &normalize_path(&path),
+                        &path,
                         BoundWsPath {
                             app: Some(km.source.process.clone()),
                             secure_subdomain: None,
@@ -1284,21 +1289,15 @@ async fn handle_app_message(
                     );
                 }
                 HttpServerAction::WebSocketSecureBind {
-                    mut path,
+                    path,
                     encrypted,
                     extension,
                 } => {
-                    path = if path.starts_with('/') {
-                        format!("/{}{}", km.source.process, path)
-                    } else {
-                        format!("/{}/{}", km.source.process, path)
-                    };
-                    let process_id_hash =
-                        format!("{:x}", Sha256::digest(km.source.process.to_string()));
-                    let subdomain = process_id_hash.split_at(32).0.to_owned();
+                    let path = format_path_with_process(&km.source.process, &path);
+                    let subdomain = generate_secure_subdomain(&km.source.process);
                     let mut ws_path_bindings = ws_path_bindings.write().await;
                     ws_path_bindings.add(
-                        &normalize_path(&path),
+                        &path,
                         BoundWsPath {
                             app: Some(km.source.process.clone()),
                             secure_subdomain: Some(subdomain),
@@ -1309,14 +1308,10 @@ async fn handle_app_message(
                     );
                 }
                 HttpServerAction::WebSocketUnbind { mut path } => {
+                    let path = format_path_with_process(&km.source.process, &path);
                     let mut ws_path_bindings = ws_path_bindings.write().await;
-                    path = if path.starts_with('/') {
-                        format!("/{}{}", km.source.process, path)
-                    } else {
-                        format!("/{}/{}", km.source.process, path)
-                    };
                     ws_path_bindings.add(
-                        &normalize_path(&path),
+                        &path,
                         BoundWsPath {
                             app: None,
                             secure_subdomain: None,

--- a/kinode/src/net/indirect.rs
+++ b/kinode/src/net/indirect.rs
@@ -40,7 +40,14 @@ pub async fn connect_to_router(router_id: &Identity, ext: &IdentityExt, data: &N
     );
     if let Some((_ip, port)) = router_id.tcp_routing() {
         match tcp::init_direct(ext, data, &router_id, *port, true, peer_rx).await {
-            Ok(()) => return,
+            Ok(()) => {
+                utils::print_debug(
+                    &ext.print_tx,
+                    &format!("net: connected to router {} via tcp", router_id.name),
+                )
+                .await;
+                return;
+            }
             Err(peer_rx) => {
                 return connect::handle_failed_connection(ext, data, router_id, peer_rx).await;
             }
@@ -48,7 +55,14 @@ pub async fn connect_to_router(router_id: &Identity, ext: &IdentityExt, data: &N
     }
     if let Some((_ip, port)) = router_id.ws_routing() {
         match ws::init_direct(ext, data, &router_id, *port, true, peer_rx).await {
-            Ok(()) => return,
+            Ok(()) => {
+                utils::print_debug(
+                    &ext.print_tx,
+                    &format!("net: connected to router {} via ws", router_id.name),
+                )
+                .await;
+                return;
+            }
             Err(peer_rx) => {
                 return connect::handle_failed_connection(ext, data, router_id, peer_rx).await;
             }

--- a/kinode/src/register.rs
+++ b/kinode/src/register.rs
@@ -785,7 +785,7 @@ async fn success_response(
     encoded_keyfile: Vec<u8>,
 ) -> Result<warp::reply::Response, Rejection> {
     let encoded_keyfile_str = base64_standard.encode(&encoded_keyfile);
-    let token = match keygen::generate_jwt(&decoded_keyfile.jwt_secret_bytes, &our.name) {
+    let token = match keygen::generate_jwt(&decoded_keyfile.jwt_secret_bytes, &our.name, &None) {
         Some(token) => token,
         None => {
             return Ok(warp::reply::with_status(
@@ -805,11 +805,9 @@ async fn success_response(
         warp::reply::with_status(warp::reply::json(&encoded_keyfile_str), StatusCode::FOUND)
             .into_response();
 
-    let headers = response.headers_mut();
-
-    match HeaderValue::from_str(&format!("kinode-auth_{}={};", &our.name, &token)) {
+    match HeaderValue::from_str(&format!("kinode-auth_{}={token};", our.name)) {
         Ok(v) => {
-            headers.append(SET_COOKIE, v);
+            response.headers_mut().append(SET_COOKIE, v);
         }
         Err(_) => {
             return Ok(warp::reply::with_status(

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -993,6 +993,7 @@ pub struct ImportKeyfileInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoginInfo {
     pub password_hash: String,
+    pub subdomain: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/lib/src/http/server_types.rs
+++ b/lib/src/http/server_types.rs
@@ -194,5 +194,6 @@ pub struct WsRegisterResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct JwtClaims {
     pub username: String,
+    pub subdomain: Option<String>,
     pub expiration: u64,
 }


### PR DESCRIPTION
## Problem

Secure subdomains had rotted just a bit from disuse. Also, we are exposing sensitive APIs via HTTP frontends in the core distro.

## Solution

This PR cleans up the subdomain logic at the runtime level, and switches the `settings:sys` app over to actually using them. It goes along with a commit in the `develop` branch of process_lib. 

However, we still serve sensitive APIs from the `app_store:sys` frontend. I would switch that over too, but the homepage currently relies on fetching from those sensitive APIs in exactly the way we want to make impossible. As a result, we will need to change the homepage logic to fetch that data using in-node capabilities-controlled messaging and switch app store to secure-subdomains in that PR.

## Testing

- boot a node
- try accessing the Settings app
- you will need to log in again

## Docs Update

TODO