### PR TITLE
fix: delete old /pkg when new one is unzipped to there

### DIFF
--- a/kinode/packages/app_store/app_store/src/utils.rs
+++ b/kinode/packages/app_store/app_store/src/utils.rs
@@ -253,6 +253,15 @@ pub fn create_package_drive(
         })?)
         .send_and_await_response(VFS_TIMEOUT)??;
 
+    // DELETE the /pkg folder in the package drive
+    // in order to replace with the fresh one
+    Request::to(("our", "vfs", "distro", "sys"))
+        .body(serde_json::to_vec(&vfs::VfsRequest {
+            path: drive_name.clone(),
+            action: vfs::VfsAction::RemoveDirAll,
+        })?)
+        .send_and_await_response(VFS_TIMEOUT)??;
+
     // convert the zip to a new package drive
     let response = Request::to(("our", "vfs", "distro", "sys"))
         .body(serde_json::to_vec(&vfs::VfsRequest {

--- a/kinode/src/state.rs
+++ b/kinode/src/state.rs
@@ -403,6 +403,8 @@ async fn bootstrap(
         // create a new package in VFS
         let our_drive_name = [package_name, package_publisher].join(":");
         let pkg_path = format!("{}/vfs/{}/pkg", &home_directory_path, &our_drive_name);
+        // delete anything currently residing in the pkg folder
+        fs::remove_dir_all(&pkg_path).await?;
         fs::create_dir_all(&pkg_path)
             .await
             .expect("bootstrap vfs dir pkg creation failed!");


### PR DESCRIPTION
## Problem

When a userspace package is installed, we unzip it into a /pkg folder. On subsequent installs, this folder was being overwritten but not wiped, leading to old files living on unless explicitly deleted.

## Solution

These two small changes to bootstrap (runtime) and app store (userspace) make it such that a /pkg folder is always wiped before a package is unzipped into it.

## Testing

- Boot a node, observe success
- Install an app, delete some files from /pkg, install it again, observe the deletion

## Docs Update

We should document this aspect of development better in general.
