### PR TITLE
eth: explicit rpc error return

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,6 +3074,7 @@ dependencies = [
  "aes-gcm",
  "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=6f8ebb4)",
  "alloy-contract",
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=6f8ebb4)",
  "alloy-network",
  "alloy-primitives 0.6.4",
  "alloy-providers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3292,6 +3292,7 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 name = "lib"
 version = "0.8.0"
 dependencies = [
+ "alloy-json-rpc 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=6f8ebb4)",
  "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=6f8ebb4)",
  "anyhow",
  "kit",

--- a/kinode/Cargo.toml
+++ b/kinode/Cargo.toml
@@ -30,6 +30,7 @@ alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "6f8ebb4" }
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "6f8ebb4" }
 alloy-pubsub = { git = "https://github.com/alloy-rs/alloy", rev = "6f8ebb4" }
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "6f8ebb4" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "6f8ebb4" }
 alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "6f8ebb4", features = ["ws"]}
 alloy-transport-ws = { git = "https://github.com/alloy-rs/alloy", rev = "6f8ebb4" }
 alloy-providers = { git = "https://github.com/alloy-rs/alloy", rev = "6f8ebb4" }

--- a/kinode/src/eth/mod.rs
+++ b/kinode/src/eth/mod.rs
@@ -621,7 +621,7 @@ async fn fulfill_request(
             Err(rpc_error) => {
                 // if rpc_error is of type ErrResponse, return to user!
                 if let RpcError::ErrorResp(err) = rpc_error {
-                    return EthResponse::Err(EthError::RpcError(err.to_string()));
+                    return EthResponse::Err(EthError::RpcError(err));
                 }
                 verbose_print(
                     print_tx,
@@ -656,7 +656,7 @@ async fn fulfill_request(
         )
         .await;
         if let EthResponse::Err(e) = response {
-            if e == EthError::RpcMalformedResponse {
+            if let EthError::RpcMalformedResponse = e {
                 node_provider.usable = false;
             }
         } else {

--- a/kinode/src/eth/mod.rs
+++ b/kinode/src/eth/mod.rs
@@ -1,3 +1,4 @@
+use alloy_json_rpc::RpcError;
 use alloy_providers::provider::Provider;
 use alloy_pubsub::PubSubFrontend;
 use alloy_rpc_client::ClientBuilder;
@@ -618,6 +619,10 @@ async fn fulfill_request(
                 return EthResponse::Response { value };
             }
             Err(rpc_error) => {
+                // if rpc_error is of type ErrResponse, return to user!
+                if let RpcError::ErrorResp(err) = rpc_error {
+                    return EthResponse::Err(EthError::RpcError(err.to_string()));
+                }
                 verbose_print(
                     print_tx,
                     &format!(

--- a/kinode/src/eth/subscription.rs
+++ b/kinode/src/eth/subscription.rs
@@ -287,7 +287,7 @@ async fn build_subscription(
                 node_provider.usable = false;
             }
             EthResponse::Err(e) => {
-                if e == EthError::RpcMalformedResponse {
+                if let EthError::RpcMalformedResponse = e {
                     node_provider.usable = false;
                 }
             }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,6 +18,7 @@ tokio = "1.28"
 
 [dependencies]
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "6f8ebb4" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "6f8ebb4" }
 lazy_static = "1.4.0"
 rand = "0.8.4"
 ring = "0.17.8"

--- a/lib/src/eth.rs
+++ b/lib/src/eth.rs
@@ -61,6 +61,8 @@ pub enum EthResponse {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub enum EthError {
+    /// RPC provider returned an error
+    RpcError(String),
     /// provider module cannot parse message
     MalformedRequest,
     /// No RPC provider for the chain

--- a/lib/src/eth.rs
+++ b/lib/src/eth.rs
@@ -1,3 +1,4 @@
+use alloy_json_rpc::ErrorPayload;
 use alloy_rpc_types::pubsub::{Params, SubscriptionKind, SubscriptionResult};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -59,10 +60,10 @@ pub enum EthResponse {
     Err(EthError),
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum EthError {
     /// RPC provider returned an error
-    RpcError(String),
+    RpcError(ErrorPayload),
     /// provider module cannot parse message
     MalformedRequest,
     /// No RPC provider for the chain


### PR DESCRIPTION
## Problem

If I send a signed transaction that will fail on the rpc level, for example with too low a gas level, the eth runtime currently does a few things:

receives error, assumes something is wrong with the provider, returns a NoRpcFound error, restart subscriptions.

## Solution

If ErrResponse from provider, to_string() it and return it to the user so they know what went wrong.

## Notes

corresponding process_lib update: https://github.com/kinode-dao/process_lib/pull/80
