### PR TITLE
Dp/on demand buildserver

### DIFF
--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -19,4 +19,4 @@ jobs:
         port: ${{ secrets.SSH_PORT }}
         command_timeout: 60m
         script: |
-          curl -X PUT http://localhost:8000/monitor/build-kinode
+          curl —max-time 3600 -X PUT http://localhost:8000/monitor/build-kinode


### PR DESCRIPTION
brought curl timeout in line with the overall command/workflow timeout length