### PR TITLE
reloadable widgets

### DIFF
--- a/kinode/packages/app_store/app_store/src/http_api.rs
+++ b/kinode/packages/app_store/app_store/src/http_api.rs
@@ -126,6 +126,15 @@ fn make_widget() -> String {
                 })
                 .catch(error => console.error('Error fetching apps:', error));
         });
+
+        // listen for reload events from the mobile app
+        // we're in an iframe, so they will be posted messages
+        // the message will be 'reload' and we don't care about origin
+        window.addEventListener('message', function(event) {
+            if (event.data === 'reload') {
+                location.reload();
+            }
+        });
     </script>
 </body>
 </html>"#

--- a/kinode/packages/kino_updates/widget/src/lib.rs
+++ b/kinode/packages/kino_updates/widget/src/lib.rs
@@ -86,6 +86,16 @@ fn create_widget(posts: Vec<KinodeBlogPost>) -> String {
     >
         {}
     </div>
+    <script>
+        // listen for reload events from the mobile app
+        // we're in an iframe, so they will be posted messages
+        // the message will be 'reload' and we don't care about origin
+        window.addEventListener('message', function(event) {
+            if (event.data === 'reload') {
+                location.reload();
+            }
+        });
+    </script>
 </body>
 </html>"#,
         posts


### PR DESCRIPTION
## Problem

On the mobile app, especially while we're still in alpha/beta, a user might get a widget into an unrecoverable state (navigating via a link to a page inside the iframe, for example).

## Solution

In our iframes, listen for messages from the parent window. On `reload` message, reload the iframe.

## Testing

- [ ] Click the reload button in the ios app and verify that a widget in a broken state returns to functional state.

## Docs Update

WIP. I intend to add a Widgets page to the docs with this PR, but I first need to verify that the reload message works as intended.

## Notes

10/10, no notes
