### PR TITLE
remove tailwind from appstore and kinoupdates widgets

### DIFF
--- a/kinode/packages/app_store/app_store/src/http_api.rs
+++ b/kinode/packages/app_store/app_store/src/http_api.rs
@@ -60,22 +60,88 @@ pub fn init_frontend(our: &Address) {
 fn make_widget() -> String {
     return r#"<html>
 <head>
-    <script src="https://cdn.tailwindcss.com"></script>
     <style>
-        .app {
-            width: 100%;
+        /* General body styles */
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
         }
 
+        a {
+            text-decoration: none;
+            color: inherit;
+        }
+        
+        body {
+            color: white;
+            overflow: hidden;
+        }
+        
+        /* Flex container for apps */
+        #latest-apps {
+            display: flex;
+            flex-wrap: wrap;
+            padding: 0.5rem;
+            gap: 0.5rem;
+            align-items: center;
+            backdrop-filter: saturate(1.25);
+            border-radius: 0.75rem;
+            box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+            height: 100vh;
+            width: 100vw;
+            overflow-y: auto;
+            scrollbar-color: transparent transparent;
+            scrollbar-width: none;
+        }
+        
+        /* Individual app container */
+        .app {
+            padding: 0.5rem;
+            display: flex;
+            flex-grow: 1;
+            align-items: stretch;
+            border-radius: 0.75rem;
+            box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+            background-color: rgba(255, 255, 255, 0.1);
+            cursor: pointer;
+            font-family: sans-serif;
+            width: 100%;
+        }
+        
+        .app:hover {
+            background-color: rgba(255, 255, 255, 0.2);
+        }
+        
+        /* App image styling */
         .app-image {
+            border-radius: 0.75rem;
+            margin-right: 0.5rem;
+            flex-grow: 1;
             background-size: cover;
             background-repeat: no-repeat;
             background-position: center;
+            height: 92px;
+            width: 92px;
+            max-width: 33%;
         }
-
+        
+        /* App information styling */
         .app-info {
-            max-width: 67%
+            display: flex;
+            flex-direction: column;
+            flex-grow: 1;
+            max-width: 67%;
         }
-
+        
+        /* Headings within app-info */
+        .app-info h2 {
+            font-weight: bold;
+            font-size: medium;
+        }
+        
+        /* Responsive design for larger screens */
         @media screen and (min-width: 500px) {
             .app {
                 width: 49%;
@@ -84,15 +150,7 @@ fn make_widget() -> String {
     </style>
 </head>
 <body class="text-white overflow-hidden">
-    <div
-        id="latest-apps"
-        class="flex flex-wrap p-2 gap-2 items-center backdrop-brightness-125 rounded-xl shadow-lg h-screen w-screen overflow-y-auto"
-        style="
-            scrollbar-color: transparent transparent;
-            scrollbar-width: none;
-        "
-    >
-    </div>
+    <div id="latest-apps"></div>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             fetch('/main:app_store:sys/apps/listed', { credentials: 'include' })
@@ -102,22 +160,19 @@ fn make_widget() -> String {
                     data.forEach(app => {
                         if (app.metadata) {
                             const a = document.createElement('a');
-                            a.className = 'app p-2 grow flex items-stretch rounded-lg shadow bg-white/10 hover:bg-white/20 font-sans cursor-pointer';
+                            a.className = 'app';
                             a.href = `/main:app_store:sys/app-details/${app.package}:${app.publisher}`
                             a.target = '_blank';
                             a.rel = 'noopener noreferrer';
                             const iconLetter = app.metadata_hash.replace('0x', '')[0].toUpperCase();
-                            a.innerHTML = `<div
-                                class="app-image rounded mr-2 grow"
+                            a.innerHTML = `<div 
+                                class="app-image"
                                 style="
                                     background-image: url('${app.metadata.image || `/icons/${iconLetter}`}');
-                                    height: 92px;
-                                    width: 92px;
-                                    max-width: 33%;
                                 "
                             ></div>
-                            <div class="app-info flex flex-col grow">
-                                <h2 class="font-bold">${app.metadata.name}</h2>
+                            <div class="app-info">
+                                <h2>${app.metadata.name}</h2>
                                 <p>${app.metadata.description}</p>
                             </div>`;
                                 container.appendChild(a);

--- a/kinode/packages/app_store/app_store/src/http_api.rs
+++ b/kinode/packages/app_store/app_store/src/http_api.rs
@@ -61,8 +61,6 @@ fn make_widget() -> String {
     return r#"<html>
 <head>
     <style>
-        /* General body styles */
-
         * {
             box-sizing: border-box;
             margin: 0;
@@ -73,13 +71,12 @@ fn make_widget() -> String {
             text-decoration: none;
             color: inherit;
         }
-        
+
         body {
             color: white;
             overflow: hidden;
         }
-        
-        /* Flex container for apps */
+
         #latest-apps {
             display: flex;
             flex-wrap: wrap;
@@ -95,8 +92,7 @@ fn make_widget() -> String {
             scrollbar-color: transparent transparent;
             scrollbar-width: none;
         }
-        
-        /* Individual app container */
+
         .app {
             padding: 0.5rem;
             display: flex;
@@ -109,39 +105,35 @@ fn make_widget() -> String {
             font-family: sans-serif;
             width: 100%;
         }
-        
+
         .app:hover {
             background-color: rgba(255, 255, 255, 0.2);
         }
-        
-        /* App image styling */
+
         .app-image {
             border-radius: 0.75rem;
             margin-right: 0.5rem;
             flex-grow: 1;
-            background-size: cover;
+            background-size: contain;
             background-repeat: no-repeat;
             background-position: center;
             height: 92px;
             width: 92px;
             max-width: 33%;
         }
-        
-        /* App information styling */
+
         .app-info {
             display: flex;
             flex-direction: column;
             flex-grow: 1;
             max-width: 67%;
         }
-        
-        /* Headings within app-info */
+
         .app-info h2 {
             font-weight: bold;
             font-size: medium;
         }
-        
-        /* Responsive design for larger screens */
+
         @media screen and (min-width: 500px) {
             .app {
                 width: 49%;
@@ -165,7 +157,7 @@ fn make_widget() -> String {
                             a.target = '_blank';
                             a.rel = 'noopener noreferrer';
                             const iconLetter = app.metadata_hash.replace('0x', '')[0].toUpperCase();
-                            a.innerHTML = `<div 
+                            a.innerHTML = `<div
                                 class="app-image"
                                 style="
                                     background-image: url('${app.metadata.image || `/icons/${iconLetter}`}');

--- a/kinode/packages/kino_updates/widget/src/lib.rs
+++ b/kinode/packages/kino_updates/widget/src/lib.rs
@@ -33,7 +33,7 @@ fn init(_our: Address) {
                 serde_json::json!({
                     "Add": {
                         "label": "KinoUpdates",
-                        "widget": create_widget(fetch_most_recent_blog_posts(12)),
+                        "widget": create_widget(fetch_most_recent_blog_posts(6)),
                     }
                 })
                 .to_string(),
@@ -49,15 +49,13 @@ fn create_widget(posts: Vec<KinodeBlogPost>) -> String {
     return format!(
         r#"<html>
 <head>
-    
     <style>
-    /* General body styles */
     * {{
         box-sizing: border-box;
         margin: 0;
         padding: 0;
     }}
-    
+
     a {{
         text-decoration: none;
         color: inherit;
@@ -77,8 +75,7 @@ fn create_widget(posts: Vec<KinodeBlogPost>) -> String {
         gap: 0.5rem;
         font-family: sans-serif;
     }}
-    
-    /* Flex container for blog posts */
+
     #latest-blog-posts {{
         display: flex;
         flex-direction: column;
@@ -94,8 +91,7 @@ fn create_widget(posts: Vec<KinodeBlogPost>) -> String {
         scrollbar-width: none;
         align-self: stretch;
     }}
-    
-    /* Individual blog post container */
+
     .post {{
         width: 100%;
         display: flex;
@@ -104,8 +100,7 @@ fn create_widget(posts: Vec<KinodeBlogPost>) -> String {
         border-radius: 0.5em;
         padding: 0.5em;
     }}
-    
-    /* Blog post image styling */
+
     .post-image {{
         background-size: cover;
         background-repeat: no-repeat;
@@ -114,13 +109,12 @@ fn create_widget(posts: Vec<KinodeBlogPost>) -> String {
         height: 100px;
         border-radius: 4px;
     }}
-    
-    /* Blog post information styling */
+
     .post-info {{
         max-width: 67%;
+        overflow: hidden;
     }}
-    
-    /* Responsive design for larger screens */
+
     @media screen and (min-width: 500px) {{
         .post {{
             width: 49%;
@@ -128,15 +122,13 @@ fn create_widget(posts: Vec<KinodeBlogPost>) -> String {
     }}
     </style>
 </head>
-<body class="text-white overflow-hidden h-screen w-screen flex flex-col gap-2">
+<body class="text-white overflow-hidden">
     <div
         id="latest-blog-posts"
-        class="flex flex-col p-2 gap-2 backdrop-brightness-125 rounded-xl shadow-lg h-screen w-screen overflow-y-auto self-stretch"
         style="
             scrollbar-color: transparent transparent;
             scrollbar-width: none;
-        "
-    >
+        ">
         {}
     </div>
 </body>
@@ -176,17 +168,17 @@ fn trim_content(content: &str) -> String {
 
 fn post_to_html_string(post: KinodeBlogPost) -> String {
     format!(
-        r#"<a 
-            class="post p-2 grow self-stretch flex items-stretch rounded-lg shadow bg-white/10 hover:bg-white/20 font-sans w-full"
+        r#"<a
+            class="post"
             href="https://kinode.org/blog/post/{}"
-            target="_blank" 
+            target="_blank"
             rel="noopener noreferrer"
         >
         <div
-            class="post-image rounded mr-2 grow self-stretch h-full"
+            class="post-image"
             style="background-image: url('https://kinode.org{}');"
         ></div>
-        <div class="post-info flex flex-col grow">
+        <div class="post-info">
             <h2 class="font-bold">{}</h2>
             <p>{}</p>
         </div>

--- a/kinode/packages/kino_updates/widget/src/lib.rs
+++ b/kinode/packages/kino_updates/widget/src/lib.rs
@@ -33,7 +33,7 @@ fn init(_our: Address) {
                 serde_json::json!({
                     "Add": {
                         "label": "KinoUpdates",
-                        "widget": create_widget(fetch_most_recent_blog_posts(6)),
+                        "widget": create_widget(fetch_most_recent_blog_posts(12)),
                     }
                 })
                 .to_string(),

--- a/kinode/packages/kino_updates/widget/src/lib.rs
+++ b/kinode/packages/kino_updates/widget/src/lib.rs
@@ -33,7 +33,7 @@ fn init(_our: Address) {
                 serde_json::json!({
                     "Add": {
                         "label": "KinoUpdates",
-                        "widget": create_widget(fetch_most_recent_blog_posts(6)),
+                        "widget": create_widget(fetch_most_recent_blog_posts(12)),
                     }
                 })
                 .to_string(),
@@ -49,30 +49,83 @@ fn create_widget(posts: Vec<KinodeBlogPost>) -> String {
     return format!(
         r#"<html>
 <head>
-    <script src="https://cdn.tailwindcss.com"></script>
+    
     <style>
+    /* General body styles */
+    * {{
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+    }}
+    
+    a {{
+        text-decoration: none;
+        color: inherit;
+    }}
+
+    h2 {{
+        font-size: medium;
+    }}
+
+    body {{
+        color: white;
+        overflow: hidden;
+        height: 100vh;
+        width: 100vw;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        font-family: sans-serif;
+    }}
+    
+    /* Flex container for blog posts */
+    #latest-blog-posts {{
+        display: flex;
+        flex-direction: column;
+        padding: 0.5rem;
+        gap: 0.5rem;
+        backdrop-filter: brightness(1.25);
+        border-radius: 0.75rem;
+        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+        height: 100vh;
+        width: 100vw;
+        overflow-y: auto;
+        scrollbar-color: transparent transparent;
+        scrollbar-width: none;
+        align-self: stretch;
+    }}
+    
+    /* Individual blog post container */
+    .post {{
+        width: 100%;
+        display: flex;
+        gap: 8px;
+        background-color: rgba(255, 255, 255, 0.1);
+        border-radius: 0.5em;
+        padding: 0.5em;
+    }}
+    
+    /* Blog post image styling */
+    .post-image {{
+        background-size: cover;
+        background-repeat: no-repeat;
+        background-position: center;
+        width: 100px;
+        height: 100px;
+        border-radius: 4px;
+    }}
+    
+    /* Blog post information styling */
+    .post-info {{
+        max-width: 67%;
+    }}
+    
+    /* Responsive design for larger screens */
+    @media screen and (min-width: 500px) {{
         .post {{
-            width: 100%;
+            width: 49%;
         }}
-
-        .post-image {{
-            background-size: cover;
-            background-repeat: no-repeat;
-            background-position: center;
-            width: 100px;
-            height: 100px;
-            border-radius: 16px;
-        }}
-
-        .post-info {{
-            max-width: 67%
-        }}
-
-        @media screen and (min-width: 500px) {{
-            .post {{
-                width: 49%;
-            }}
-        }}
+    }}
     </style>
 </head>
 <body class="text-white overflow-hidden h-screen w-screen flex flex-col gap-2">


### PR DESCRIPTION
## Problem

The appstore and kinoupdates widgets chastise us not to be so slack as to include non-production minified CSS in our production code.

## Solution

Purge the offending library and replace it with wholesome AI slop.

## Testing

- [x] Open homepage and confirm Tailwind warnings do not show. 

## Notes

Semper vigilans! 
