### PR TITLE
kernel: only overwrite request prompting_message when there could be a reply to it

### DIFF
--- a/kinode/src/kernel/standard_host.rs
+++ b/kinode/src/kernel/standard_host.rs
@@ -101,7 +101,10 @@ impl process::ProcessState {
     ) -> Result<(wit::Address, wit::Message), (wit::SendError, Option<wit::Context>)> {
         let (mut km, context) = match incoming {
             Ok(mut km) => match km.message {
-                t::Message::Request(t::Request { ref expects_response, .. }) => {
+                t::Message::Request(t::Request {
+                    ref expects_response,
+                    ..
+                }) => {
                     self.last_blob = km.lazy_load_blob;
                     km.lazy_load_blob = None;
                     if expects_response.is_some() || km.rsvp.is_some() {

--- a/kinode/src/kernel/standard_host.rs
+++ b/kinode/src/kernel/standard_host.rs
@@ -101,10 +101,13 @@ impl process::ProcessState {
     ) -> Result<(wit::Address, wit::Message), (wit::SendError, Option<wit::Context>)> {
         let (mut km, context) = match incoming {
             Ok(mut km) => match km.message {
-                t::Message::Request(_) => {
+                t::Message::Request(t::Request { ref expects_response, .. }) => {
                     self.last_blob = km.lazy_load_blob;
                     km.lazy_load_blob = None;
-                    self.prompting_message = Some(km.clone());
+                    if expects_response.is_some() || km.rsvp.is_some() {
+                        // update prompting_message iff there is someone to reply to
+                        self.prompting_message = Some(km.clone());
+                    }
                     (km, None)
                 }
                 t::Message::Response(_) => match self.contexts.remove(&km.id) {

--- a/kinode/src/kernel/standard_host_v0.rs
+++ b/kinode/src/kernel/standard_host_v0.rs
@@ -101,7 +101,10 @@ impl process::ProcessState {
     ) -> Result<(wit::Address, wit::Message), (wit::SendError, Option<wit::Context>)> {
         let (mut km, context) = match incoming {
             Ok(mut km) => match km.message {
-                t::Message::Request(t::Request { ref expects_response, .. }) => {
+                t::Message::Request(t::Request {
+                    ref expects_response,
+                    ..
+                }) => {
                     self.last_blob = km.lazy_load_blob;
                     km.lazy_load_blob = None;
                     if expects_response.is_some() || km.rsvp.is_some() {

--- a/kinode/src/kernel/standard_host_v0.rs
+++ b/kinode/src/kernel/standard_host_v0.rs
@@ -101,10 +101,13 @@ impl process::ProcessState {
     ) -> Result<(wit::Address, wit::Message), (wit::SendError, Option<wit::Context>)> {
         let (mut km, context) = match incoming {
             Ok(mut km) => match km.message {
-                t::Message::Request(_) => {
+                t::Message::Request(t::Request { ref expects_response, .. }) => {
                     self.last_blob = km.lazy_load_blob;
                     km.lazy_load_blob = None;
-                    self.prompting_message = Some(km.clone());
+                    if expects_response.is_some() || km.rsvp.is_some() {
+                        // update prompting_message iff there is someone to reply to
+                        self.prompting_message = Some(km.clone());
+                    }
                     (km, None)
                 }
                 t::Message::Response(_) => match self.contexts.remove(&km.id) {


### PR DESCRIPTION
## Problem

![Untitled](https://github.com/kinode-dao/kinode/assets/79381743/ce1ced1f-efa9-4aff-8a79-e0b9c9bb115d)

## Solution

Only update the `prompting_message` when new one could conceivably be useful.

## Testing

Ask me

## Docs Update

TODO

## Notes

This is a small change but should be carefully considered because
1. It is technically breaking,
2. Even if we decide we want it, we may want to do a similar thing with the `Response` `None` context case, in the match case just below.

Let's discuss @dr-frmr 