### PR TITLE
use blog post header image thumbnails for kinoupdates widget

### DIFF
--- a/kinode/packages/kino_updates/widget/src/lib.rs
+++ b/kinode/packages/kino_updates/widget/src/lib.rs
@@ -176,7 +176,7 @@ fn post_to_html_string(post: KinodeBlogPost) -> String {
         >
         <div
             class="post-image"
-            style="background-image: url('https://kinode.org{}');"
+            style="background-image: url('https://kinode.org{}-medium');"
         ></div>
         <div class="post-info">
             <h2 class="font-bold">{}</h2>

--- a/kinode/packages/kino_updates/widget/src/lib.rs
+++ b/kinode/packages/kino_updates/widget/src/lib.rs
@@ -176,7 +176,7 @@ fn post_to_html_string(post: KinodeBlogPost) -> String {
         >
         <div
             class="post-image"
-            style="background-image: url('https://kinode.org{}-medium');"
+            style="background-image: url('https://kinode.org{}-thumbnail');"
         ></div>
         <div class="post-info">
             <h2 class="font-bold">{}</h2>


### PR DESCRIPTION
## Problem

Blog post images in the KinoUpdates widget load fullsize images rather slowly.

## Solution

- [x] Update the blog API to create and serve thumbnail sized images.
- [x] Query the thumbnails in the widget.

## Testing

- [x] Verify loading of images is snappy.
- [x] Inspect image source: verify image ends with `-thumbnail`.
