### PR TITLE
top: don't show capabilities by default, add --show-caps (-c) flag to do so.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5744,6 +5744,7 @@ name = "top"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "clap",
  "kinode_process_lib 0.8.0 (git+https://github.com/kinode-dao/process_lib?tag=v0.8.0)",
  "serde",
  "serde_json",

--- a/kinode/packages/terminal/m/Cargo.toml
+++ b/kinode/packages/terminal/m/Cargo.toml
@@ -8,7 +8,7 @@ simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"
-clap = "4.4.18"
+clap = "4.4"
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.8.0" }
 regex = "1.10.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/kinode/packages/terminal/top/Cargo.toml
+++ b/kinode/packages/terminal/top/Cargo.toml
@@ -8,6 +8,7 @@ simulation-mode = []
 
 [dependencies]
 anyhow = "1.0"
+clap = "4.4"
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.8.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
… do so

## Problem

Issue #421 

## Solution

Add flag to `top` script and adjust formatting

## Testing

`top`

`top -c`

`top --show-caps`

`top terminal:terminal:sys`

`top terminal:terminal:sys -c`

`top terminal:terminal:sys --show-caps`
