### PR TITLE
fix revoke all behavior, make caps printing on verbosity=3 cleaner

### DIFF
--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -1426,6 +1426,42 @@ pub enum CapMessage {
     },
 }
 
+impl std::fmt::Display for CapMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            CapMessage::Add { on, caps, .. } => write!(
+                f,
+                "caps: add {} on {on}",
+                caps.iter()
+                    .map(|c| c.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CapMessage::Drop { on, caps, .. } => write!(
+                f,
+                "caps: drop {} on {on}",
+                caps.iter()
+                    .map(|c| c.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+            CapMessage::Has { on, cap, .. } => write!(f, "caps: has {} on {on}", cap),
+            CapMessage::GetAll { on, .. } => write!(f, "caps: get all on {on}"),
+            CapMessage::RevokeAll { on, .. } => write!(f, "caps: revoke all on {on}"),
+            CapMessage::FilterCaps { on, caps, .. } => {
+                write!(
+                    f,
+                    "caps: filter for {} on {on}",
+                    caps.iter()
+                        .map(|c| c.to_string())
+                        .collect::<Vec<String>>()
+                        .join(", ")
+                )
+            }
+        }
+    }
+}
+
 pub type ReverseCapIndex = HashMap<ProcessId, HashMap<ProcessId, Vec<Capability>>>;
 
 pub type ProcessMap = HashMap<ProcessId, PersistedProcess>;


### PR DESCRIPTION
## Problem

Issue #416 

## Solution

It seems like revoking all capabilities on process spindown wasn't working for a while, which led to us not observing this issue. Now that RevokeAll is operating as expected, removing capabilities generated by a process when it gets killed or crashes, we need to re-grant capabilities in the OnExit::Restart case.

I came up with a simpler solution: adding a flag to the kill procedure that simply skips over the RevokeAll call. Then I use that flag in the Restart case on process spindown.

## Testing

See #416 

## Docs Update

We should thoroughly document this whole thing -- I'll get on that

## Notes

Also made capabilities print more nicely in terminal on verbosity 3.
