### PR TITLE
fix: if hitting path before login, redirect to login

### DIFF
--- a/kinode/src/http/server.rs
+++ b/kinode/src/http/server.rs
@@ -218,7 +218,6 @@ pub async fn http_server(
     ));
 
     while let Some(km) = recv_in_server.recv().await {
-        // we *can* move this into a dedicated task, but it's not necessary
         handle_app_message(
             km,
             http_response_senders.clone(),
@@ -585,10 +584,28 @@ async fn http_handler(
                 &jwt_secret_bytes,
             ) {
                 // redirect to login page so they can get an auth token
-                return Ok(warp::http::Response::builder()
-                    .status(StatusCode::OK)
-                    .body(login_html.to_string())
-                    .into_response());
+                if original_path == "" {
+                    return Ok(warp::http::Response::builder()
+                        .status(StatusCode::OK)
+                        .body(login_html.to_string())
+                        .into_response());
+                } else {
+                    return Ok(warp::http::Response::builder()
+                        .status(StatusCode::TEMPORARY_REDIRECT)
+                        .header(
+                            "Location",
+                            format!(
+                                "{}://{}",
+                                match headers.get("X-Forwarded-Proto") {
+                                    Some(proto) => proto.to_str().unwrap_or("http"),
+                                    None => "http",
+                                },
+                                host,
+                            ),
+                        )
+                        .body(vec![])
+                        .into_response());
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

#425 

## Solution

If a path is not bound to a subdomain, instead of directly serving subdomain-focused login page, redirect to `/`.

The only problem with this is that the user then has to navigate back to the path they were trying to hit directly pre-log-in.

## Testing

See #425 

## Docs Update

N/A

