### PR TITLE
conditional removed in workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
The conditional test was failing unexpectedly.  As it's merely a redundant safety measure, I'm removing it for now so as not to hold up the automated builds.