### PR TITLE
fix login redirects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "kinode_lib"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "lib",
 ]
@@ -3391,7 +3391,7 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "lib"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "alloy",
  "kit",

--- a/kinode/packages/settings/settings/src/lib.rs
+++ b/kinode/packages/settings/settings/src/lib.rs
@@ -157,9 +157,12 @@ fn initialize(our: Address) {
         .unwrap();
 
     // Serve the index.html and other UI files found in pkg/ui at the root path.
-    http::serve_ui(&our, "ui", true, false, vec!["/"]).unwrap();
-    http::bind_http_path("/ask", true, false).unwrap();
-    http::bind_ws_path("/", true, false).unwrap();
+    //http::serve_ui(&our, "ui", true, false, vec!["/"]).unwrap();
+    //http::bind_http_path("/ask", true, false).unwrap();
+    //http::bind_ws_path("/", true, false).unwrap();
+    http::secure_serve_ui(&our, "ui", vec!["/"]).unwrap();
+    http::secure_bind_http_path("/ask").unwrap();
+    http::secure_bind_ws_path("/", false).unwrap();
 
     // Grab our state, then enter the main event loop.
     let mut state: SettingsState = SettingsState::new(our);

--- a/kinode/packages/settings/settings/src/lib.rs
+++ b/kinode/packages/settings/settings/src/lib.rs
@@ -157,12 +157,9 @@ fn initialize(our: Address) {
         .unwrap();
 
     // Serve the index.html and other UI files found in pkg/ui at the root path.
-    //http::serve_ui(&our, "ui", true, false, vec!["/"]).unwrap();
-    //http::bind_http_path("/ask", true, false).unwrap();
-    //http::bind_ws_path("/", true, false).unwrap();
-    http::secure_serve_ui(&our, "ui", vec!["/"]).unwrap();
-    http::secure_bind_http_path("/ask").unwrap();
-    http::secure_bind_ws_path("/", false).unwrap();
+    http::serve_ui(&our, "ui", true, false, vec!["/"]).unwrap();
+    http::bind_http_path("/ask", true, false).unwrap();
+    http::bind_ws_path("/", true, false).unwrap();
 
     // Grab our state, then enter the main event loop.
     let mut state: SettingsState = SettingsState::new(our);

--- a/kinode/src/http/login.html
+++ b/kinode/src/http/login.html
@@ -1194,10 +1194,13 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
     }
 
     const firstPathItem = window.location.pathname.split('/')[1];
-    if (firstPathItem === '') {
-      document.getElementById("node-and-domain").innerText = "${node} ";
-    } else {
+    const expectedSecureSubdomain = generateSecureSubdomain(firstPathItem);
+    const maybeSecureSubdomain = window.location.host.split('.')[0];
+    const isSecureSubdomain = expectedSecureSubdomain === maybeSecureSubdomain;
+    if (isSecureSubdomain) {
       document.getElementById("node-and-domain").innerText = "${node}: authenticate for secure subdomain app " + firstPathItem;
+    } else {
+      document.getElementById("node-and-domain").innerText = "${node} ";
     }
 
     async function login(password) {
@@ -1210,7 +1213,10 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
       const result = await fetch("/login", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ password_hash: hashHex, subdomain: firstPathItem }),
+        body: JSON.stringify({
+          password_hash: hashHex,
+          subdomain: isSecureSubdomain ? firstPathItem : '',
+        }),
       });
 
       if (result.status == 200) {
@@ -1224,6 +1230,17 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
         document.getElementById("password").focus();
         return;
       }
+    }
+
+    function generateSecureSubdomain(processString) {
+      const parts = processString.split(':');
+      const package = parts[1];
+      const publisher = parts[2];
+      const subdomain = [package, publisher].join("-")
+        .split("")
+        .map(c => c.match(/[a-zA-Z0-9]/) ? c : '-')
+        .join("");
+      return subdomain;
     }
 
     document.addEventListener("DOMContentLoaded", () => {

--- a/kinode/src/http/server.rs
+++ b/kinode/src/http/server.rs
@@ -546,12 +546,21 @@ async fn http_handler(
                 .into_response());
             }
             if request_subdomain != subdomain {
+                let query_string = if !query_params.is_empty() {
+                    let params: Vec<String> = query_params.iter()
+                        .map(|(key, value)| format!("{}={}", key, value))
+                        .collect();
+                    format!("?{}", params.join("&"))
+                } else {
+                    String::new()
+                };
+
                 return Ok(warp::http::Response::builder()
                     .status(StatusCode::TEMPORARY_REDIRECT)
                     .header(
                         "Location",
                         format!(
-                            "{}://{}.{}{}",
+                            "{}://{}.{}{}{}",
                             match headers.get("X-Forwarded-Proto") {
                                 Some(proto) => proto.to_str().unwrap_or("http"),
                                 None => "http",
@@ -559,6 +568,7 @@ async fn http_handler(
                             subdomain,
                             host,
                             original_path,
+                            query_string,
                         ),
                     )
                     .body(vec![])

--- a/kinode/src/http/server.rs
+++ b/kinode/src/http/server.rs
@@ -584,28 +584,10 @@ async fn http_handler(
                 &jwt_secret_bytes,
             ) {
                 // redirect to login page so they can get an auth token
-                if original_path == "" {
-                    return Ok(warp::http::Response::builder()
-                        .status(StatusCode::OK)
-                        .body(login_html.to_string())
-                        .into_response());
-                } else {
-                    return Ok(warp::http::Response::builder()
-                        .status(StatusCode::TEMPORARY_REDIRECT)
-                        .header(
-                            "Location",
-                            format!(
-                                "{}://{}",
-                                match headers.get("X-Forwarded-Proto") {
-                                    Some(proto) => proto.to_str().unwrap_or("http"),
-                                    None => "http",
-                                },
-                                host,
-                            ),
-                        )
-                        .body(vec![])
-                        .into_response());
-                }
+                return Ok(warp::http::Response::builder()
+                    .status(StatusCode::OK)
+                    .body(login_html.to_string())
+                    .into_response());
             }
         }
     }

--- a/kinode/src/http/server.rs
+++ b/kinode/src/http/server.rs
@@ -547,7 +547,8 @@ async fn http_handler(
             }
             if request_subdomain != subdomain {
                 let query_string = if !query_params.is_empty() {
-                    let params: Vec<String> = query_params.iter()
+                    let params: Vec<String> = query_params
+                        .iter()
                         .map(|(key, value)| format!("{}={}", key, value))
                         .collect();
                     format!("?{}", params.join("&"))


### PR DESCRIPTION
## Problem

Resolves #429

## Solution

1. Change the login page logic to correctly determine if we are on secure subdomain. In the case where there is a non `/` path but we are not on a secure subdomain, this lets us redirect to the same path (including query params) after login.
2. Use @bacwyls s solution to preserve query params when logging into secure subdomain https://github.com/bacwyls/kinode/commit/396a9015a4eb351298558bfbff7b69a8dda5f74e


## Testing

The cases to test are:
1. Login as normal to `/`
2. Login to `/chess:chess:sys` and see redirect after login
3. Login to `/chess:chess:sys?foo=bar` and see redirect after login including query param
4. Login to `/chess:chess:sys` and see redirect after login (secure subdomain)
5. Login to `/chess:chess:sys?foo=bar` and see redirect after login including query param (secure subdomain)

To test 4&5, use commit b4395e0 which has `settings:settings:sys` served on secure subdomain. the subsequent commit (dc93350) set it back to insecure.

## Docs Update

None

## Notes

There is an interesting behavior where you can login to a secure subdomain when the insecured node has not been logged in. I think this was always the case. Not sure if it is a desired behavior or not.

h/t @bacwyls 