### PR TITLE
fix: boot as direct if keyfile indicates desire to

### DIFF
--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -224,8 +224,6 @@ async fn main() {
         }
     };
 
-    println!("our: {:?}\r", our);
-
     // the boolean flag determines whether the runtime module is *public* or not,
     // where public means that any process can always message it.
     #[allow(unused_mut)]

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -224,6 +224,8 @@ async fn main() {
         }
     };
 
+    println!("our: {:?}\r", our);
+
     // the boolean flag determines whether the runtime module is *public* or not,
     // where public means that any process can always message it.
     #[allow(unused_mut)]

--- a/kinode/src/register.rs
+++ b/kinode/src/register.rs
@@ -757,6 +757,11 @@ pub async fn assign_routing(
         ip & 0xFF
     );
 
+    println!("routers: {:?}\r", routers);
+    println!("node_ip: {:?}\r", node_ip);
+    println!("ws: {:?}\r", ws);
+    println!("tcp: {:?}\r", tcp);
+
     if !routers.is_empty() {
         // indirect node
         return Ok(());

--- a/kinode/src/register.rs
+++ b/kinode/src/register.rs
@@ -707,7 +707,6 @@ pub async fn assign_routing(
     let namehash = FixedBytes::<32>::from_slice(&keygen::namehash(&our.name));
     let ip_call = ipCall { _0: namehash }.abi_encode();
     let key_call = keyCall { _0: namehash }.abi_encode();
-    let router_call = routersCall { _0: namehash }.abi_encode();
     let tx_input = TransactionInput::new(Bytes::from(ip_call));
     let tx = TransactionRequest::default()
         .to(kns_address)
@@ -737,18 +736,6 @@ pub async fn assign_routing(
         ));
     }
 
-    let router_tx_input = TransactionInput::new(Bytes::from(router_call));
-    let router_tx = TransactionRequest::default()
-        .to(kns_address)
-        .input(router_tx_input);
-
-    let Ok(routers) = provider.call(&router_tx).await else {
-        return Err(anyhow::anyhow!("Failed to fetch node routers from PKI"));
-    };
-    let Ok(routers) = <Vec<FixedBytes<32>>>::abi_decode(&routers, false) else {
-        return Err(anyhow::anyhow!("Failed to decode node routers from PKI"));
-    };
-
     let node_ip = format!(
         "{}.{}.{}.{}",
         (ip >> 24) & 0xFF,
@@ -757,12 +744,7 @@ pub async fn assign_routing(
         ip & 0xFF
     );
 
-    println!("routers: {:?}\r", routers);
-    println!("node_ip: {:?}\r", node_ip);
-    println!("ws: {:?}\r", ws);
-    println!("tcp: {:?}\r", tcp);
-
-    if !routers.is_empty() {
+    if !our.is_direct() {
         // indirect node
         return Ok(());
     }

--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -587,7 +587,7 @@ pub async fn terminal(
             _ = sigalrm.recv() => return Err(anyhow::anyhow!("exiting due to SIGALRM")),
             _ = sighup.recv() =>  return Err(anyhow::anyhow!("exiting due to SIGHUP")),
             _ = sigint.recv() =>  return Err(anyhow::anyhow!("exiting due to SIGINT")),
-            _ = sigpipe.recv() => return Err(anyhow::anyhow!("exiting due to SIGPIPE")),
+            _ = sigpipe.recv() => continue, // IGNORE SIGPIPE!
             _ = sigquit.recv() => return Err(anyhow::anyhow!("exiting due to SIGQUIT")),
             _ = sigterm.recv() => return Err(anyhow::anyhow!("exiting due to SIGTERM")),
             _ = sigusr1.recv() => return Err(anyhow::anyhow!("exiting due to SIGUSR1")),


### PR DESCRIPTION
## Problem

Hotfix for a bug in which nodes that have routers listed onchain but have since re-registered as direct can't boot.

## Solution

Fix the boot flow so that directness as indicated in keyfile is honored.

