### PR TITLE
net: remove all namehash usage

### DIFF
--- a/kinode/src/net/connect.rs
+++ b/kinode/src/net/connect.rs
@@ -101,11 +101,7 @@ async fn connect_via_router(
         routers.shuffle(&mut rand::thread_rng());
         routers
     };
-    for router_namehash in &routers_shuffled {
-        let Some(router_name) = data.names.get(router_namehash) else {
-            // router does not exist in PKI that we know of
-            continue;
-        };
+    for router_name in &routers_shuffled {
         if router_name.as_ref() == ext.our.name {
             // we can't route through ourselves
             continue;

--- a/kinode/src/net/types.rs
+++ b/kinode/src/net/types.rs
@@ -55,8 +55,8 @@ pub struct RoutingRequest {
 }
 
 pub type Peers = Arc<DashMap<String, Peer>>;
-pub type PKINames = Arc<DashMap<String, NodeId>>;
 pub type OnchainPKI = Arc<DashMap<String, Identity>>;
+
 /// (from, target) -> from's socket
 pub type PendingPassthroughs = Arc<DashMap<(NodeId, NodeId), PendingStream>>;
 pub enum PendingStream {
@@ -98,6 +98,5 @@ pub struct IdentityExt {
 pub struct NetData {
     pub pki: OnchainPKI,
     pub peers: Peers,
-    pub names: PKINames,
     pub pending_passthroughs: PendingPassthroughs,
 }

--- a/kinode/src/net/utils.rs
+++ b/kinode/src/net/utils.rs
@@ -1,6 +1,6 @@
 use crate::net::types::{
-    HandshakePayload, OnchainPKI, PKINames, Peers, PendingPassthroughs, PendingStream,
-    RoutingRequest, TCP_PROTOCOL, WS_PROTOCOL,
+    HandshakePayload, OnchainPKI, Peers, PendingPassthroughs, PendingStream, RoutingRequest,
+    TCP_PROTOCOL, WS_PROTOCOL,
 };
 use lib::types::core::{
     Identity, KernelMessage, KnsUpdate, Message, MessageSender, NetAction, NetworkErrorSender,
@@ -175,7 +175,7 @@ pub async fn maintain_passthrough(socket_1: PendingStream, socket_2: PendingStre
     }
 }
 
-pub fn ingest_log(log: KnsUpdate, pki: &OnchainPKI, names: &PKINames) {
+pub fn ingest_log(log: KnsUpdate, pki: &OnchainPKI) {
     pki.insert(
         log.name.clone(),
         Identity {
@@ -191,7 +191,6 @@ pub fn ingest_log(log: KnsUpdate, pki: &OnchainPKI, names: &PKINames) {
             },
         },
     );
-    names.insert(log.node, log.name);
 }
 
 pub fn validate_signature(from: &str, signature: &[u8], message: &[u8], pki: &OnchainPKI) -> bool {

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -2005,14 +2005,10 @@ pub enum NetAction {
     /// in the future could get from remote provider
     KnsUpdate(KnsUpdate),
     KnsBatchUpdate(Vec<KnsUpdate>),
-    /// add a (namehash -> name) to our representation of the PKI
-    AddName(String, String),
     /// get a list of peers we are connected to
     GetPeers,
     /// get the [`Identity`] struct for a single peer
     GetPeer(String),
-    /// get the [`NodeId`] associated with a given namehash, if any
-    GetName(String),
     /// get a user-readable diagnostics string containing networking inforamtion
     GetDiagnostics,
     /// sign the attached blob payload, sign with our node's networking key.


### PR DESCRIPTION
## Problem

We no longer need namehash indexing at the networking protocol level. This simplifies the data structures significantly and allows us to only care about actual node names at the runtime level.

## Solution

TODO 

## Testing

TODO

## Docs Update

TODO

## Notes

This is a **breaking change** affecting `net:distro:sys` API. Document accordingly on 0.9.0 release.
