### PR TITLE
fix: don't use from_block in eth subscribe filters

### DIFF
--- a/kinode/packages/app_store/app_store/src/utils.rs
+++ b/kinode/packages/app_store/app_store/src/utils.rs
@@ -76,7 +76,6 @@ pub fn fetch_state(our: Address, provider: eth::Provider) -> State {
 pub fn app_store_filter(state: &State) -> eth::Filter {
     eth::Filter::new()
         .address(eth::Address::from_str(&state.contract_address).unwrap())
-        .from_block(state.last_saved_block)
         .events(EVENTS)
 }
 
@@ -84,7 +83,10 @@ pub fn app_store_filter(state: &State) -> eth::Filter {
 pub fn fetch_and_subscribe_logs(state: &mut State) {
     let filter = app_store_filter(state);
     // get past logs, subscribe to new ones.
-    for log in fetch_logs(&state.provider, &filter) {
+    for log in fetch_logs(
+        &state.provider,
+        &filter.clone().from_block(state.last_saved_block),
+    ) {
         if let Err(e) = state.ingest_contract_event(log, false) {
             println!("error ingesting log: {e:?}");
         };

--- a/kinode/packages/kino_updates/widget/src/lib.rs
+++ b/kinode/packages/kino_updates/widget/src/lib.rs
@@ -6,8 +6,8 @@ wit_bindgen::generate!({
     world: "process-v0",
 });
 
-/// 20 minutes
-const REFRESH_INTERVAL: u64 = 20 * 60 * 1000;
+/// 2 hours
+const REFRESH_INTERVAL: u64 = 120 * 60 * 1000;
 
 #[derive(Serialize, Deserialize)]
 struct KinodeBlogPost {


### PR DESCRIPTION
## Problem

Infura suddenly errors when a subscription includes a `from_block` parameter.

## Solution

Update our apps to not do this.

## Testing

Boot a node with an Infura RPC.

