### PR TITLE
eth: fix deadlock casued by multiple subscriptions/requests

### DIFF
--- a/kinode/src/eth/subscription.rs
+++ b/kinode/src/eth/subscription.rs
@@ -224,19 +224,17 @@ async fn build_subscription(
             Ok(sub) => {
                 let rx = sub.into_raw();
                 let mut is_replacement_successful = true;
-                providers
-                    .entry(chain_id)
-                    .and_modify(|aps| {
-                        let Some(index) = find_index(
-                            &aps.urls.iter().map(|u| u.url.as_str()).collect(),
-                            &url_provider.url) else
-                        {
-                            is_replacement_successful = false;
-                            return ();
-                        };
-                        aps.urls.remove(index);
-                        aps.urls.insert(0, url_provider.clone());
-                    });
+                providers.entry(chain_id).and_modify(|aps| {
+                    let Some(index) = find_index(
+                        &aps.urls.iter().map(|u| u.url.as_str()).collect(),
+                        &url_provider.url,
+                    ) else {
+                        is_replacement_successful = false;
+                        return ();
+                    };
+                    aps.urls.remove(index);
+                    aps.urls.insert(0, url_provider.clone());
+                });
                 if !is_replacement_successful {
                     verbose_print(
                         print_tx,
@@ -257,20 +255,18 @@ async fn build_subscription(
                 .await;
                 // this provider failed and needs to be reset
                 let mut is_reset_successful = true;
-                providers
-                    .entry(chain_id)
-                    .and_modify(|aps| {
-                        let Some(index) = find_index(
-                            &aps.urls.iter().map(|u| u.url.as_str()).collect(),
-                            &url_provider.url) else
-                        {
-                            is_reset_successful = false;
-                            return ();
-                        };
-                        let mut url = aps.urls.remove(index);
-                        url.pubsub = None;
-                        aps.urls.insert(index, url);
-                    });
+                providers.entry(chain_id).and_modify(|aps| {
+                    let Some(index) = find_index(
+                        &aps.urls.iter().map(|u| u.url.as_str()).collect(),
+                        &url_provider.url,
+                    ) else {
+                        is_reset_successful = false;
+                        return ();
+                    };
+                    let mut url = aps.urls.remove(index);
+                    url.pubsub = None;
+                    aps.urls.insert(index, url);
+                });
                 if !is_reset_successful {
                     verbose_print(
                         print_tx,
@@ -341,7 +337,8 @@ async fn build_subscription(
                     &chain_id,
                     &node_provider.kns_update.name,
                     print_tx,
-                ).await;
+                )
+                .await;
             }
             EthResponse::Err(e) => {
                 if let EthError::RpcMalformedResponse = e {
@@ -350,7 +347,8 @@ async fn build_subscription(
                         &chain_id,
                         &node_provider.kns_update.name,
                         print_tx,
-                    ).await;
+                    )
+                    .await;
                 }
             }
         }

--- a/kinode/src/eth/subscription.rs
+++ b/kinode/src/eth/subscription.rs
@@ -180,15 +180,21 @@ async fn build_subscription(
     else {
         return Err(EthError::PermissionDenied); // will never hit
     };
-    let Some(mut aps) = providers.get_mut(&chain_id) else {
-        return Err(EthError::NoRpcForChain);
+    let mut urls = {
+        // in code block to drop providers lock asap to avoid deadlock
+        let Some(aps) = providers.get(&chain_id) else {
+            return Err(EthError::NoRpcForChain);
+        };
+        aps.urls.clone()
     };
+    let chain_id = chain_id.clone();
+
     // first, try any url providers we have for this chain,
     // then if we have none or they all fail, go to node providers.
     // finally, if no provider works, return an error.
 
     // bump the successful provider to the front of the list for future requests
-    for (index, url_provider) in aps.urls.iter_mut().enumerate() {
+    for url_provider in urls.iter_mut() {
         let pubsub = match &url_provider.pubsub {
             Some(pubsub) => pubsub,
             None => {
@@ -217,8 +223,27 @@ async fn build_subscription(
         {
             Ok(sub) => {
                 let rx = sub.into_raw();
-                let successful_provider = aps.urls.remove(index);
-                aps.urls.insert(0, successful_provider);
+                let mut is_replacement_successful = true;
+                providers
+                    .entry(chain_id)
+                    .and_modify(|aps| {
+                        let Some(index) = find_index(
+                            &aps.urls.iter().map(|u| u.url.as_str()).collect(),
+                            &url_provider.url) else
+                        {
+                            is_replacement_successful = false;
+                            return ();
+                        };
+                        aps.urls.remove(index);
+                        aps.urls.insert(0, url_provider.clone());
+                    });
+                if !is_replacement_successful {
+                    verbose_print(
+                        print_tx,
+                        &format!("eth: unexpectedly couldn't find provider to be modified"),
+                    )
+                    .await;
+                }
                 return Ok(Ok(rx));
             }
             Err(rpc_error) => {
@@ -231,7 +256,28 @@ async fn build_subscription(
                 )
                 .await;
                 // this provider failed and needs to be reset
-                url_provider.pubsub = None;
+                let mut is_reset_successful = true;
+                providers
+                    .entry(chain_id)
+                    .and_modify(|aps| {
+                        let Some(index) = find_index(
+                            &aps.urls.iter().map(|u| u.url.as_str()).collect(),
+                            &url_provider.url) else
+                        {
+                            is_reset_successful = false;
+                            return ();
+                        };
+                        let mut url = aps.urls.remove(index);
+                        url.pubsub = None;
+                        aps.urls.insert(index, url);
+                    });
+                if !is_reset_successful {
+                    verbose_print(
+                        print_tx,
+                        &format!("eth: unexpectedly couldn't find provider to be modified"),
+                    )
+                    .await;
+                }
             }
         }
     }
@@ -241,7 +287,14 @@ async fn build_subscription(
     // we need to create our own unique sub id because in the remote provider node,
     // all subs will be identified under our process address.
     let remote_sub_id = rand::random();
-    for node_provider in &mut aps.nodes {
+    let nodes = {
+        // in code block to drop providers lock asap to avoid deadlock
+        let Some(aps) = providers.get(&chain_id) else {
+            return Err(EthError::NoRpcForChain);
+        };
+        aps.nodes.clone()
+    };
+    for node_provider in &nodes {
         verbose_print(
             &print_tx,
             &format!(
@@ -283,11 +336,21 @@ async fn build_subscription(
             }
             EthResponse::Response { .. } => {
                 // the response to a SubscribeLogs request must be an 'ok'
-                node_provider.usable = false;
+                set_node_unusable(
+                    &providers,
+                    &chain_id,
+                    &node_provider.kns_update.name,
+                    print_tx,
+                ).await;
             }
             EthResponse::Err(e) => {
                 if let EthError::RpcMalformedResponse = e {
-                    node_provider.usable = false;
+                    set_node_unusable(
+                        &providers,
+                        &chain_id,
+                        &node_provider.kns_update.name,
+                        print_tx,
+                    ).await;
                 }
             }
         }


### PR DESCRIPTION
## Problem

Our default eth provider, `providerfren.os`, frequently hangs, requiring restart.

## Solution

Fix deadlock by minimizing the amount of time locks are acquired for. In particular move everything that communicates with a timeout outside of a lock.

## Testing

To test I:
1. Set up an eth provider using this binary or master
2. Modified kns_indexer to infinitely loop sending `get_logs()`, by commenting out https://github.com/kinode-dao/kinode/blob/fbf961e9de224de922e274b08bfbf860311dd963/kinode/packages/kns_indexer/kns_indexer/src/lib.rs#L163
3. Run one node using looping kns indexer, pointed at eth provider
4. Start a second one & stop if it successfully connects, repeating until either witness deadlock or get bored

Using that protocol, I get a deadlock immediately on master, whereas I have not witnessed a deadlock on this branch.

## Docs Update

None

## Notes

None