### PR TITLE
Use build args for Kinode version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM debian:12-slim AS downloader
+ARG VERSION
 
 WORKDIR /tmp/download
 
 RUN apt-get update
-RUN apt-get install wget curl openssl jq unzip -y
+RUN apt-get install unzip -y
 
-ADD https://api.github.com/repos/kinode-dao/kinode/releases releases.json
-RUN wget "https://github.com/kinode-dao/kinode/releases/download/$(cat releases.json | jq -r '.[0].tag_name')/kinode-x86_64-unknown-linux-gnu.zip"
+ADD "https://github.com/kinode-dao/kinode/releases/download/${VERSION}/kinode-x86_64-unknown-linux-gnu.zip" kinode-x86_64-unknown-linux-gnu.zip
 RUN unzip kinode-x86_64-unknown-linux-gnu.zip
 
 FROM debian:12-slim

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 </p>
 
+
 Kinode is a general-purpose sovereign cloud computer, built for crypto.
 
 This repo contains the core runtime and processes.
@@ -16,10 +17,10 @@ Then follow the instructions to [install it](https://book.kinode.org/install.htm
 
 If you have questions, join the [Kinode discord](https://discord.gg/TCgdca5Bjt) and drop us a line in `#dev-support`.
 
+
 ## Setup
 
 On certain operating systems, you may need to install these dependencies if they are not already present:
-
 - openssl-sys: https://docs.rs/crate/openssl-sys/0.9.19
 - libclang 5.0: https://rust-lang.github.io/rust-bindgen/requirements.html
 
@@ -53,7 +54,6 @@ No security audits of this crate have ever been performed. This software is unde
 Make sure not to use the same home directory for two nodes at once! You can use any name for the home directory: here we just use `home`. The `--` here separates cargo arguments from binary arguments.
 
 TODO: document feature flags in `--simulation-mode`
-
 ```bash
 # OPTIONAL: --release flag
 cargo +nightly run -p kinode -- home
@@ -66,7 +66,6 @@ On boot you will be prompted to navigate to `localhost:8080` (or whatever HTTP p
 By default, a node will use the [hardcoded providers](./kinode/src/eth/default_providers_mainnet.json) for the network it is booted on. A node can use a WebSockets RPC URL directly, or use another Kinode as a relay point. To adjust the providers a node uses, just create and modify the `.eth_providers` file in the node's home folder (set at boot). See the Kinode Book for more docs, and see the [default providers file here](./kinode/src/eth/default_providers_mainnet.json) for a template to create `.eth_providers`.
 
 You may also add a RPC provider or otherwise modify your configuration by sending messages from the terminal to the `eth:distro:sys` process. You can get one for free at `alchemy.com`. Use this message format to add a provider -- this will make your node's performance better when accessing a blockchain:
-
 ```
 m our@eth:distro:sys '{"AddProvider": {"chain_id": <SOME_CHAIN_ID>, "trusted": true, "provider": {"RpcUrl": "<WS_RPC_URL>"}}}'
 ```
@@ -122,18 +121,18 @@ The `sys` publisher is not a real node ID, but it's also not a special case valu
 - CTRL+R to search history, CTRL+R again to toggle through search results, CTRL+G to cancel search
 
 - `m <address> '<json>'`: send an inter-process message. <address> is formatted as <node>@<process_id>. <process_id> is formatted as <process_name>:<package_name>:<publisher_node>. JSON containing spaces must be wrapped in single-quotes (`''`).
-  - Example: `m our@eth:distro:sys "SetPublic" -a 5`
-  - the '-a' flag is used to expect a response with a given timeout
-  - `our` will always be interpolated by the system as your node's name
+    - Example: `m our@eth:distro:sys "SetPublic" -a 5`
+    - the '-a' flag is used to expect a response with a given timeout
+    - `our` will always be interpolated by the system as your node's name
 - `hi <name> <string>`: send a text message to another node's command line.
-  - Example: `hi ben.os hello world`
+    - Example: `hi ben.os hello world`
 - `top <process_id>`: display kernel debugging info about a process. Leave the process ID blank to display info about all processes and get the total number of running processes.
-  - Example: `top net:distro:sys`
-  - Example: `top`
+    - Example: `top net:distro:sys`
+    - Example: `top`
 - `cat <vfs-file-path>`: print the contents of a file in the terminal
-  - Example: `cat /terminal:sys/pkg/scripts.json`
+    - Example: `cat /terminal:sys/pkg/scripts.json`
 - `echo <text>`: print `text` to the terminal
-  - Example: `echo foo`
+    - Example: `echo foo`
 - `net_diagnostics`: print some useful networking diagnostic data
 - `peers`: print the peers the node currently hold connections with
 - `peer <name>`: print the peer's PKI info, if it exists
@@ -147,7 +146,6 @@ The image includes EXPOSE directives for TCP port `8080` and TCP port `9000`. Po
 If you are running a direct node, you must map port `9000` to the same port on the host and on your router. Otherwise, your Kinode will not be able to connect to the rest of the network as connection info is written to the chain, and this information is based on the view from inside the Docker container.
 
 To build a local Docker image, run the following command in this project root.
-
 ```bash
 # The `VERSION` may be replaced with the tag of a GitHub release
 docker build -t 0xlynett/kinode . --build-arg VERSION=v0.8.6

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 </p>
 
-
 Kinode is a general-purpose sovereign cloud computer, built for crypto.
 
 This repo contains the core runtime and processes.
@@ -17,10 +16,10 @@ Then follow the instructions to [install it](https://book.kinode.org/install.htm
 
 If you have questions, join the [Kinode discord](https://discord.gg/TCgdca5Bjt) and drop us a line in `#dev-support`.
 
-
 ## Setup
 
 On certain operating systems, you may need to install these dependencies if they are not already present:
+
 - openssl-sys: https://docs.rs/crate/openssl-sys/0.9.19
 - libclang 5.0: https://rust-lang.github.io/rust-bindgen/requirements.html
 
@@ -54,6 +53,7 @@ No security audits of this crate have ever been performed. This software is unde
 Make sure not to use the same home directory for two nodes at once! You can use any name for the home directory: here we just use `home`. The `--` here separates cargo arguments from binary arguments.
 
 TODO: document feature flags in `--simulation-mode`
+
 ```bash
 # OPTIONAL: --release flag
 cargo +nightly run -p kinode -- home
@@ -66,6 +66,7 @@ On boot you will be prompted to navigate to `localhost:8080` (or whatever HTTP p
 By default, a node will use the [hardcoded providers](./kinode/src/eth/default_providers_mainnet.json) for the network it is booted on. A node can use a WebSockets RPC URL directly, or use another Kinode as a relay point. To adjust the providers a node uses, just create and modify the `.eth_providers` file in the node's home folder (set at boot). See the Kinode Book for more docs, and see the [default providers file here](./kinode/src/eth/default_providers_mainnet.json) for a template to create `.eth_providers`.
 
 You may also add a RPC provider or otherwise modify your configuration by sending messages from the terminal to the `eth:distro:sys` process. You can get one for free at `alchemy.com`. Use this message format to add a provider -- this will make your node's performance better when accessing a blockchain:
+
 ```
 m our@eth:distro:sys '{"AddProvider": {"chain_id": <SOME_CHAIN_ID>, "trusted": true, "provider": {"RpcUrl": "<WS_RPC_URL>"}}}'
 ```
@@ -121,18 +122,18 @@ The `sys` publisher is not a real node ID, but it's also not a special case valu
 - CTRL+R to search history, CTRL+R again to toggle through search results, CTRL+G to cancel search
 
 - `m <address> '<json>'`: send an inter-process message. <address> is formatted as <node>@<process_id>. <process_id> is formatted as <process_name>:<package_name>:<publisher_node>. JSON containing spaces must be wrapped in single-quotes (`''`).
-    - Example: `m our@eth:distro:sys "SetPublic" -a 5`
-    - the '-a' flag is used to expect a response with a given timeout
-    - `our` will always be interpolated by the system as your node's name
+  - Example: `m our@eth:distro:sys "SetPublic" -a 5`
+  - the '-a' flag is used to expect a response with a given timeout
+  - `our` will always be interpolated by the system as your node's name
 - `hi <name> <string>`: send a text message to another node's command line.
-    - Example: `hi ben.os hello world`
+  - Example: `hi ben.os hello world`
 - `top <process_id>`: display kernel debugging info about a process. Leave the process ID blank to display info about all processes and get the total number of running processes.
-    - Example: `top net:distro:sys`
-    - Example: `top`
+  - Example: `top net:distro:sys`
+  - Example: `top`
 - `cat <vfs-file-path>`: print the contents of a file in the terminal
-    - Example: `cat /terminal:sys/pkg/scripts.json`
+  - Example: `cat /terminal:sys/pkg/scripts.json`
 - `echo <text>`: print `text` to the terminal
-    - Example: `echo foo`
+  - Example: `echo foo`
 - `net_diagnostics`: print some useful networking diagnostic data
 - `peers`: print the peers the node currently hold connections with
 - `peer <name>`: print the peer's PKI info, if it exists
@@ -146,12 +147,15 @@ The image includes EXPOSE directives for TCP port `8080` and TCP port `9000`. Po
 If you are running a direct node, you must map port `9000` to the same port on the host and on your router. Otherwise, your Kinode will not be able to connect to the rest of the network as connection info is written to the chain, and this information is based on the view from inside the Docker container.
 
 To build a local Docker image, run the following command in this project root.
-```
-docker build -t 0xlynett/kinode .
+
+```bash
+# The `VERSION` may be replaced with the tag of a GitHub release
+docker build -t 0xlynett/kinode . --build-arg VERSION=v0.8.6
 ```
 
 For example:
-```
+
+```bash
 docker volume create kinode-volume
 
 docker run -d -p 8080:8080 -it --name my-kinode \


### PR DESCRIPTION
## Problem

Right now, running `docker build` always pulls the latest Kinode binary from GitHub Releases.

## Solution

Edited the Dockerfile to add a `VERSION` argument.

## Testing

Lmao

## Docs Update

N/A