### PR TITLE
kns: ip encoding change

### DIFF
--- a/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
+++ b/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
@@ -506,15 +506,15 @@ fn decode_routers(data: &[u8], state: &State) -> anyhow::Result<Vec<String>> {
 
 pub fn bytes_to_ip(bytes: &[u8]) -> anyhow::Result<IpAddr> {
     match bytes.len() {
+        4 => {
+            // IPv4 address
+            let ip_num = u32::from_be_bytes(bytes.try_into().unwrap());
+            Ok(IpAddr::V4(Ipv4Addr::from(ip_num)))
+        }
         16 => {
+            // IPv6 address
             let ip_num = u128::from_be_bytes(bytes.try_into().unwrap());
-            if ip_num < (1u128 << 32) {
-                // IPv4
-                Ok(IpAddr::V4(Ipv4Addr::from(ip_num as u32)))
-            } else {
-                // IPv6
-                Ok(IpAddr::V6(Ipv6Addr::from(ip_num)))
-            }
+            Ok(IpAddr::V6(Ipv6Addr::from(ip_num)))
         }
         _ => Err(anyhow::anyhow!("Invalid byte length for IP address")),
     }

--- a/kinode/src/register-ui/src/abis/helpers.ts
+++ b/kinode/src/register-ui/src/abis/helpers.ts
@@ -1,8 +1,16 @@
 
 import { NetworkingInfo } from "../lib/types";
+import { kinohash } from "../utils/kinohash";
 import { ipToBytes, portToBytes } from "../utils/kns_encoding";
 import { multicallAbi, kinomapAbi, mechAbi, KINOMAP, MULTICALL } from "./";
 import { encodeFunctionData, encodePacked, stringToHex, bytesToHex } from "viem";
+
+// Function to encode router names into keccak256 hashes
+// Function to encode router names into keccak256 hashes
+const encodeRouters = (routers: string[]): `0x${string}` => {
+    const hashedRouters = routers.map(router => kinohash(router).slice(2)); // Remove '0x' prefix
+    return `0x${hashedRouters.join('')}`;
+};
 
 export const generateNetworkingKeys = async ({
     direct,
@@ -78,6 +86,8 @@ export const generateNetworkingKeys = async ({
             ]
         });
 
+    const encodedRouters = encodeRouters(allowed_routers);
+
     const router_call =
         encodeFunctionData({
             abi: kinomapAbi,
@@ -86,7 +96,7 @@ export const generateNetworkingKeys = async ({
                 encodePacked(["bytes"], [stringToHex("~routers")]),
                 encodePacked(
                     ["bytes"],
-                    [stringToHex(allowed_routers.join(","))]
+                    [encodedRouters]
                 )]
         });
 

--- a/kinode/src/register-ui/src/utils/kns_encoding.ts
+++ b/kinode/src/register-ui/src/utils/kns_encoding.ts
@@ -20,24 +20,24 @@ export function bytesToIp(bytes: Uint8Array): string {
 }
 
 export function ipToBytes(ip: string): Uint8Array {
-    const bytes = new Uint8Array(16);
-    const view = new DataView(bytes.buffer);
-
     if (ip.includes(':')) {
-        // IPv6
+        // IPv6: Create a 16-byte array
+        const bytes = new Uint8Array(16);
+        const view = new DataView(bytes.buffer);
         const parts = ip.split(':');
         for (let i = 0; i < 8; i++) {
             view.setUint16(i * 2, parseInt(parts[i] || '0', 16));
         }
+        return bytes;
     } else {
-        // IPv4
+        // IPv4: Create a 4-byte array
+        const bytes = new Uint8Array(4);
         const parts = ip.split('.');
         for (let i = 0; i < 4; i++) {
-            bytes[12 + i] = parseInt(parts[i], 10);
+            bytes[i] = parseInt(parts[i], 10);
         }
+        return bytes;
     }
-
-    return bytes;
 }
 
 export function bytesToPort(bytes: Uint8Array): number {


### PR DESCRIPTION
Currently we encode both ipv4 and ipv6 addresses in 16byte big endian arrays, this could be variable given we can match on the length of a note value easily
