### PR TITLE
eth provider fixes

### DIFF
--- a/kinode/src/eth/subscription.rs
+++ b/kinode/src/eth/subscription.rs
@@ -113,7 +113,6 @@ pub async fn create_new_subscription(
                         let (keepalive_err_sender, keepalive_err_receiver) =
                             tokio::sync::mpsc::channel(1);
                         response_channels.insert(keepalive_km_id, keepalive_err_sender);
-                        let response_channels = response_channels.clone();
                         subs.insert(
                             remote_sub_id,
                             ActiveSub::Remote {

--- a/kinode/src/eth/subscription.rs
+++ b/kinode/src/eth/subscription.rs
@@ -470,7 +470,7 @@ async fn maintain_remote_subscription(
                     true,
                     Some(30),
                     IncomingReq::SubKeepalive(remote_sub_id),
-                    &send_to_loop,
+                    send_to_loop,
                 ).await;
             }
             _incoming = net_error_rx.recv() => {
@@ -487,6 +487,23 @@ async fn maintain_remote_subscription(
             }
         }
     };
+    // tell provider node we don't need their services anymore
+    // (in case they did not close the subscription on their side,
+    // such as in the 2-hour timeout case)
+    kernel_message(
+        our,
+        rand::random(),
+        Address {
+            node: provider_node.to_string(),
+            process: ETH_PROCESS_ID.clone(),
+        },
+        None,
+        true,
+        None,
+        EthAction::UnsubscribeLogs(sub_id),
+        send_to_loop,
+    )
+    .await;
     active_subscriptions
         .entry(target.clone())
         .and_modify(|sub_map| {

--- a/kinode/src/eth/subscription.rs
+++ b/kinode/src/eth/subscription.rs
@@ -500,7 +500,7 @@ async fn maintain_remote_subscription(
         None,
         true,
         None,
-        EthAction::UnsubscribeLogs(sub_id),
+        EthAction::UnsubscribeLogs(remote_sub_id),
         send_to_loop,
     )
     .await;


### PR DESCRIPTION
## Problem

Eth provider works well for client, but provider still gets bloat of many stale subscriptions

## Solution

On client side, manually unsubscribe any time a subscription is dropped.

## Testing

Run a provider and a client for a few days


