### PR TITLE
keyfile: encode/decode as JSON for better cross-lang support, keep bincode as backup

### DIFF
--- a/kinode/src/register.rs
+++ b/kinode/src/register.rs
@@ -124,15 +124,24 @@ pub async fn register(
         .or(warp::path("our").and(warp::get()).and(keyfile.clone()).map(
             move |keyfile: Option<Vec<u8>>| {
                 if let Some(keyfile) = keyfile {
-                    if let Ok((username, _, _, _, _, _)) = bincode::deserialize::<(
+                    if let Ok((username, _, _, _, _, _)) = serde_json::from_slice::<(
                         String,
                         Vec<String>,
                         Vec<u8>,
                         Vec<u8>,
                         Vec<u8>,
                         Vec<u8>,
-                    )>(keyfile.as_ref())
-                    {
+                    )>(&keyfile)
+                    .or_else(|_| {
+                        bincode::deserialize::<(
+                            String,
+                            Vec<String>,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                            Vec<u8>,
+                        )>(&keyfile)
+                    }) {
                         return warp::reply::html(username);
                     }
                 }


### PR DESCRIPTION
## Problem

In the future, people will use other frontends or programs to generate keyfiles to boot a kinode. We can imagine this very easily for non-`.os` usernames. Using bincode as the keyfile ser/de format will limit those other programs to be written in Rust -- switching to JSON allows programs in other langauges to much more easily generate valid keyfiles.

## Solution

Switch encoding to `serde_json` and decoding to first try `serde_json`, then try `bincode` (for backwards compatibility) if that fails.

## Testing

1. Boot an old node (pre-this-PR) without issue
2. Import an old keyfile without issue
3. Boot a new node, generate a new keyfile
4. Import that keyfile without issue

## Docs Update

N/A

