### PR TITLE
register: support custom TLZs (hackily)

### DIFF
--- a/kinode/src/register-ui/src/App.tsx
+++ b/kinode/src/register-ui/src/App.tsx
@@ -3,6 +3,7 @@ import { Navigate, BrowserRouter as Router, Route, Routes, useParams } from 'rea
 
 import CommitDotOsName from "./pages/CommitDotOsName";
 import MintDotOsName from "./pages/MintDotOsName";
+import MintCustom from "./pages/MintCustom";
 import SetPassword from "./pages/SetPassword";
 import Login from './pages/Login'
 import ResetDotOsName from './pages/ResetDotOsName'
@@ -19,7 +20,7 @@ function App() {
   const [keyFileName, setKeyFileName] = useState<string>('');
   const [reset, setReset] = useState<boolean>(false);
   const [direct, setDirect] = useState<boolean>(false);
-  const [knsName, setOsName] = useState<string>('');
+  const [knsName, setKnsName] = useState<string>('');
   const [appSizeOnLoad, setAppSizeOnLoad] = useState<number>(0);
   const [networkingKey, setNetworkingKey] = useState<string>('');
   const [ipAddress, setIpAddress] = useState<number>(0);
@@ -50,7 +51,7 @@ function App() {
           const info: UnencryptedIdentity = await infoResponse.json()
 
           if (initialVisit) {
-            setOsName(info.name)
+            setKnsName(info.name)
             setRouters(info.allowed_routers)
             setNavigateToLogin(true)
             setInitialVisit(false)
@@ -87,7 +88,7 @@ function App() {
     keyFileName, setKeyFileName,
     reset, setReset,
     pw, setPw,
-    knsName, setOsName,
+    knsName, setKnsName,
     connectOpen, openConnect, closeConnect,
     networkingKey, setNetworkingKey,
     ipAddress, setIpAddress,
@@ -114,6 +115,7 @@ function App() {
               <Route path="/reset" element={<ResetDotOsName {...props} />} />
               <Route path="/import-keyfile" element={<ImportKeyfile {...props} />} />
               <Route path="/login" element={<Login {...props} />} />
+              <Route path="/custom-register" element={<MintCustom {...props} />} />
             </Routes>
           </main>
         </Router>

--- a/kinode/src/register-ui/src/abis/index.ts
+++ b/kinode/src/register-ui/src/abis/index.ts
@@ -24,28 +24,11 @@ export const mechAbi = parseAbi([
     "function token() external view returns (uint256,address,uint256)"
 ])
 
-export const dotOsAbi = [
-    {
-        type: 'function',
-        name: 'commit',
-        stateMutability: 'nonpayable',
-        inputs: [
-            { name: '_commit', type: 'bytes32' },
-        ],
-        outputs: [],
-    },
-    {
-        type: 'function',
-        name: 'mint',
-        stateMutability: 'nonpayable',
-        inputs: [
-            { name: 'who', type: 'address' },
-            { name: 'name', type: 'bytes' },
-            { name: 'initialization', type: 'bytes' },
-            { name: 'erc721Data', type: 'bytes' },
-            { name: 'implementation', type: 'address' },
-            { name: 'secret', type: 'bytes32' },
-        ],
-        outputs: [{ type: 'address' }],
-    },
-] as const
+export const dotOsAbi = parseAbi([
+    "function commit(bytes32 _commit) external",
+    "function mint(address who, bytes calldata name, bytes calldata initialization, bytes calldata erc721Data, address implementation, bytes32 secret) external returns (address)"
+]);
+
+export const customAbi = parseAbi([
+    "function mint(address who, bytes calldata name, bytes calldata initialization, bytes calldata erc721Data, address implementation) external returns (address)"
+]);

--- a/kinode/src/register-ui/src/lib/types.ts
+++ b/kinode/src/register-ui/src/lib/types.ts
@@ -13,7 +13,7 @@ export interface PageProps {
   direct: boolean,
   setDirect: React.Dispatch<React.SetStateAction<boolean>>,
   knsName: string,
-  setOsName: React.Dispatch<React.SetStateAction<string>>,
+  setKnsName: React.Dispatch<React.SetStateAction<string>>,
   key: string,
   keyFileName: string,
   setKeyFileName: React.Dispatch<React.SetStateAction<string>>,

--- a/kinode/src/register-ui/src/pages/CommitDotOsName.tsx
+++ b/kinode/src/register-ui/src/pages/CommitDotOsName.tsx
@@ -17,7 +17,7 @@ interface RegisterOsNameProps extends PageProps { }
 function CommitDotOsName({
     direct,
     setDirect,
-    setOsName,
+    setKnsName,
     setNetworkingKey,
     setIpAddress,
     setWsPort,
@@ -80,10 +80,10 @@ function CommitDotOsName({
 
     useEffect(() => {
         if (isConfirmed) {
-            setOsName(`${name}.os`);
+            setKnsName(`${name}.os`);
             navigate("/mint-os-name");
         }
-    }, [isConfirmed, address, name, setOsName, navigate]);
+    }, [isConfirmed, address, name, setKnsName, navigate]);
 
     return (
         <div className="container fade-in">

--- a/kinode/src/register-ui/src/pages/KinodeHome.tsx
+++ b/kinode/src/register-ui/src/pages/KinodeHome.tsx
@@ -12,7 +12,7 @@ function KinodeHome({ knsName }: OsHomeProps) {
     const resetRedir = () => navigate('/reset')
     const importKeyfileRedir = () => navigate('/import-keyfile')
     const loginRedir = () => navigate('/login')
-
+    const customRegisterRedir = () => navigate('/custom-register')
     const previouslyBooted = Boolean(knsName)
 
     useEffect(() => {
@@ -35,7 +35,7 @@ function KinodeHome({ knsName }: OsHomeProps) {
                                 <h4 className="text-center mb-2">New here? Register a username to get started</h4>
                                 <div className="button-group">
                                     <button onClick={registerRedir} className="button">
-                                        Register Kinode Name
+                                        Register .os Name
                                     </button>
                                 </div>
                                 <h4 className="text-center mt-2 mb-2">Other options</h4>
@@ -45,6 +45,9 @@ function KinodeHome({ knsName }: OsHomeProps) {
                                     </button>
                                     <button onClick={importKeyfileRedir} className="button secondary">
                                         Import Keyfile
+                                    </button>
+                                    <button onClick={customRegisterRedir} className="button secondary">
+                                        Register non-.os Name (Advanced)
                                     </button>
                                 </div>
                             </>

--- a/kinode/src/register-ui/src/pages/Login.tsx
+++ b/kinode/src/register-ui/src/pages/Login.tsx
@@ -13,7 +13,7 @@ function Login({
   routers,
   setRouters,
   knsName,
-  setOsName,
+  setKnsName,
 }: LoginProps) {
   const navigate = useNavigate();
 
@@ -29,7 +29,7 @@ function Login({
           res.json()
         )) as UnencryptedIdentity;
         setRouters(infoData.allowed_routers);
-        setOsName(infoData.name);
+        setKnsName(infoData.name);
       } catch { }
     })();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/kinode/src/register-ui/src/pages/MintCustom.tsx
+++ b/kinode/src/register-ui/src/pages/MintCustom.tsx
@@ -1,0 +1,145 @@
+import { useState, useEffect, FormEvent, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import Loader from "../components/Loader";
+import { PageProps } from "../lib/types";
+
+import DirectCheckbox from "../components/DirectCheckbox";
+
+import { useAccount, useWaitForTransactionReceipt, useSendTransaction } from "wagmi";
+import { useConnectModal, useAddRecentTransaction } from "@rainbow-me/rainbowkit"
+import { customAbi, generateNetworkingKeys, KINO_ACCOUNT_IMPL } from "../abis";
+import { encodePacked, encodeFunctionData, stringToHex } from "viem";
+
+interface MintCustomNameProps extends PageProps { }
+
+function MintCustom({
+    direct,
+    setDirect,
+    knsName,
+    setKnsName,
+    setNetworkingKey,
+    setIpAddress,
+    setWsPort,
+    setTcpPort,
+    setRouters,
+}: MintCustomNameProps) {
+    let { address } = useAccount();
+    let navigate = useNavigate();
+    let { openConnectModal } = useConnectModal();
+
+    const { data: hash, sendTransaction, isPending, isError, error } = useSendTransaction({
+        mutation: {
+            onSuccess: (data) => {
+                addRecentTransaction({ hash: data, description: `Mint ${knsName}` });
+            }
+        }
+    });
+    const { isLoading: isConfirming, isSuccess: isConfirmed } =
+        useWaitForTransactionReceipt({
+            hash,
+        });
+    const addRecentTransaction = useAddRecentTransaction();
+
+    const [triggerNameCheck, setTriggerNameCheck] = useState<boolean>(false)
+
+    useEffect(() => {
+        document.title = "Mint"
+    }, [])
+
+    useEffect(() => setTriggerNameCheck(!triggerNameCheck), [address])
+
+    let handleMint = useCallback(async (e: FormEvent) => {
+        e.preventDefault()
+        e.stopPropagation()
+
+        const formData = new FormData(e.target as HTMLFormElement)
+
+        if (!address) {
+            openConnectModal?.()
+            return
+        }
+
+        const initCall = await generateNetworkingKeys({
+            direct,
+            our_address: address,
+            label: knsName,
+            setNetworkingKey,
+            setIpAddress,
+            setWsPort,
+            setTcpPort,
+            setRouters,
+            reset: false,
+        });
+
+        setKnsName(formData.get('full-kns-name') as string)
+
+        const name = formData.get('name') as string
+
+        console.log("full kns name", formData.get('full-kns-name'))
+        console.log("name", name)
+
+        const data = encodeFunctionData({
+            abi: customAbi,
+            functionName: 'mint',
+            args: [
+                address,
+                encodePacked(["bytes"], [stringToHex(name)]),
+                initCall,
+                "0x",
+                KINO_ACCOUNT_IMPL,
+            ],
+        })
+
+        // use data to write to contract -- do NOT use writeContract
+        // writeContract will NOT generate the correct selector for some reason
+        // probably THEIR bug.. no abi works
+        try {
+            sendTransaction({
+                to: formData.get('tba') as `0x${string}`,
+                data: data,
+                gas: 1000000n,
+            })
+        } catch (error) {
+            console.error('Failed to send transaction:', error)
+        }
+    }, [direct, address, sendTransaction, setNetworkingKey, setIpAddress, setWsPort, setTcpPort, setRouters, openConnectModal])
+
+    useEffect(() => {
+        if (isConfirmed) {
+            navigate("/set-password");
+        }
+    }, [isConfirmed, address, navigate]);
+
+    return (
+        <div className="container fade-in">
+            <div className="section">
+                {Boolean(address) && (
+                    <form className="form" onSubmit={handleMint}>
+                        {isPending || isConfirming ? (
+                            <Loader msg={isConfirming ? 'Minting name...' : 'Please confirm the transaction in your wallet'} />
+                        ) : (
+                            <>
+                                <input type="text" name="name" placeholder="Enter kimap name" />
+                                <input type="text" name="full-kns-name" placeholder="Enter full KNS name" />
+                                <input type="text" name="tba" placeholder="Enter TBA to mint under" />
+                                <DirectCheckbox {...{ direct, setDirect }} />
+                                <div className="button-group">
+                                    <button type="submit" className="button">
+                                        Mint custom name
+                                    </button>
+                                </div>
+                            </>
+                        )}
+                        {isError && (
+                            <p className="error-message">
+                                Error: {error?.message || 'There was an error minting your name, please try again.'}
+                            </p>
+                        )}
+                    </form>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default MintCustom;

--- a/kinode/src/register-ui/src/pages/ResetDotOsName.tsx
+++ b/kinode/src/register-ui/src/pages/ResetDotOsName.tsx
@@ -28,7 +28,7 @@ function ResetKnsName({
   setDirect,
   setReset,
   knsName,
-  setOsName,
+  setKnsName,
   setNetworkingKey,
   setIpAddress,
   setWsPort,
@@ -135,7 +135,7 @@ function ResetKnsName({
           if (index === -1) vets.push(NAME_NOT_REGISTERED);
         }
 
-        if (nameVets.length === 0) setOsName(normalized);
+        if (nameVets.length === 0) setKnsName(normalized);
       }
 
       setNameVets(vets);

--- a/kinode/src/register-ui/src/pages/SetPassword.tsx
+++ b/kinode/src/register-ui/src/pages/SetPassword.tsx
@@ -111,7 +111,6 @@ function SetPassword({
               res.status < 300 &&
               Number(res.headers.get("content-length")) !== appSizeOnLoad
             ) {
-              console.log("WE GOOD, ROUTING")
               clearInterval(interval);
               window.location.replace("/");
             }

--- a/kinode/src/register.rs
+++ b/kinode/src/register.rs
@@ -105,6 +105,7 @@ pub async fn register(
         .or(warp::path("reset"))
         .or(warp::path("import-keyfile"))
         .or(warp::path("set-password"))
+        .or(warp::path("custom-register"))
         .and(warp::get())
         .map(move |_| warp::reply::html(include_str!("register-ui/build/index.html")));
 


### PR DESCRIPTION
## Problem

We now have more than just `.os` to register names beneath.

## Solution

Add a custom mint page that lets users manually mint node identities in kimap.

## Testing

1. on boot, "register non-.os name (advanced)"
2. find TBA contract address, calculate full name manually
3. register, boot, test

## Notes

This is super bad UX and should be improved with a better way to mint arbitrary entries 
