### PR TITLE
fix import keyfile!

### DIFF
--- a/kinode/src/register-ui/src/pages/ImportKeyfile.tsx
+++ b/kinode/src/register-ui/src/pages/ImportKeyfile.tsx
@@ -62,7 +62,7 @@ function ImportKeyfile({
             credentials: 'include',
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-              keyfile: Buffer.from(localKey).toString('base64'),
+              keyfile: Buffer.from(localKey).toString('utf8'),
               password_hash: hashed_password,
             }),
           });

--- a/kinode/src/register.rs
+++ b/kinode/src/register.rs
@@ -443,6 +443,7 @@ async fn handle_import_keyfile(
     sender: Arc<RegistrationSender>,
     provider: Arc<RootProvider<PubSubFrontend>>,
 ) -> Result<impl Reply, Rejection> {
+    println!("received base64 keyfile: {}\r", info.keyfile);
     // if keyfile was not present in node and is present from user upload
     let encoded_keyfile = match base64_standard.decode(info.keyfile) {
         Ok(k) => k,
@@ -455,6 +456,10 @@ async fn handle_import_keyfile(
         }
     };
 
+    println!(
+        "received keyfile: {}\r",
+        String::from_utf8_lossy(&encoded_keyfile)
+    );
     let (decoded_keyfile, mut our) =
         match keygen::decode_keyfile(&encoded_keyfile, &info.password_hash) {
             Ok(k) => {


### PR DESCRIPTION
## Problem

Keyfile import was broken!

## Solution

Don't double-encode as base64!

## Testing

```
1. Boot node
2. Save keyfile
3. Boot again by importing that keyfile
```

## Docs Update

N/A

## Notes

Note that .keyfile format is base64, but .keys is simply a JSON-string.
