### PR TITLE
build script output reruns skip UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ rustup target add wasm32-wasi
 rustup target add wasm32-wasi --toolchain nightly
 cargo install cargo-wasi
 
+# Install NPM so we can build frontends for "distro" packages.
+# https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+# If you want to skip this step, run cargo build with the environment variable SKIP_BUILD_FRONTEND=true
+
 # Build the runtime, along with a number of "distro" Wasm modules.
 # The compiled binary will be at `kinode/target/debug/kinode`
 # OPTIONAL: --release flag (slower build; faster runtime; binary at `kinode/target/release/kinode`)


### PR DESCRIPTION
## Problem

Build.rs still wonky, see #480

## Solution

Attempt to both make build script maximally sensitive to updates while skipping rebuild if only build-outputs have changed since last build. Seems to fix #480 

## Testing

build runtime,
change elements,
use SKIP_BUILD_FRONTEND flag,
etc

## Docs Update

N/A

## Notes

Let's test this on all the platforms we develop on frequently
