### PR TITLE
app_store: auto_update

### DIFF
--- a/kinode/packages/app_store/api/app_store:sys-v0.wit
+++ b/kinode/packages/app_store/api/app_store:sys-v0.wit
@@ -4,6 +4,7 @@ interface downloads {
     //
 
     use standard.{package-id};
+    use chain.{onchain-metadata};
 
     variant download-requests {
         // remote only
@@ -13,6 +14,7 @@ interface downloads {
         size(size-update),
         // local only
         local-download(local-download-request),
+        auto-update(auto-update-request),
         download-complete(download-complete-request),
         get-files(option<package-id>),
         remove-file(remove-file-request),
@@ -31,6 +33,11 @@ interface downloads {
         package-id: package-id,
         download-from: string,
         desired-version-hash: string,
+    }
+
+    record auto-update-request {
+        package-id: package-id,
+        metadata: onchain-metadata,
     }
 
     record remote-download-request {

--- a/kinode/packages/app_store/app_store/src/http_api.rs
+++ b/kinode/packages/app_store/app_store/src/http_api.rs
@@ -245,7 +245,6 @@ fn gen_package_info(id: &PackageId, state: &PackageState) -> serde_json::Value {
         "our_version_hash": state.our_version_hash,
         "verified": state.verified,
         "caps_approved": state.caps_approved,
-        "manifest_hash": state.manifest_hash,
     })
 }
 

--- a/kinode/packages/app_store/app_store/src/state.rs
+++ b/kinode/packages/app_store/app_store/src/state.rs
@@ -50,10 +50,10 @@ pub struct PackageState {
     pub our_version_hash: String,
     pub verified: bool,
     pub caps_approved: bool,
-    /// the hash of the manifest file, which is used to determine whether package
+    /// the hash of the request_capabilites field of every process, which is used to determine whether package
     /// capabilities have changed. if they have changed, auto-install must fail
     /// and the user must approve the new capabilities.
-    pub manifest_hash: Option<String>,
+    pub caps_hashes: HashMap<String, String>,
 }
 
 /// this process's saved state
@@ -62,7 +62,6 @@ pub struct State {
     pub packages: HashMap<PackageId, PackageState>,
     /// the APIs we have
     pub installed_apis: HashSet<PackageId>,
-    // requested maybe too.
 }
 
 impl State {
@@ -115,6 +114,7 @@ impl State {
                 timeout: 5,
             };
             let manifest_bytes = manifest_file.read()?;
+            let caps_hashes = utils::extract_caps_hashes(&manifest_bytes)?;
 
             self.packages.insert(
                 package_id.clone(),
@@ -122,7 +122,7 @@ impl State {
                     our_version_hash,
                     verified: true,       // implicitly verified (TODO re-evaluate)
                     caps_approved: false, // must re-approve if you want to do something ??
-                    manifest_hash: Some(utils::keccak_256_hash(&manifest_bytes)),
+                    caps_hashes,
                 },
             );
 

--- a/kinode/packages/app_store/app_store/src/state.rs
+++ b/kinode/packages/app_store/app_store/src/state.rs
@@ -50,10 +50,10 @@ pub struct PackageState {
     pub our_version_hash: String,
     pub verified: bool,
     pub caps_approved: bool,
-    /// the hash of the request_capabilites field of every process, which is used to determine whether package
+    /// the hash of the manifest, which is used to determine whether package
     /// capabilities have changed. if they have changed, auto-install must fail
     /// and the user must approve the new capabilities.
-    pub caps_hashes: HashMap<String, String>,
+    pub manifest_hash: Option<String>,
 }
 
 /// this process's saved state
@@ -114,15 +114,14 @@ impl State {
                 timeout: 5,
             };
             let manifest_bytes = manifest_file.read()?;
-            let caps_hashes = utils::extract_caps_hashes(&manifest_bytes)?;
-
+            let manifest_hash = utils::keccak_256_hash(&manifest_bytes);
             self.packages.insert(
                 package_id.clone(),
                 PackageState {
                     our_version_hash,
                     verified: true,       // implicitly verified (TODO re-evaluate)
                     caps_approved: false, // must re-approve if you want to do something ??
-                    caps_hashes,
+                    manifest_hash: Some(manifest_hash),
                 },
             );
 

--- a/kinode/packages/app_store/downloads/src/lib.rs
+++ b/kinode/packages/app_store/downloads/src/lib.rs
@@ -3,18 +3,23 @@
 //! manages downloading and sharing of versioned packages.
 //!
 use crate::kinode::process::downloads::{
-    DirEntry, DownloadCompleteRequest, DownloadError, DownloadRequests, DownloadResponses, Entry,
-    FileEntry, HashMismatch, LocalDownloadRequest, RemoteDownloadRequest, RemoveFileRequest,
+    AutoUpdateRequest, DirEntry, DownloadCompleteRequest, DownloadError, DownloadRequests,
+    DownloadResponses, Entry, FileEntry, HashMismatch, LocalDownloadRequest, RemoteDownloadRequest,
+    RemoveFileRequest,
 };
-use std::{collections::HashSet, io::Read, str::FromStr};
+use std::{
+    collections::{HashMap, HashSet},
+    io::Read,
+    str::FromStr,
+};
 
 use ft_worker_lib::{spawn_receive_transfer, spawn_send_transfer};
 use kinode_process_lib::{
     await_message, call_init, get_blob, get_state,
     http::client,
-    print_to_terminal, println, set_state,
+    kernel_types as kt, print_to_terminal, println, set_state,
     vfs::{self, Directory, File},
-    Address, Message, PackageId, Request, Response,
+    Address, Message, PackageId, ProcessId, Request, Response,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -40,7 +45,9 @@ pub enum Resp {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct State {
+    // persisted metadata about which packages we are mirroring
     mirroring: HashSet<PackageId>,
+    // note, pending auto_updates are not persisted.
 }
 
 impl State {
@@ -74,14 +81,22 @@ fn init(our: Address) {
         open_or_create_dir("/app_store:sys/downloads").expect("could not open downloads");
     let mut tmp = open_or_create_dir("/app_store:sys/downloads/tmp").expect("could not open tmp");
 
+    let mut auto_updates: HashSet<(PackageId, String)> = HashSet::new();
+
     loop {
         match await_message() {
             Err(send_error) => {
                 print_to_terminal(1, &format!("got network error: {send_error}"));
             }
             Ok(message) => {
-                if let Err(e) = handle_message(&our, &mut state, &message, &mut downloads, &mut tmp)
-                {
+                if let Err(e) = handle_message(
+                    &our,
+                    &mut state,
+                    &message,
+                    &mut downloads,
+                    &mut tmp,
+                    &mut auto_updates,
+                ) {
                     print_to_terminal(1, &format!("error handling message: {:?}", e));
                 }
             }
@@ -99,6 +114,7 @@ fn handle_message(
     message: &Message,
     downloads: &mut Directory,
     tmp: &mut Directory,
+    auto_updates: &mut HashSet<(PackageId, String)>,
 ) -> anyhow::Result<()> {
     if message.is_request() {
         match serde_json::from_slice::<DownloadRequests>(message.body())? {
@@ -153,7 +169,6 @@ fn handle_message(
                         },
                     ))?)
                     .send()?;
-                // ok, now technically everything is ze ready. let's see what awaits and updates we send upstream/to the frontend.
             }
             DownloadRequests::RemoteDownload(download_request) => {
                 // this is a node requesting a download from us.
@@ -183,17 +198,47 @@ fn handle_message(
                     .send();
             }
             DownloadRequests::DownloadComplete(req) => {
-                // forward to main:app_store:sys
+                if !message.is_local(our) {
+                    return Err(anyhow::anyhow!("got non local download complete"));
+                }
+                // if we have a pending auto_install, forward that context to the main process.
+                // it will check if the caps_hashes match (no change in capabilities), and auto_install if it does.
+
+                let context = if auto_updates.remove(&(
+                    req.package_id.clone().to_process_lib(),
+                    req.version_hash.clone(),
+                )) {
+                    match get_caps_hashes(
+                        req.package_id.clone().to_process_lib(),
+                        req.version_hash.clone(),
+                    ) {
+                        Ok(caps_hashes) => Some(serde_json::to_vec(&caps_hashes)?),
+                        Err(e) => {
+                            print_to_terminal(
+                                1,
+                                &format!("auto_update: error getting caps hashes: {:?}", e),
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
                 // pushed to UI via websockets
-                let _ = Request::to(("our", "main", "app_store", "sys"))
-                    .body(serde_json::to_vec(&req)?)
-                    .send();
+                let mut request = Request::to(("our", "main", "app_store", "sys"))
+                    .body(serde_json::to_vec(&req)?);
+
+                if let Some(ctx) = context {
+                    request = request.context(ctx);
+                }
+                request.send()?;
             }
             DownloadRequests::GetFiles(maybe_id) => {
                 // if not local, throw to the boonies.
                 // note, can also implement a discovery protocol here in the future
                 if !message.is_local(our) {
-                    return Err(anyhow::anyhow!("not local"));
+                    return Err(anyhow::anyhow!("got non local get_files"));
                 }
                 let files = match maybe_id {
                     Some(id) => {
@@ -293,16 +338,56 @@ fn handle_message(
                     ))?)
                     .send()?;
             }
+            DownloadRequests::AutoUpdate(auto_update_request) => {
+                if !message.is_local(&our)
+                    && message.source().process != ProcessId::new(Some("chain"), "app_store", "sys")
+                {
+                    return Err(anyhow::anyhow!(
+                        "got auto-update from non local chain source"
+                    ));
+                }
+
+                let AutoUpdateRequest {
+                    package_id,
+                    metadata,
+                } = auto_update_request.clone();
+                let process_lib_package_id = package_id.clone().to_process_lib();
+
+                // default auto_update to publisher. TODO: more config here.
+                let download_from = metadata.properties.publisher;
+                let current_version = metadata.properties.current_version;
+                let code_hashes = metadata.properties.code_hashes;
+
+                let version_hash = code_hashes
+                    .iter()
+                    .find(|(version, _)| version == &current_version)
+                    .map(|(_, hash)| hash.clone())
+                    .ok_or_else(|| anyhow::anyhow!("auto_update: error for package_id: {}, current_version: {}, no matching hash found", process_lib_package_id.to_string(), current_version))?;
+
+                let download_request = LocalDownloadRequest {
+                    package_id,
+                    download_from,
+                    desired_version_hash: version_hash.clone(),
+                };
+
+                // kick off local download to ourselves.
+                Request::to(("our", "downloads", "app_store", "sys"))
+                    .body(serde_json::to_vec(&DownloadRequests::LocalDownload(
+                        download_request,
+                    ))?)
+                    .send()?;
+
+                auto_updates.insert((process_lib_package_id, version_hash));
+            }
             _ => {}
         }
     } else {
         match serde_json::from_slice::<Resp>(message.body())? {
             Resp::Download(download_response) => {
-                // TODO handle download response
-                // maybe push to http? need await for that...
+                // these are handled in line.
                 print_to_terminal(
                     1,
-                    &format!("got download response: {:?}", download_response),
+                    &format!("got a weird download response: {:?}", download_response),
                 );
             }
             Resp::HttpClient(resp) => {
@@ -449,6 +534,26 @@ fn extract_and_write_manifest(file_contents: &[u8], manifest_path: &str) -> anyh
     Ok(())
 }
 
+fn get_caps_hashes(
+    package_id: PackageId,
+    version_hash: String,
+) -> anyhow::Result<HashMap<String, String>> {
+    let package_dir = format!("{}/{}", "/app_store:sys/downloads", package_id.to_string());
+    let manifest_path = format!("{}/{}.json", package_dir, version_hash);
+    let manifest_file = vfs::open_file(&manifest_path, false, None)?;
+
+    let manifest_bytes = manifest_file.read()?;
+    let manifest = serde_json::from_slice::<Vec<kt::PackageManifestEntry>>(&manifest_bytes)?;
+    let mut caps_hashes = HashMap::new();
+
+    for process in &manifest {
+        let caps_bytes = serde_json::to_vec(&process.request_capabilities)?;
+        let caps_hash = keccak_256_hash(&caps_bytes);
+        caps_hashes.insert(process.process_name.clone(), caps_hash);
+    }
+    Ok(caps_hashes)
+}
+
 /// helper function for vfs files, open if exists, if not create
 fn open_or_create_file(path: &str) -> anyhow::Result<File> {
     match vfs::open_file(path, false, None) {
@@ -462,13 +567,21 @@ fn open_or_create_file(path: &str) -> anyhow::Result<File> {
 
 /// helper function for vfs directories, open if exists, if not create
 fn open_or_create_dir(path: &str) -> anyhow::Result<Directory> {
-    match vfs::open_dir(path, false, None) {
+    match vfs::open_dir(path, true, None) {
         Ok(dir) => Ok(dir),
-        Err(_) => match vfs::open_dir(path, true, None) {
+        Err(_) => match vfs::open_dir(path, false, None) {
             Ok(dir) => Ok(dir),
-            Err(_) => Err(anyhow::anyhow!("could not create file")),
+            Err(_) => Err(anyhow::anyhow!("could not create dir")),
         },
     }
+}
+
+/// generate a Keccak-256 hash string (with 0x prefix) of the metadata bytes
+pub fn keccak_256_hash(bytes: &[u8]) -> String {
+    use sha3::{Digest, Keccak256};
+    let mut hasher = Keccak256::new();
+    hasher.update(bytes);
+    format!("0x{:x}", hasher.finalize())
 }
 
 // quite annoyingly, we must convert from our gen'd version of PackageId

--- a/kinode/packages/app_store/ft_worker/src/lib.rs
+++ b/kinode/packages/app_store/ft_worker/src/lib.rs
@@ -163,8 +163,10 @@ fn handle_receiver(
                             print_to_terminal(
                                 1,
                                 &format!(
-                                    "ft_worker: hash mismatch: {} != {}",
-                                    version_hash, recieved_hash
+                                    "ft_worker: {} hash mismatch: desired: {} != actual: {}",
+                                    package_id.to_string(),
+                                    version_hash,
+                                    recieved_hash
                                 ),
                             );
                             let req = DownloadCompleteRequest {
@@ -290,7 +292,7 @@ fn extract_and_write_manifest(file_contents: &[u8], manifest_path: &str) -> anyh
             let manifest_file = open_or_create_file(&manifest_path)?;
             manifest_file.write(contents.as_bytes())?;
 
-            println!("Extracted and wrote manifest.json");
+            print_to_terminal(1, "Extracted and wrote manifest.json");
             break;
         }
     }

--- a/kinode/packages/app_store/ui/src/pages/MyDownloadsPage.tsx
+++ b/kinode/packages/app_store/ui/src/pages/MyDownloadsPage.tsx
@@ -79,8 +79,15 @@ export default function MyDownloadsPage() {
         setIsInstalling(true);
         setError(null);
         try {
-            const packageId = [...currentPath, selectedItem.File.name.replace('.zip', '')].join(':');
-            const versionHash = selectedItem.File.name.replace('.zip', '');
+            const fileName = selectedItem.File.name;
+            const parts = fileName.split(':');
+            const versionHash = parts.pop()?.replace('.zip', '');
+
+            if (!versionHash) throw new Error('Invalid file name format');
+
+            // Construct packageId by combining currentPath and remaining parts of the filename
+            const packageId = [...currentPath, ...parts].join(':');
+
             await installApp(packageId, versionHash);
             await fetchInstalled();
             setShowCapApproval(false);

--- a/kinode/packages/app_store/ui/src/types/Apps.ts
+++ b/kinode/packages/app_store/ui/src/types/Apps.ts
@@ -59,7 +59,6 @@ export interface PackageState {
     our_version_hash: string;
     verified: boolean;
     caps_approved: boolean;
-    manifest_hash?: string;
 }
 
 export interface PackageManifest {


### PR DESCRIPTION
## Problem

Our previous app_store implementations didn't have full auto_update functionality.

## Solution

When chain:app_store:sys hears of a new valid package, it checks whether the user has enabled auto_update for it (stored in its state), and forwards an AutoUpdateRequest to the downloads process with metadata and package_id. 

Downloads (currently) defaults to downloading from the publisher_id, fetches current_version code_hash from metadata. Spawns a download.

Once finished, is forwarded to main process with the new manifest_hash in the context of a DownloadCompleteRequest. main checks if the hash is the same as the currently installed package, then installs. 

## Notes

chain:app_store:sys doesn't currently Persist anything (with current log sizes, we can afford to fetch anew every boot), but we can change this.

This also means that auto_update info is not persisted either, which can be a slight curveball right now.