### PR TITLE
app_store: retry once on rpc error

### DIFF
--- a/kinode/packages/app_store/app_store/src/http_api.rs
+++ b/kinode/packages/app_store/app_store/src/http_api.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use kinode_process_lib::{
     http::{self, server, Method, StatusCode},
-    println, Address, LazyLoadBlob, PackageId, Request,
+    Address, LazyLoadBlob, PackageId, Request,
 };
 use kinode_process_lib::{SendError, SendErrorKind};
 use serde_json::json;
@@ -224,13 +224,6 @@ fn get_package_id(url_params: &HashMap<String, String>) -> anyhow::Result<Packag
 
     let id = package_id.parse::<PackageId>()?;
     Ok(id)
-}
-
-fn get_version_hash(url_params: &HashMap<String, String>) -> anyhow::Result<String> {
-    let Some(version_hash) = url_params.get("version_hash") else {
-        return Err(anyhow::anyhow!("Missing version_hash"));
-    };
-    Ok(version_hash.to_string())
 }
 
 fn gen_package_info(id: &PackageId, state: &PackageState) -> serde_json::Value {

--- a/kinode/packages/app_store/app_store/src/state.rs
+++ b/kinode/packages/app_store/app_store/src/state.rs
@@ -1,5 +1,5 @@
 use crate::{utils, VFS_TIMEOUT};
-use kinode_process_lib::{kimap, println, vfs, PackageId};
+use kinode_process_lib::{kimap, vfs, PackageId};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 

--- a/kinode/packages/app_store/app_store/src/utils.rs
+++ b/kinode/packages/app_store/app_store/src/utils.rs
@@ -11,10 +11,7 @@ use {
         get_blob, kernel_types as kt, println, vfs, Address, LazyLoadBlob, PackageId, ProcessId,
         Request,
     },
-    std::{
-        collections::{HashMap, HashSet},
-        str::FromStr,
-    },
+    std::collections::{HashMap, HashSet},
 };
 
 // quite annoyingly, we must convert from our gen'd version of PackageId

--- a/kinode/packages/app_store/chain/src/lib.rs
+++ b/kinode/packages/app_store/chain/src/lib.rs
@@ -253,7 +253,6 @@ fn handle_eth_log(our: &Address, state: &mut State, log: eth::Log) -> anyhow::Re
     // the app store exclusively looks for ~metadata-uri postings: if one is
     // observed, we then *query* for ~metadata-hash to verify the content
     // at the URI.
-    //
 
     let metadata_uri = String::from_utf8_lossy(&note.data).to_string();
     let is_our_package = &package_id.publisher() == &our.node();
@@ -263,7 +262,21 @@ fn handle_eth_log(our: &Address, state: &mut State, log: eth::Log) -> anyhow::Re
         let hash_note = format!("~metadata-hash.{}", note.parent_path);
 
         // owner can change which we don't track (yet?) so don't save, need to get when desired
-        let (tba, _owner, data) = state.kimap.get(&hash_note).map_err(|e| {
+        let (tba, _owner, data) = match state.kimap.get(&hash_note) {
+            Ok(gr) => Ok(gr),
+            Err(e) => match e {
+                eth::EthError::RpcError(_) => {
+                    // retry on RpcError after DELAY_MS sleep
+                    // sleep here rather than with, e.g., a message to
+                    //  `timer:distro:sys` so that events are processed in
+                    //  order of receipt
+                    std::thread::sleep(std::time::Duration::from_millis(DELAY_MS));
+                    state.kimap.get(&hash_note)
+                }
+                _ => Err(e),
+            },
+        }
+        .map_err(|e| {
             println!("Couldn't find {hash_note}: {e:?}");
             anyhow::anyhow!("metadata hash mismatch")
         })?;

--- a/kinode/packages/app_store/chain/src/lib.rs
+++ b/kinode/packages/app_store/chain/src/lib.rs
@@ -40,11 +40,6 @@ const KIMAP_ADDRESS: &'static str = kimap::KIMAP_ADDRESS; // optimism
 #[cfg(feature = "simulation-mode")]
 const KIMAP_ADDRESS: &str = "0xcA92476B2483aBD5D82AEBF0b56701Bb2e9be658";
 
-#[cfg(not(feature = "simulation-mode"))]
-const KIMAP_FIRST_BLOCK: u64 = kimap::KIMAP_FIRST_BLOCK;
-#[cfg(feature = "simulation-mode")]
-const KIMAP_FIRST_BLOCK: u64 = 1;
-
 const DELAY_MS: u64 = 1_000; // 1s
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/kinode/packages/app_store/download/src/lib.rs
+++ b/kinode/packages/app_store/download/src/lib.rs
@@ -62,7 +62,7 @@ fn init(our: Address) {
     };
 
     match response {
-        DownloadResponses::Error(e) => {
+        DownloadResponses::Error(_e) => {
             println!("download: error");
         }
         DownloadResponses::Success => {

--- a/kinode/packages/app_store/downloads/src/lib.rs
+++ b/kinode/packages/app_store/downloads/src/lib.rs
@@ -7,17 +7,13 @@ use crate::kinode::process::downloads::{
     DownloadResponses, Entry, FileEntry, HashMismatch, LocalDownloadRequest, RemoteDownloadRequest,
     RemoveFileRequest,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    io::Read,
-    str::FromStr,
-};
+use std::{collections::HashSet, io::Read, str::FromStr};
 
 use ft_worker_lib::{spawn_receive_transfer, spawn_send_transfer};
 use kinode_process_lib::{
     await_message, call_init, get_blob, get_state,
     http::client,
-    kernel_types as kt, print_to_terminal, println, set_state,
+    print_to_terminal, println, set_state,
     vfs::{self, Directory, File},
     Address, Message, PackageId, ProcessId, Request, Response,
 };
@@ -113,7 +109,7 @@ fn handle_message(
     state: &mut State,
     message: &Message,
     downloads: &mut Directory,
-    tmp: &mut Directory,
+    _tmp: &mut Directory,
     auto_updates: &mut HashSet<(PackageId, String)>,
 ) -> anyhow::Result<()> {
     if message.is_request() {


### PR DESCRIPTION
## Problem

Infura-backed nodes struggle to keep up with the rate of requests on boot: they get throttled, and so app_store state gets mangled.

## Solution

Sleep for 1s and retry on RpcError.