### PR TITLE
register: properly apply punycode conversion to submitted name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "kinode_lib"
-version = "0.9.2"
+version = "0.9.1"
 dependencies = [
  "lib",
 ]
@@ -3755,7 +3755,7 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "lib"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "alloy 0.2.1",
  "kit 0.6.8",

--- a/kinode/packages/app_store/app_store/src/utils.rs
+++ b/kinode/packages/app_store/app_store/src/utils.rs
@@ -114,11 +114,8 @@ pub fn new_package(
 
     let download_resp = serde_json::from_slice::<DownloadResponses>(&resp.body())?;
 
-    match download_resp {
-        DownloadResponses::Error(e) => {
-            return Err(anyhow::anyhow!("failed to add download: {:?}", e));
-        }
-        _ => {}
+    if let DownloadResponses::Error(e) = download_resp {
+        return Err(anyhow::anyhow!("failed to add download: {:?}", e));
     }
     Ok(())
 }

--- a/kinode/src/register-ui/src/components/EnterKnsName.tsx
+++ b/kinode/src/register-ui/src/components/EnterKnsName.tsx
@@ -47,12 +47,6 @@ function EnterKnsName({
       let validities: string[] = [];
       setIsPunyfied('');
 
-      const len = [...name].length;
-      index = validities.indexOf(NAME_LENGTH);
-      if (len < 9 && len !== 0) {
-        if (index === -1) validities.push(NAME_LENGTH);
-      } else if (index !== -1) validities.splice(index, 1);
-
       let normalized = ''
       index = validities.indexOf(NAME_INVALID_PUNY);
       try {
@@ -61,6 +55,12 @@ function EnterKnsName({
       } catch (e) {
         if (index === -1) validities.push(NAME_INVALID_PUNY);
       }
+
+      const len = [...normalized].length - 3;
+      index = validities.indexOf(NAME_LENGTH);
+      if (len < 9 && len !== 0) {
+        if (index === -1) validities.push(NAME_LENGTH);
+      } else if (index !== -1) validities.splice(index, 1);
 
       if (normalized !== (name + ".os")) setIsPunyfied(normalized);
 

--- a/kinode/src/register-ui/src/pages/CommitDotOsName.tsx
+++ b/kinode/src/register-ui/src/pages/CommitDotOsName.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, FormEvent, useCallback } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { toAscii } from "idna-uts46-hx";
 import EnterKnsName from "../components/EnterKnsName";
 import Loader from "../components/Loader";
 import { PageProps } from "../lib/types";
@@ -66,6 +67,7 @@ function CommitDotOsName({
             openConnectModal?.()
             return
         }
+        setName(toAscii(name));
         console.log("committing to .os name: ", name)
         const commitSecret = keccak256(stringToHex(name))
         const commit = keccak256(


### PR DESCRIPTION
## Problem

You can register names with unicode characters in them through the frontend (which will warn but not prevent it).

## Solution

Use the punycode-normalized text for the input.

## Testing

Try minting with a special character like ü on main and here.

## Docs Update

None

## Notes

I saw some mint tx.s fail; not sure if that is related to this PR, not sure why it would be.