### PR TITLE
fakenet fixes

### DIFF
--- a/kinode/packages/app_store/chain/src/lib.rs
+++ b/kinode/packages/app_store/chain/src/lib.rs
@@ -38,7 +38,7 @@ const CHAIN_TIMEOUT: u64 = 60; // 60s
 #[cfg(not(feature = "simulation-mode"))]
 const KIMAP_ADDRESS: &'static str = kimap::KIMAP_ADDRESS; // optimism
 #[cfg(feature = "simulation-mode")]
-const KIMAP_ADDRESS: &str = "0xcA92476B2483aBD5D82AEBF0b56701Bb2e9be658";
+const KIMAP_ADDRESS: &str = "0xEce71a05B36CA55B895427cD9a440eEF7Cf3669D";
 
 const DELAY_MS: u64 = 1_000; // 1s
 

--- a/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
+++ b/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
@@ -433,15 +433,22 @@ fn handle_log(
             if !kimap::valid_note(&note) {
                 return Err(anyhow::anyhow!("skipping invalid note: {note}"));
             }
-            if let Some(block_number) = log.block_number {
-                print_to_terminal(
-                    1,
-                    &format!("adding note to pending_notes for block {block_number}"),
-                );
-                pending_notes
-                    .entry(block_number)
-                    .or_default()
-                    .push((decoded, 0));
+            // handle note: if it precedes parent mint event, add it to pending_notes
+            if let Err(e) = handle_note(state, &decoded) {
+                if let Some(KnsError::NoParentError) = e.downcast_ref::<KnsError>() {
+                    if let Some(KnsError::NoParentError) = e.downcast_ref::<KnsError>() {
+                        if let Some(block_number) = log.block_number {
+                            print_to_terminal(
+                                1,
+                                &format!("adding note to pending_notes for block {block_number}"),
+                            );
+                            pending_notes
+                                .entry(block_number)
+                                .or_default()
+                                .push((decoded, 0));
+                        }
+                    }
+                }
             }
         }
         _log => {

--- a/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
+++ b/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
@@ -436,17 +436,15 @@ fn handle_log(
             // handle note: if it precedes parent mint event, add it to pending_notes
             if let Err(e) = handle_note(state, &decoded) {
                 if let Some(KnsError::NoParentError) = e.downcast_ref::<KnsError>() {
-                    if let Some(KnsError::NoParentError) = e.downcast_ref::<KnsError>() {
-                        if let Some(block_number) = log.block_number {
-                            print_to_terminal(
-                                1,
-                                &format!("adding note to pending_notes for block {block_number}"),
-                            );
-                            pending_notes
-                                .entry(block_number)
-                                .or_default()
-                                .push((decoded, 0));
-                        }
+                    if let Some(block_number) = log.block_number {
+                        print_to_terminal(
+                            1,
+                            &format!("adding note to pending_notes for block {block_number}"),
+                        );
+                        pending_notes
+                            .entry(block_number)
+                            .or_default()
+                            .push((decoded, 0));
                     }
                 }
             }

--- a/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
+++ b/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
@@ -154,6 +154,7 @@ fn main(our: Address, mut state: State) -> anyhow::Result<()> {
         &mut pending_notes,
     );
     println!("done syncing old logs.");
+    handle_pending_notes(&mut state, &mut pending_notes)?;
 
     loop {
         let Ok(message) = await_message() else {

--- a/kinode/src/fakenet.rs
+++ b/kinode/src/fakenet.rs
@@ -58,38 +58,7 @@ pub async fn mint_local(
 
     let provider: RootProvider<PubSubFrontend> = ProviderBuilder::default().on_ws(ws).await?;
 
-    // interesting, even if we have a minted name, this does not explicitly fail.
-    // also note, fake.dev.os seems to currently work, need to gate dots from names?
-    let mint_call = mintCall {
-        who: wallet_address,
-        label: Bytes::from(label.as_bytes().to_vec()),
-        initialization: vec![].into(),
-        erc721Data: vec![].into(),
-        implementation: Address::from_str(KINO_ACCOUNT_IMPL).unwrap(),
-    }
-    .abi_encode();
-
-    let nonce = provider.get_transaction_count(wallet_address).await?;
-
-    let tx = TransactionRequest::default()
-        .to(minter)
-        .input(TransactionInput::new(mint_call.into()))
-        .nonce(nonce)
-        .with_chain_id(31337)
-        .with_gas_limit(12_000_00)
-        .with_max_priority_fee_per_gas(200_000_000_000)
-        .with_max_fee_per_gas(300_000_000_000);
-
-    // Build the transaction using the `EthereumSigner` with the provided signer.
-    let tx_envelope = tx.build(&wallet).await?;
-
-    // Encode the transaction using EIP-2718 encoding.
-    let tx_encoded = tx_envelope.encoded_2718();
-
-    // Send the raw transaction and retrieve the transaction receipt.
-    let _tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
-
-    // get tba to set KNS records
+    // get tba to see if name is already registered
     let namehash: [u8; 32] = keygen::namehash(name);
 
     let get_call = getCall {
@@ -149,30 +118,56 @@ pub async fn mint_local(
         },
     ];
 
+    let is_reset = tba != Address::default();
+
     let multicall = aggregateCall { calls: multicalls }.abi_encode();
 
-    let execute_call = executeCall {
+    let execute_call: Vec<u8> = executeCall {
         to: multicall_address,
         value: U256::from(0), // free mint
         data: multicall.into(),
-        operation: 1, // ?
+        operation: 1,
     }
     .abi_encode();
+
+    let (input_bytes, to) = if is_reset {
+        // name is already registered, multicall reset it
+        (execute_call, tba)
+    } else {
+        // name is not registered, mint it with multicall in initialization param
+        (
+            mintCall {
+                who: wallet_address,
+                label: Bytes::from(label.as_bytes().to_vec()),
+                initialization: execute_call.into(),
+                erc721Data: vec![].into(),
+                implementation: Address::from_str(KINO_ACCOUNT_IMPL).unwrap(),
+            }
+            .abi_encode(),
+            minter,
+        )
+    };
 
     let nonce = provider.get_transaction_count(wallet_address).await?;
 
     let tx = TransactionRequest::default()
-        .to(tba)
-        .input(TransactionInput::new(execute_call.into()))
+        .to(to)
+        .input(TransactionInput::new(input_bytes.into()))
         .nonce(nonce)
         .with_chain_id(31337)
         .with_gas_limit(12_000_00)
         .with_max_priority_fee_per_gas(200_000_000_000)
         .with_max_fee_per_gas(300_000_000_000);
 
+    // Build the transaction using the `EthereumSigner` with the provided signer.
     let tx_envelope = tx.build(&wallet).await?;
+
+    // Encode the transaction using EIP-2718 encoding.
     let tx_encoded = tx_envelope.encoded_2718();
-    let _tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
+
+    // Send the raw transaction and retrieve the transaction receipt.
+    let tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
+    let _receipt = tx_hash.get_receipt().await?;
 
     Ok(())
 }

--- a/kinode/src/fakenet.rs
+++ b/kinode/src/fakenet.rs
@@ -166,8 +166,7 @@ pub async fn mint_local(
     let tx_encoded = tx_envelope.encoded_2718();
 
     // Send the raw transaction and retrieve the transaction receipt.
-    let tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
-    let _receipt = tx_hash.get_receipt().await?;
+    let _tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
 
     Ok(())
 }

--- a/kinode/src/fakenet.rs
+++ b/kinode/src/fakenet.rs
@@ -166,7 +166,8 @@ pub async fn mint_local(
     let tx_encoded = tx_envelope.encoded_2718();
 
     // Send the raw transaction and retrieve the transaction receipt.
-    let _tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
+    let tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
+    let _receipt = tx_hash.get_receipt().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Problem
New kimap indexing changes not fully working on fakenodes.

## Solution
Do 1 transaction only in src/fakenet.rs for registration, optimistically handle notes assuming their mint event came first.

## Notes

Thought we might've had to do a `--block-time 3` or similar argument to anvil in kit chain, but does not look like it (if we handle notes optimistically). App store publishing works on fakenet
