### PR TITLE
fix: kns registration: disallow capital letters

### DIFF
--- a/kinode/packages/app_store/ui/package-lock.json
+++ b/kinode/packages/app_store/ui/package-lock.json
@@ -3749,8 +3749,6 @@
     },
     "node_modules/@parcel/watcher-wasm/node_modules/napi-wasm": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/napi-wasm/-/napi-wasm-1.1.0.tgz",
-      "integrity": "sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==",
       "inBundle": true,
       "license": "MIT"
     },

--- a/kinode/src/register-ui/src/components/EnterKnsName.tsx
+++ b/kinode/src/register-ui/src/components/EnterKnsName.tsx
@@ -47,6 +47,12 @@ function EnterKnsName({
       let validities: string[] = [];
       setIsPunyfied('');
 
+      if (/[A-Z]/.test(name)) {
+        validities.push(NAME_URL);
+        setNameValidities(validities);
+        return;
+      }
+
       let normalized = ''
       index = validities.indexOf(NAME_INVALID_PUNY);
       try {
@@ -69,7 +75,9 @@ function EnterKnsName({
         index = validities.indexOf(NAME_URL);
         if (name !== "" && !isValidDomain(normalized)) {
           if (index === -1) validities.push(NAME_URL);
-        } else if (index !== -1) validities.splice(index, 1);
+        } else if (index !== -1) {
+          validities.splice(index, 1);
+        }
 
         index = validities.indexOf(NAME_CLAIMED);
 


### PR DESCRIPTION
## Problem

Capital letters were getting lost in the shuffle during registration validity checks

## Solution

Add a simple check to disallow

## Testing

```
1. Try using capital letters in .os registration
```

## Notes

This whole validities-checks code needs a fat refactor and generalization away from `.os` only
