### PR TITLE
app_store: new downloads page, sanity checks while publishing

### DIFF
--- a/kinode/packages/app_store/chain/src/lib.rs
+++ b/kinode/packages/app_store/chain/src/lib.rs
@@ -38,7 +38,7 @@ const CHAIN_TIMEOUT: u64 = 60; // 60s
 #[cfg(not(feature = "simulation-mode"))]
 const KIMAP_ADDRESS: &'static str = kimap::KIMAP_ADDRESS; // optimism
 #[cfg(feature = "simulation-mode")]
-const KIMAP_ADDRESS: &str = "0xcA92476B2483aBD5D82AEBF0b56701Bb2e9be658";
+const KIMAP_ADDRESS: &str = "0xEce71a05B36CA55B895427cD9a440eEF7Cf3669D";
 
 const DELAY_MS: u64 = 1_000; // 1s
 

--- a/kinode/packages/app_store/ft_worker/src/ft_worker_lib.rs
+++ b/kinode/packages/app_store/ft_worker/src/ft_worker_lib.rs
@@ -13,12 +13,13 @@ pub fn spawn_send_transfer(
     to_addr: &Address,
 ) -> anyhow::Result<()> {
     let transfer_id: u64 = rand::random();
+    let timer_id = ProcessId::new(Some("timer"), "distro", "sys");
     let Ok(worker_process_id) = spawn(
         Some(&transfer_id.to_string()),
         &format!("{}/pkg/ft_worker.wasm", our.package_id()),
         OnExit::None,
         our_capabilities(),
-        vec![],
+        vec![timer_id],
         false,
     ) else {
         return Err(anyhow::anyhow!("failed to spawn ft_worker!"));
@@ -48,12 +49,13 @@ pub fn spawn_receive_transfer(
     timeout: u64,
 ) -> anyhow::Result<Address> {
     let transfer_id: u64 = rand::random();
+    let timer_id = ProcessId::new(Some("timer"), "distro", "sys");
     let Ok(worker_process_id) = spawn(
         Some(&transfer_id.to_string()),
         &format!("{}/pkg/ft_worker.wasm", our.package_id()),
         OnExit::None,
         our_capabilities(),
-        vec![],
+        vec![timer_id],
         false,
     ) else {
         return Err(anyhow::anyhow!("failed to spawn ft_worker!"));

--- a/kinode/packages/app_store/pkg/manifest.json
+++ b/kinode/packages/app_store/pkg/manifest.json
@@ -9,6 +9,7 @@
             "http_server:distro:sys",
             "main:app_store:sys",
             "chain:app_store:sys",
+            "terminal:terminal:sys",
             "vfs:distro:sys",
             {
                 "process": "vfs:distro:sys",
@@ -20,6 +21,7 @@
         "grant_capabilities": [
             "http_server:distro:sys",
             "vfs:distro:sys",
+            "terminal:terminal:sys",
             "http_client:distro:sys"
         ],
         "public": false

--- a/kinode/packages/app_store/pkg/scripts.json
+++ b/kinode/packages/app_store/pkg/scripts.json
@@ -4,10 +4,12 @@
         "public": false,
         "request_networking": false,
         "request_capabilities": [
-            "main:app_store:sys"
+            "main:app_store:sys",
+            "downloads:app_store:sys"
         ],
         "grant_capabilities": [
-            "main:app_store:sys"
+            "main:app_store:sys",
+            "downloads:app_store:sys"
         ],
         "wit_version": 0
     },

--- a/kinode/packages/app_store/ui/src/components/MirrorSelector.tsx
+++ b/kinode/packages/app_store/ui/src/components/MirrorSelector.tsx
@@ -3,7 +3,7 @@ import useAppsStore from "../store";
 
 interface MirrorSelectorProps {
     packageId: string | undefined;
-    onMirrorSelect: (mirror: string) => void;
+    onMirrorSelect: (mirror: string, status: boolean | null | 'http') => void;
 }
 
 const MirrorSelector: React.FC<MirrorSelectorProps> = ({ packageId, onMirrorSelect }) => {
@@ -40,8 +40,10 @@ const MirrorSelector: React.FC<MirrorSelectorProps> = ({ packageId, onMirrorSele
     }, [packageId, fetchListing, checkMirror]);
 
     useEffect(() => {
-        onMirrorSelect(selectedMirror);
-    }, [selectedMirror, onMirrorSelect]);
+        if (selectedMirror) {
+            onMirrorSelect(selectedMirror, mirrorStatuses[selectedMirror]);
+        }
+    }, [selectedMirror, mirrorStatuses, onMirrorSelect]);
 
     const handleMirrorChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const value = e.target.value;

--- a/kinode/packages/app_store/ui/src/components/PackageSelector.tsx
+++ b/kinode/packages/app_store/ui/src/components/PackageSelector.tsx
@@ -1,0 +1,77 @@
+import React, { useState, useEffect } from 'react';
+import useAppsStore from "../store";
+
+interface PackageSelectorProps {
+    onPackageSelect: (packageName: string, publisherId: string) => void;
+}
+
+const PackageSelector: React.FC<PackageSelectorProps> = ({ onPackageSelect }) => {
+    const { installed } = useAppsStore();
+    const [selectedPackage, setSelectedPackage] = useState<string>("");
+    const [customPackage, setCustomPackage] = useState<string>("");
+    const [isCustomPackageSelected, setIsCustomPackageSelected] = useState(false);
+
+    useEffect(() => {
+        if (selectedPackage && selectedPackage !== "custom") {
+            const [packageName, publisherId] = selectedPackage.split(':');
+            onPackageSelect(packageName, publisherId);
+        }
+    }, [selectedPackage, onPackageSelect]);
+
+    const handlePackageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = e.target.value;
+        if (value === "custom") {
+            setIsCustomPackageSelected(true);
+        } else {
+            setSelectedPackage(value);
+            setIsCustomPackageSelected(false);
+            setCustomPackage("");
+        }
+    };
+
+    const handleSetCustomPackage = () => {
+        if (customPackage) {
+            const [packageName, publisherId] = customPackage.split(':');
+            if (packageName && publisherId) {
+                onPackageSelect(packageName, publisherId);
+                setSelectedPackage(customPackage);
+                setIsCustomPackageSelected(false);
+            } else {
+                alert("Please enter the package name and publisher ID in the format 'packageName:publisherId'");
+            }
+        }
+    };
+
+    return (
+        <div className="package-selector">
+            <select value={selectedPackage} onChange={handlePackageChange}>
+                <option value="">Select a package</option>
+                <option value="custom">Custom package</option>
+                {!isCustomPackageSelected && customPackage && (
+                    <option value={customPackage}>{customPackage}</option>
+                )}
+                {Object.keys(installed).map((packageFullName) => (
+                    <option key={packageFullName} value={packageFullName}>
+                        {packageFullName}
+                    </option>
+                ))}
+            </select>
+            {isCustomPackageSelected && (
+                <div className="custom-package-input">
+                    <input
+                        type="text"
+                        value={customPackage}
+                        onChange={(e) => setCustomPackage(e.target.value)}
+                        placeholder="Enter as packageName:publisherId"
+                        style={{ width: '100%', marginBottom: '10px' }}
+                    />
+                    <button onClick={handleSetCustomPackage} disabled={!customPackage}>
+                        Set Custom Package
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default PackageSelector;

--- a/kinode/packages/app_store/ui/src/components/index.ts
+++ b/kinode/packages/app_store/ui/src/components/index.ts
@@ -1,2 +1,3 @@
 export { default as Header } from './Header';
 export { default as MirrorSelector } from './MirrorSelector';
+export { default as PackageSelector } from './PackageSelector';

--- a/kinode/packages/app_store/ui/src/index.css
+++ b/kinode/packages/app_store/ui/src/index.css
@@ -317,35 +317,220 @@ td {
 
 /* Download Page */
 .downloads-page {
-    background-color: light-dark(var(--off-white), var(--off-black));
-    border-radius: var(--border-radius);
-    padding: 1rem;
+    background-color: light-dark(var(--white), var(--maroon));
+    border-radius: 8px;
+    padding: 2rem;
+    margin-bottom: 2rem;
 }
 
-.mirror-selection {
-    max-width: 300px;
+.app-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
     margin-bottom: 1rem;
+}
+
+.app-header h2 {
+    margin: 0;
+}
+
+.launch-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    font-size: 14px;
+    background-color: var(--orange);
+    color: var(--white);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.launch-button:hover {
+    background-color: var(--dark-orange);
+}
+
+.version-selector {
+    margin-bottom: 1rem;
+}
+
+.version-selector select {
+    width: 100%;
+    padding: 0.75rem;
+    border: 2px solid var(--orange);
+    border-radius: 4px;
+    background-color: light-dark(var(--white), var(--tasteful-dark));
+    color: light-dark(var(--off-black), var(--off-white));
+    transition: all 0.3s ease;
+}
+
+.version-selector select:focus {
+    outline: none;
+    border-color: var(--dark-orange);
+    box-shadow: 0 0 0 3px rgba(255, 79, 0, 0.2);
+}
+
+.download-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.download-button,
+.install-button,
+.installed-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    font-size: 16px;
+    font-weight: bold;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.download-button {
+    background-color: var(--orange);
+    color: var(--white);
+}
+
+.download-button:hover:not(:disabled) {
+    background-color: var(--dark-orange);
+}
+
+.install-button {
+    background-color: var(--blue);
+    color: var(--white);
+}
+
+.install-button:hover {
+    background-color: color-mix(in srgb, var(--blue) 80%, black);
+}
+
+.installed-button {
+    background-color: var(--gray);
+    color: var(--white);
+    cursor: not-allowed;
+}
+
+.download-button:disabled,
+.install-button:disabled,
+.installed-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.my-downloads {
+    margin-top: 1rem;
+}
+
+.my-downloads>button {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background-color: transparent;
+    color: var(--orange);
+    border: 2px solid var(--orange);
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.my-downloads>button:hover {
+    background-color: var(--orange);
+    color: var(--white);
+}
+
+.my-downloads table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+
+.my-downloads th,
+.my-downloads td {
+    padding: 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--gray);
+}
+
+.my-downloads td button {
+    margin-right: 0.5rem;
 }
 
 .app-details {
     margin-top: 1rem;
 }
 
-.detail-section {
+.app-details>button {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background-color: transparent;
+    color: var(--orange);
+    border: 2px solid var(--orange);
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.app-details>button:hover {
+    background-color: var(--orange);
+    color: var(--white);
+}
+
+.app-details pre {
     background-color: light-dark(var(--tan), var(--tasteful-dark));
-    border-radius: var(--border-radius);
+    color: light-dark(var(--off-black), var(--off-white));
     padding: 1rem;
-    margin-bottom: 1rem;
+    border-radius: 4px;
+    overflow-x: auto;
+    margin-top: 1rem;
+}
+
+.cap-approval-popup {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.cap-approval-content {
+    background-color: light-dark(var(--white), var(--tasteful-dark));
+    color: light-dark(var(--off-black), var(--off-white));
+    padding: 2rem;
+    border-radius: 8px;
+    max-width: 80%;
+    max-height: 80%;
+    overflow-y: auto;
 }
 
 .json-display {
+    background-color: light-dark(var(--tan), var(--off-black));
+    color: light-dark(var(--off-black), var(--off-white));
+    padding: 1rem;
+    border-radius: 4px;
     white-space: pre-wrap;
-    word-break: break-all;
-    max-height: 300px;
-    overflow-y: auto;
-    background-color: light-dark(var(--off-white), var(--off-black));
-    padding: 0.5rem;
-    border-radius: var(--border-radius);
+    word-break: break-word;
+}
+
+.approval-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    margin-top: 1rem;
 }
 
 /* My Downloads Page */

--- a/kinode/packages/app_store/ui/src/index.css
+++ b/kinode/packages/app_store/ui/src/index.css
@@ -224,6 +224,11 @@ td {
     align-items: center;
     gap: 0.5rem;
     color: var(--red);
+    font-size: 0.9rem;
+    margin-top: 0.25rem;
+}
+
+.form-group {
     margin-bottom: 1rem;
 }
 

--- a/kinode/packages/app_store/ui/src/pages/DownloadPage.tsx
+++ b/kinode/packages/app_store/ui/src/pages/DownloadPage.tsx
@@ -16,7 +16,7 @@ export default function DownloadPage() {
         downloadApp,
         installApp,
         removeDownload,
-        checkMirror,
+        clearAllActiveDownloads,
     } = useAppsStore();
 
     const [showMetadata, setShowMetadata] = useState(false);
@@ -34,8 +34,9 @@ export default function DownloadPage() {
     useEffect(() => {
         if (id) {
             fetchData(id);
+            clearAllActiveDownloads();
         }
-    }, [id, fetchData]);
+    }, [id, fetchData, clearAllActiveDownloads]);
 
     const handleMirrorSelect = useCallback((mirror: string, status: boolean | null | 'http') => {
         setSelectedMirror(mirror);

--- a/kinode/packages/app_store/ui/src/pages/DownloadPage.tsx
+++ b/kinode/packages/app_store/ui/src/pages/DownloadPage.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
-import { useParams } from "react-router-dom";
-import { FaDownload, FaCheck, FaSpinner, FaRocket, FaChevronDown, FaChevronUp, FaTrash } from "react-icons/fa";
+import { useParams, useNavigate } from "react-router-dom";
+import { FaDownload, FaSpinner, FaChevronDown, FaChevronUp, FaRocket, FaTrash, FaPlay } from "react-icons/fa";
 import useAppsStore from "../store";
 import { MirrorSelector } from '../components';
 
 export default function DownloadPage() {
+    const navigate = useNavigate();
     const { id } = useParams<{ id: string }>();
     const {
         listings,
@@ -15,14 +16,15 @@ export default function DownloadPage() {
         downloadApp,
         installApp,
         removeDownload,
-        clearAllActiveDownloads,
+        checkMirror,
     } = useAppsStore();
 
     const [showMetadata, setShowMetadata] = useState(false);
     const [selectedMirror, setSelectedMirror] = useState<string>("");
-
+    const [selectedVersion, setSelectedVersion] = useState<string>("");
+    const [showMyDownloads, setShowMyDownloads] = useState(false);
+    const [isMirrorOnline, setIsMirrorOnline] = useState<boolean | null>(null);
     const [showCapApproval, setShowCapApproval] = useState(false);
-    const [selectedVersion, setSelectedVersion] = useState<{ version: string, hash: string } | null>(null);
     const [manifest, setManifest] = useState<any>(null);
 
     const app = useMemo(() => listings[id || ""], [listings, id]);
@@ -31,21 +33,80 @@ export default function DownloadPage() {
 
     useEffect(() => {
         if (id) {
-            clearAllActiveDownloads();
             fetchData(id);
         }
-    }, [id, fetchData, clearAllActiveDownloads]);
+    }, [id, fetchData]);
+
+    const handleMirrorSelect = useCallback((mirror: string, status: boolean | null | 'http') => {
+        setSelectedMirror(mirror);
+        setIsMirrorOnline(status === 'http' ? true : status);
+    }, []);
+
+
+    const sortedVersions = useMemo(() => {
+        if (!app || !app.metadata?.properties?.code_hashes) return [];
+        return app.metadata.properties.code_hashes
+            .map(([version, hash]) => ({ version, hash }))
+            .sort((a, b) => {
+                const vA = a.version.split('.').map(Number);
+                const vB = b.version.split('.').map(Number);
+                for (let i = 0; i < Math.max(vA.length, vB.length); i++) {
+                    if (vA[i] > vB[i]) return -1;
+                    if (vA[i] < vB[i]) return 1;
+                }
+                return 0;
+            });
+    }, [app]);
 
     useEffect(() => {
-        if (app && !selectedMirror) {
-            setSelectedMirror(app.package_id.publisher_node || "");
+        if (sortedVersions.length > 0 && !selectedVersion) {
+            setSelectedVersion(sortedVersions[0].version);
         }
-    }, [app, selectedMirror]);
+    }, [sortedVersions, selectedVersion]);
 
-    const handleDownload = useCallback((version: string, hash: string) => {
-        if (!id || !selectedMirror || !app) return;
-        downloadApp(id, hash, selectedMirror);
-    }, [id, selectedMirror, app, downloadApp]);
+    const isDownloaded = useMemo(() => {
+        if (!app || !selectedVersion) return false;
+        const versionData = sortedVersions.find(v => v.version === selectedVersion);
+        if (!versionData) return false;
+        return appDownloads.some(d => d.File && d.File.name === `${versionData.hash}.zip`);
+    }, [app, selectedVersion, sortedVersions, appDownloads]);
+
+    const isDownloading = useMemo(() => {
+        if (!app || !selectedVersion) return false;
+        const versionData = sortedVersions.find(v => v.version === selectedVersion);
+        if (!versionData) return false;
+        const downloadKey = `${app.package_id.package_name}:${selectedMirror}:${versionData.hash}`;
+        return !!activeDownloads[downloadKey];
+    }, [app, selectedVersion, sortedVersions, selectedMirror, activeDownloads]);
+
+
+    const downloadProgress = useMemo(() => {
+        if (!isDownloading || !app || !selectedVersion) return null;
+        const versionData = sortedVersions.find(v => v.version === selectedVersion);
+        if (!versionData) return null;
+        const downloadKey = `${app.package_id.package_name}:${selectedMirror}:${versionData.hash}`;
+        const progress = activeDownloads[downloadKey];
+        return progress ? Math.round((progress.downloaded / progress.total) * 100) : 0;
+    }, [isDownloading, app, selectedVersion, sortedVersions, selectedMirror, activeDownloads]);
+
+    const isCurrentVersionInstalled = useMemo(() => {
+        if (!app || !selectedVersion || !installedApp) return false;
+        const versionData = sortedVersions.find(v => v.version === selectedVersion);
+        return versionData ? installedApp.our_version_hash === versionData.hash : false;
+    }, [app, selectedVersion, installedApp, sortedVersions]);
+
+    const handleDownload = useCallback(() => {
+        if (!id || !selectedMirror || !app || !selectedVersion) return;
+        const versionData = sortedVersions.find(v => v.version === selectedVersion);
+        if (versionData) {
+            downloadApp(id, versionData.hash, selectedMirror);
+        }
+    }, [id, selectedMirror, app, selectedVersion, sortedVersions, downloadApp]);
+
+    const handleRemoveDownload = useCallback((hash: string) => {
+        if (!id) return;
+        removeDownload(id, hash).then(() => fetchData(id));
+    }, [id, removeDownload, fetchData]);
 
     const handleInstall = useCallback((version: string, hash: string) => {
         if (!id || !app) return;
@@ -54,7 +115,6 @@ export default function DownloadPage() {
             try {
                 const manifestData = JSON.parse(download.File.manifest);
                 setManifest(manifestData);
-                setSelectedVersion({ version, hash });
                 setShowCapApproval(true);
             } catch (error) {
                 console.error('Failed to parse manifest:', error);
@@ -64,37 +124,27 @@ export default function DownloadPage() {
         }
     }, [id, app, appDownloads]);
 
+    const canDownload = useMemo(() => {
+        return selectedMirror && (isMirrorOnline === true || selectedMirror.startsWith('http')) && !isDownloading && !isDownloaded;
+    }, [selectedMirror, isMirrorOnline, isDownloading, isDownloaded]);
+
     const confirmInstall = useCallback(() => {
         if (!id || !selectedVersion) return;
-        installApp(id, selectedVersion.hash).then(() => {
-            fetchData(id);
-            setShowCapApproval(false);
-            setManifest(null);
-        });
-    }, [id, selectedVersion, installApp, fetchData]);
+        const versionData = sortedVersions.find(v => v.version === selectedVersion);
+        if (versionData) {
+            installApp(id, versionData.hash).then(() => {
+                fetchData(id);
+                setShowCapApproval(false);
+                setManifest(null);
+            });
+        }
+    }, [id, selectedVersion, sortedVersions, installApp, fetchData]);
 
-    const handleRemoveDownload = useCallback((version: string, hash: string) => {
-        if (!id) return;
-        removeDownload(id, hash).then(() => fetchData(id));
-    }, [id, removeDownload, fetchData]);
-
-    const versionList = useMemo(() => {
-        if (!app || !app.metadata?.properties?.code_hashes) return [];
-
-        return app.metadata.properties.code_hashes.map(([version, hash]) => {
-            const download = appDownloads.find(d => d.File && d.File.name === `${hash}.zip`);
-            const downloadKey = `${app.package_id.package_name}:${app.package_id.publisher_node}:${hash}`;
-            const activeDownload = activeDownloads[downloadKey];
-            const isDownloaded = !!download?.File && download.File.size > 0;
-            const isInstalled = installedApp?.our_version_hash === hash;
-            const isDownloading = !!activeDownload && activeDownload.downloaded < activeDownload.total;
-            const progress = isDownloading ? activeDownload : { downloaded: 0, total: 100 };
-
-            console.log(`Version ${version} - isInstalled: ${isInstalled}, installedApp:`, installedApp);
-
-            return { version, hash, isDownloaded, isInstalled, isDownloading, progress };
-        });
-    }, [app, appDownloads, activeDownloads, installedApp]);
+    const handleLaunch = useCallback(() => {
+        if (app) {
+            navigate(`/${app.package_id.package_name}:${app.package_id.package_name}:${app.package_id.publisher_node}/`);
+        }
+    }, [app, navigate]);
 
     if (!app) {
         return <div className="downloads-page"><h4>Loading app details...</h4></div>;
@@ -102,79 +152,104 @@ export default function DownloadPage() {
 
     return (
         <div className="downloads-page">
-            <h2>{app.metadata?.name || app.package_id.package_name}</h2>
+            <div className="app-header">
+                <h2>{app.metadata?.name || app.package_id.package_name}</h2>
+                {installedApp && (
+                    <button onClick={handleLaunch} className="launch-button">
+                        <FaPlay /> Launch
+                    </button>
+                )}
+            </div>
             <p>{app.metadata?.description}</p>
 
-            <MirrorSelector packageId={id} onMirrorSelect={setSelectedMirror} />
+            <div className="version-selector">
+                <select
+                    value={selectedVersion}
+                    onChange={(e) => setSelectedVersion(e.target.value)}
+                >
+                    {sortedVersions.map(({ version }, index) => (
+                        <option key={version} value={version}>
+                            {version} {index === 0 ? "(newest)" : ""}
+                        </option>
+                    ))}
+                </select>
+            </div>
 
-            <div className="version-list">
-                <h3>Available Versions</h3>
-                {versionList.length === 0 ? (
-                    <p>No versions available for this app.</p>
+            <div className="download-section">
+                <MirrorSelector
+                    packageId={id}
+                    onMirrorSelect={handleMirrorSelect}
+                />
+                {isCurrentVersionInstalled ? (
+                    <button className="installed-button" disabled>
+                        <FaRocket /> Installed
+                    </button>
+                ) : isDownloaded ? (
+                    <button
+                        onClick={() => {
+                            const versionData = sortedVersions.find(v => v.version === selectedVersion);
+                            if (versionData) {
+                                handleInstall(versionData.version, versionData.hash);
+                            }
+                        }}
+                        className="install-button"
+                    >
+                        <FaRocket /> Install
+                    </button>
                 ) : (
+                    <button
+                        onClick={handleDownload}
+                        disabled={!canDownload}
+                        className="download-button"
+                    >
+                        {isDownloading ? (
+                            <>
+                                <FaSpinner className="fa-spin" />
+                                Downloading... {downloadProgress}%
+                            </>
+                        ) : (
+                            <>
+                                <FaDownload /> Download
+                            </>
+                        )}
+                    </button>
+                )}
+            </div>
+
+            <div className="my-downloads">
+                <button onClick={() => setShowMyDownloads(!showMyDownloads)}>
+                    {showMyDownloads ? <FaChevronUp /> : <FaChevronDown />} My Downloads
+                </button>
+                {showMyDownloads && (
                     <table>
                         <thead>
                             <tr>
                                 <th>Version</th>
-                                <th>Status</th>
                                 <th>Actions</th>
                             </tr>
                         </thead>
                         <tbody>
-                            {versionList.map(({ version, hash, isDownloaded, isInstalled, isDownloading, progress }) => (
-                                <tr key={version}>
-                                    <td>{version}</td>
-                                    <td>
-                                        {isInstalled ? 'Installed' : isDownloaded ? 'Downloaded' : isDownloading ? 'Downloading' : 'Not downloaded'}
-                                    </td>
-                                    <td>
-                                        {!isDownloaded && !isDownloading && (
-                                            <button
-                                                onClick={() => handleDownload(version, hash)}
-                                                disabled={!selectedMirror}
-                                                className="download-button"
-                                            >
-                                                <FaDownload /> Download
+                            {appDownloads.map((download) => {
+                                const fileName = download.File?.name;
+                                const hash = fileName ? fileName.replace('.zip', '') : '';
+                                const versionData = sortedVersions.find(v => v.hash === hash);
+                                if (!versionData) return null;
+                                return (
+                                    <tr key={hash}>
+                                        <td>{versionData.version}</td>
+                                        <td>
+                                            <button onClick={() => handleInstall(versionData.version, hash)}>
+                                                <FaRocket /> Install
                                             </button>
-                                        )}
-                                        {isDownloading && (
-                                            <div className="download-progress">
-                                                <FaSpinner className="fa-spin" />
-                                                Downloading... {Math.round((progress.downloaded / progress.total) * 100)}%
-                                            </div>
-                                        )}
-                                        {isDownloaded && !isInstalled && (
-                                            <>
-                                                <button
-                                                    onClick={() => handleInstall(version, hash)}
-                                                    className="install-button"
-                                                >
-                                                    <FaRocket /> Install
-                                                </button>
-                                                <button
-                                                    onClick={() => handleRemoveDownload(version, hash)}
-                                                    className="delete-button"
-                                                >
-                                                    <FaTrash /> Delete
-                                                </button>
-                                            </>
-                                        )}
-                                        {isInstalled && <FaCheck className="installed" />}
-                                    </td>
-                                </tr>
-                            ))}
+                                            <button onClick={() => handleRemoveDownload(hash)}>
+                                                <FaTrash /> Delete
+                                            </button>
+                                        </td>
+                                    </tr>
+                                );
+                            })}
                         </tbody>
                     </table>
-                )}
-            </div>
-
-            <div className="app-details">
-                <h3>App Details</h3>
-                <button onClick={() => setShowMetadata(!showMetadata)}>
-                    {showMetadata ? <FaChevronUp /> : <FaChevronDown />} Metadata
-                </button>
-                {showMetadata && (
-                    <pre>{JSON.stringify(app.metadata, null, 2)}</pre>
                 )}
             </div>
 
@@ -194,6 +269,17 @@ export default function DownloadPage() {
                     </div>
                 </div>
             )}
+
+
+            <div className="app-details">
+                <h3>App Details</h3>
+                <button onClick={() => setShowMetadata(!showMetadata)}>
+                    {showMetadata ? <FaChevronUp /> : <FaChevronDown />} Metadata
+                </button>
+                {showMetadata && (
+                    <pre>{JSON.stringify(app.metadata, null, 2)}</pre>
+                )}
+            </div>
         </div>
     );
 }

--- a/kinode/packages/app_store/ui/src/pages/PublishPage.tsx
+++ b/kinode/packages/app_store/ui/src/pages/PublishPage.tsx
@@ -6,10 +6,12 @@ import { keccak256, toBytes } from 'viem';
 import { mechAbi, KIMAP, encodeIntoMintCall, encodeMulticalls, kimapAbi, MULTICALL } from "../abis";
 import { kinohash } from '../utils/kinohash';
 import useAppsStore from "../store";
+import { PackageSelector } from "../components";
+
 
 export default function PublishPage() {
   const { openConnectModal } = useConnectModal();
-  const { ourApps, fetchOurApps } = useAppsStore();
+  const { ourApps, fetchOurApps, installed } = useAppsStore();
   const publicClient = usePublicClient();
 
   const { address, isConnected, isConnecting } = useAccount();
@@ -45,6 +47,11 @@ export default function PublishPage() {
       alert("Error calculating metadata hash. Please ensure the URL is valid and the metadata is in JSON format.");
     }
   }, [metadataUrl]);
+
+  const handlePackageSelection = (packageName: string, publisherId: string) => {
+    setPackageName(packageName);
+    setPublisherId(publisherId);
+  };
 
   const publishPackage = useCallback(
     async (e: FormEvent<HTMLFormElement>) => {
@@ -187,26 +194,10 @@ export default function PublishPage() {
       ) : (
         <form className="publish-form" onSubmit={publishPackage}>
           <div className="form-group">
-            <label htmlFor="package-name">Package Name</label>
-            <input
-              id="package-name"
-              type="text"
-              required
-              placeholder="my-package"
-              value={packageName}
-              onChange={(e) => setPackageName(e.target.value)}
-            />
+            <label htmlFor="package-select">Select Package</label>
+            <PackageSelector onPackageSelect={handlePackageSelection} />
           </div>
-          <div className="form-group">
-            <label htmlFor="publisher-id">Publisher ID</label>
-            <input
-              id="publisher-id"
-              type="text"
-              required
-              value={publisherId}
-              onChange={(e) => setPublisherId(e.target.value)}
-            />
-          </div>
+
           <div className="form-group">
             <label htmlFor="metadata-url">Metadata URL</label>
             <input

--- a/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
+++ b/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
@@ -433,15 +433,22 @@ fn handle_log(
             if !kimap::valid_note(&note) {
                 return Err(anyhow::anyhow!("skipping invalid note: {note}"));
             }
-            if let Some(block_number) = log.block_number {
-                print_to_terminal(
-                    1,
-                    &format!("adding note to pending_notes for block {block_number}"),
-                );
-                pending_notes
-                    .entry(block_number)
-                    .or_default()
-                    .push((decoded, 0));
+            // handle note: if it precedes parent mint event, add it to pending_notes
+            if let Err(e) = handle_note(state, &decoded) {
+                if let Some(KnsError::NoParentError) = e.downcast_ref::<KnsError>() {
+                    if let Some(KnsError::NoParentError) = e.downcast_ref::<KnsError>() {
+                        if let Some(block_number) = log.block_number {
+                            print_to_terminal(
+                                1,
+                                &format!("adding note to pending_notes for block {block_number}"),
+                            );
+                            pending_notes
+                                .entry(block_number)
+                                .or_default()
+                                .push((decoded, 0));
+                        }
+                    }
+                }
             }
         }
         _log => {

--- a/kinode/src/fakenet.rs
+++ b/kinode/src/fakenet.rs
@@ -58,38 +58,7 @@ pub async fn mint_local(
 
     let provider: RootProvider<PubSubFrontend> = ProviderBuilder::default().on_ws(ws).await?;
 
-    // interesting, even if we have a minted name, this does not explicitly fail.
-    // also note, fake.dev.os seems to currently work, need to gate dots from names?
-    let mint_call = mintCall {
-        who: wallet_address,
-        label: Bytes::from(label.as_bytes().to_vec()),
-        initialization: vec![].into(),
-        erc721Data: vec![].into(),
-        implementation: Address::from_str(KINO_ACCOUNT_IMPL).unwrap(),
-    }
-    .abi_encode();
-
-    let nonce = provider.get_transaction_count(wallet_address).await?;
-
-    let tx = TransactionRequest::default()
-        .to(minter)
-        .input(TransactionInput::new(mint_call.into()))
-        .nonce(nonce)
-        .with_chain_id(31337)
-        .with_gas_limit(12_000_00)
-        .with_max_priority_fee_per_gas(200_000_000_000)
-        .with_max_fee_per_gas(300_000_000_000);
-
-    // Build the transaction using the `EthereumSigner` with the provided signer.
-    let tx_envelope = tx.build(&wallet).await?;
-
-    // Encode the transaction using EIP-2718 encoding.
-    let tx_encoded = tx_envelope.encoded_2718();
-
-    // Send the raw transaction and retrieve the transaction receipt.
-    let _tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
-
-    // get tba to set KNS records
+    // get tba to see if name is already registered
     let namehash: [u8; 32] = keygen::namehash(name);
 
     let get_call = getCall {
@@ -149,30 +118,56 @@ pub async fn mint_local(
         },
     ];
 
+    let is_reset = tba != Address::default();
+
     let multicall = aggregateCall { calls: multicalls }.abi_encode();
 
-    let execute_call = executeCall {
+    let execute_call: Vec<u8> = executeCall {
         to: multicall_address,
         value: U256::from(0), // free mint
         data: multicall.into(),
-        operation: 1, // ?
+        operation: 1,
     }
     .abi_encode();
+
+    let (input_bytes, to) = if is_reset {
+        // name is already registered, multicall reset it
+        (execute_call, tba)
+    } else {
+        // name is not registered, mint it with multicall in initialization param
+        (
+            mintCall {
+                who: wallet_address,
+                label: Bytes::from(label.as_bytes().to_vec()),
+                initialization: execute_call.into(),
+                erc721Data: vec![].into(),
+                implementation: Address::from_str(KINO_ACCOUNT_IMPL).unwrap(),
+            }
+            .abi_encode(),
+            minter,
+        )
+    };
 
     let nonce = provider.get_transaction_count(wallet_address).await?;
 
     let tx = TransactionRequest::default()
-        .to(tba)
-        .input(TransactionInput::new(execute_call.into()))
+        .to(to)
+        .input(TransactionInput::new(input_bytes.into()))
         .nonce(nonce)
         .with_chain_id(31337)
         .with_gas_limit(12_000_00)
         .with_max_priority_fee_per_gas(200_000_000_000)
         .with_max_fee_per_gas(300_000_000_000);
 
+    // Build the transaction using the `EthereumSigner` with the provided signer.
     let tx_envelope = tx.build(&wallet).await?;
+
+    // Encode the transaction using EIP-2718 encoding.
     let tx_encoded = tx_envelope.encoded_2718();
-    let _tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
+
+    // Send the raw transaction and retrieve the transaction receipt.
+    let tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
+    let _receipt = tx_hash.get_receipt().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## ux

Rendering all versions is confusing, and they got missorted every now and then. Instead, default to newest version, and have the ability to choose with a dropdown. 

Also, if devs are about to publish a package, without having some hash of their code-versions on their local node, they should be warned. Same with publishing an invalid package_name

