### PR TITLE
kns: fix peering on boot

### DIFF
--- a/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
+++ b/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
@@ -153,6 +153,8 @@ fn main(our: Address, mut state: State) -> anyhow::Result<()> {
         notes_filter.clone(),
         &mut pending_notes,
     );
+    // set a timer tick so any pending logs will be processed
+    timer::set_timer(DELAY_MS, None);
     println!("done syncing old logs.");
 
     loop {


### PR DESCRIPTION
## Problem

Nodes can sometimes not set up peers on boot.

## Solution

After loading events on boot, set a timer tick to force processing of any pending notes.

## Testing

Boot on master & here, then
```
peer <your own node name>
```

## Docs Update

None

## Notes

None