### PR TITLE
app_store: always respond with error; use process_macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,6 +984,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "kinode_process_lib 0.9.0",
+ "process_macros",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1581,6 +1582,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "kinode_process_lib 0.9.0",
+ "process_macros",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -2334,6 +2336,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "kinode_process_lib 0.9.0",
+ "process_macros",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -2345,6 +2348,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "kinode_process_lib 0.9.1",
+ "process_macros",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -2610,6 +2614,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "kinode_process_lib 0.9.1",
+ "process_macros",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -3331,6 +3336,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "kinode_process_lib 0.9.0",
+ "process_macros",
  "serde",
  "serde_json",
  "wit-bindgen",
@@ -6444,6 +6450,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "kinode_process_lib 0.9.0",
+ "process_macros",
  "serde",
  "serde_json",
  "wit-bindgen",

--- a/kinode/packages/app_store/Cargo.toml
+++ b/kinode/packages/app_store/Cargo.toml
@@ -1,0 +1,16 @@
+[workspace]
+resolver = "2"
+members = [
+    "app_store",
+    "chain",
+    "download",
+    "downloads",
+    "ft_worker",
+    "install",
+    "uninstall",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/kinode/packages/app_store/api/app_store:sys-v1.wit
+++ b/kinode/packages/app_store/api/app_store:sys-v1.wit
@@ -55,6 +55,7 @@ interface downloads {
         http-client-error,
         blob-not-found,
         vfs-error,
+        handling-error(string),
     }
 
     record download-complete-request {
@@ -192,7 +193,6 @@ interface main {
         local(local-response),
         chain-error(chain-error),
         download-error(download-error),
-        send-error(string),
         handling-error(string),
     }
 

--- a/kinode/packages/app_store/api/app_store:sys-v1.wit
+++ b/kinode/packages/app_store/api/app_store:sys-v1.wit
@@ -1,6 +1,6 @@
 interface downloads {
     //
-    // download API as presented by download:app_store:sys-v0
+    // download API as presented by download:app_store:sys-v1
     //
 
     use standard.{package-id};
@@ -26,7 +26,7 @@ interface downloads {
     variant download-responses {
         success,
         error(download-error),
-        get-files(list<entry>),   
+        get-files(list<entry>),
     }
 
     record local-download-request {
@@ -96,7 +96,7 @@ interface downloads {
         version-hash: string,
     }
 
-    // part of new-package-request local-only flow. 
+    // part of new-package-request local-only flow.
     record add-download-request {
         package-id: package-id,
         version-hash: string,
@@ -118,7 +118,7 @@ interface downloads {
 
 interface chain {
     //
-    // on-chain API as presented by chain:app_store:sys-v0
+    // on-chain API as presented by chain:app_store:sys-v1
     //
 
     use standard.{package-id};
@@ -143,7 +143,7 @@ interface chain {
     variant chain-error {
         no-package,
     }
-    
+
     record onchain-app {
         package-id: package-id,
         tba: string,
@@ -177,7 +177,7 @@ interface chain {
 
 interface main {
     //
-    // app store API as presented by main:app_store:sys-v0
+    // app store API as presented by main:app_store:sys-v1
     //
 
     use standard.{package-id};
@@ -192,6 +192,8 @@ interface main {
         local(local-response),
         chain-error(chain-error),
         download-error(download-error),
+        send-error(string),
+        handling-error(string),
     }
 
     variant local-request {
@@ -215,7 +217,7 @@ interface main {
         package-id: package-id,
         mirror: bool,
     }
-    
+
     record install-package-request {
         package-id: package-id,
         metadata: option<onchain-metadata>, // if None == local sideload package.
@@ -250,7 +252,7 @@ interface main {
     }
 }
 
-world app-store-sys-v0 {
+world app-store-sys-v1 {
     import main;
     import downloads;
     import chain;

--- a/kinode/packages/app_store/api/app_store:sys-v1.wit
+++ b/kinode/packages/app_store/api/app_store:sys-v1.wit
@@ -25,7 +25,7 @@ interface downloads {
 
     variant download-responses {
         success,
-        error(download-error),
+        err(download-error),
         get-files(list<entry>),
     }
 
@@ -60,7 +60,7 @@ interface downloads {
     record download-complete-request {
         package-id: package-id,
         version-hash: string,
-        error: option<download-error>,
+        err: option<download-error>,
     }
 
     record hash-mismatch {
@@ -137,7 +137,7 @@ interface chain {
         get-our-apps(list<onchain-app>),
         auto-update-started,
         auto-update-stopped,
-        error(chain-error),
+        err(chain-error),
     }
 
     variant chain-error {

--- a/kinode/packages/app_store/app_store/Cargo.toml
+++ b/kinode/packages/app_store/app_store/Cargo.toml
@@ -12,6 +12,7 @@ alloy-sol-types = "0.7.6"
 anyhow = "1.0"
 bincode = "1.3.3"
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.9.0" }
+process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/kinode/packages/app_store/app_store/src/http_api.rs
+++ b/kinode/packages/app_store/app_store/src/http_api.rs
@@ -318,9 +318,7 @@ fn serve_paths(
                 DownloadResponses::GetFiles(files) => {
                     Ok((StatusCode::OK, None, serde_json::to_vec(&files)?))
                 }
-                DownloadResponses::Error(e) => {
-                    Err(anyhow::anyhow!("Error from downloads: {:?}", e))
-                }
+                DownloadResponses::Err(e) => Err(anyhow::anyhow!("Error from downloads: {:?}", e)),
                 _ => Err(anyhow::anyhow!(
                     "Invalid response from downloads: {:?}",
                     msg
@@ -348,9 +346,7 @@ fn serve_paths(
                 DownloadResponses::GetFiles(files) => {
                     Ok((StatusCode::OK, None, serde_json::to_vec(&files)?))
                 }
-                DownloadResponses::Error(e) => {
-                    Err(anyhow::anyhow!("Error from downloads: {:?}", e))
-                }
+                DownloadResponses::Err(e) => Err(anyhow::anyhow!("Error from downloads: {:?}", e)),
                 _ => Err(anyhow::anyhow!(
                     "Invalid response from downloads: {:?}",
                     msg
@@ -509,7 +505,7 @@ fn serve_paths(
                     let msg = serde_json::from_slice::<DownloadResponses>(resp.body())?;
                     match msg {
                         DownloadResponses::Success => Ok((StatusCode::OK, None, vec![])),
-                        DownloadResponses::Error(e) => {
+                        DownloadResponses::Err(e) => {
                             Err(anyhow::anyhow!("Error starting mirroring: {:?}", e))
                         }
                         _ => Err(anyhow::anyhow!(
@@ -529,7 +525,7 @@ fn serve_paths(
                     let msg = serde_json::from_slice::<DownloadResponses>(resp.body())?;
                     match msg {
                         DownloadResponses::Success => Ok((StatusCode::OK, None, vec![])),
-                        DownloadResponses::Error(e) => {
+                        DownloadResponses::Err(e) => {
                             Err(anyhow::anyhow!("Error stopping mirroring: {:?}", e))
                         }
                         _ => Err(anyhow::anyhow!(
@@ -574,7 +570,7 @@ fn serve_paths(
             let msg = serde_json::from_slice::<DownloadResponses>(resp.body())?;
             match msg {
                 DownloadResponses::Success => Ok((StatusCode::OK, None, vec![])),
-                DownloadResponses::Error(e) => Err(anyhow::anyhow!("Error removing file: {:?}", e)),
+                DownloadResponses::Err(e) => Err(anyhow::anyhow!("Error removing file: {:?}", e)),
                 _ => Err(anyhow::anyhow!(
                     "Invalid response from downloads: {:?}",
                     msg
@@ -610,7 +606,7 @@ fn serve_paths(
             match msg {
                 ChainResponses::AutoUpdateStarted
                 | ChainResponses::AutoUpdateStopped
-                | ChainResponses::Error(_) => Ok((StatusCode::OK, None, serde_json::to_vec(&msg)?)),
+                | ChainResponses::Err(_) => Ok((StatusCode::OK, None, serde_json::to_vec(&msg)?)),
                 _ => Ok((
                     StatusCode::INTERNAL_SERVER_ERROR,
                     None,

--- a/kinode/packages/app_store/app_store/src/lib.rs
+++ b/kinode/packages/app_store/app_store/src/lib.rs
@@ -74,25 +74,11 @@ fn init(our: Address) {
     loop {
         match await_message() {
             Err(send_error) => {
-                // TODO: handle these more gracefully so only real send errors are printed
-                // // for now, these are timer callbacks to already finished ft_workers.
-                // print_to_terminal(1, &format!("got network error: {send_error}"));
-
-                let error_message = format!("got network error: {send_error}");
-                println!("{error_message}");
-                Response::new()
-                    .body(AppStoreResponse::SendError(error_message))
-                    .send()
-                    .unwrap();
+                print_to_terminal(1, &format!("main: got network error: {send_error}"));
             }
             Ok(message) => {
                 if let Err(e) = handle_message(&our, &mut state, &mut http_server, &message) {
-                    let error_message = format!("error handling message: {e:?}");
-                    println!("{error_message}");
-                    Response::new()
-                        .body(AppStoreResponse::HandlingError(error_message))
-                        .send()
-                        .unwrap();
+                    print_to_terminal(1, &format!("main: error handling message: {e:?}"));
                 }
             }
         }

--- a/kinode/packages/app_store/app_store/src/lib.rs
+++ b/kinode/packages/app_store/app_store/src/lib.rs
@@ -20,8 +20,8 @@ use crate::kinode::process::downloads::{
     DownloadCompleteRequest, DownloadResponses, ProgressUpdate,
 };
 use crate::kinode::process::main::{
-    ApisResponse, GetApiResponse, HandlingError, InstallPackageRequest, InstallResponse,
-    LocalRequest, LocalResponse, NewPackageRequest, NewPackageResponse, SendError,
+    ApisResponse, GetApiResponse, InstallPackageRequest, InstallResponse, LocalRequest,
+    LocalResponse, NewPackageRequest, NewPackageResponse, Response as AppStoreResponse,
     UninstallResponse,
 };
 use kinode_process_lib::{
@@ -35,7 +35,7 @@ wit_bindgen::generate!({
     path: "target/wit",
     generate_unused_types: true,
     world: "app-store-sys-v1",
-    additional_derives: [serde::Deserialize, serde::Serialize],
+    additional_derives: [serde::Deserialize, serde::Serialize, process_macros::SerdeJsonInto],
 });
 
 mod http_api;
@@ -46,7 +46,7 @@ const VFS_TIMEOUT: u64 = 10;
 
 // internal types
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, process_macros::SerdeJsonInto)]
 #[serde(untagged)] // untagged as a meta-type for all incoming requests
 pub enum Req {
     LocalRequest(LocalRequest),
@@ -55,7 +55,7 @@ pub enum Req {
     Http(http::server::HttpServerRequest),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, process_macros::SerdeJsonInto)]
 #[serde(untagged)] // untagged as a meta-type for all incoming responses
 pub enum Resp {
     LocalResponse(LocalResponse),
@@ -80,14 +80,19 @@ fn init(our: Address) {
 
                 let error_message = format!("got network error: {send_error}");
                 println!("{error_message}");
-                let response = Response::new().body(serde_json::to_vec(SendError(error_message))?);
+                Response::new()
+                    .body(AppStoreResponse::SendError(error_message))
+                    .send()
+                    .unwrap();
             }
             Ok(message) => {
                 if let Err(e) = handle_message(&our, &mut state, &mut http_server, &message) {
                     let error_message = format!("error handling message: {e:?}");
                     println!("{error_message}");
-                    let response =
-                        Response::new().body(serde_json::to_vec(HandlingError(error_message))?);
+                    Response::new()
+                        .body(AppStoreResponse::HandlingError(error_message))
+                        .send()
+                        .unwrap();
                 }
             }
         }
@@ -105,13 +110,13 @@ fn handle_message(
     message: &Message,
 ) -> anyhow::Result<()> {
     if message.is_request() {
-        match serde_json::from_slice::<Req>(message.body())? {
+        match message.body().try_into()? {
             Req::LocalRequest(local_request) => {
                 if !message.is_local(our) {
                     return Err(anyhow::anyhow!("request from non-local node"));
                 }
                 let (body, blob) = handle_local_request(our, state, local_request);
-                let response = Response::new().body(serde_json::to_vec(&body)?);
+                let response = Response::new().body(&body);
                 if let Some(blob) = blob {
                     response.blob(blob).send()?;
                 } else {
@@ -139,7 +144,7 @@ fn handle_message(
                     http::server::WsMessageType::Text,
                     LazyLoadBlob {
                         mime: Some("application/json".to_string()),
-                        bytes: serde_json::json!({
+                        bytes: serde_json::to_vec(&serde_json::json!({
                             "kind": "progress",
                             "data": {
                                 "package_id": progress.package_id,
@@ -147,10 +152,8 @@ fn handle_message(
                                 "downloaded": progress.downloaded,
                                 "total": progress.total,
                             }
-                        })
-                        .to_string()
-                        .as_bytes()
-                        .to_vec(),
+                        }))
+                        .unwrap(),
                     },
                 );
             }
@@ -164,17 +167,15 @@ fn handle_message(
                     http::server::WsMessageType::Text,
                     LazyLoadBlob {
                         mime: Some("application/json".to_string()),
-                        bytes: serde_json::json!({
+                        bytes: serde_json::to_vec(&serde_json::json!({
                             "kind": "complete",
                             "data": {
                                 "package_id": req.package_id,
                                 "version_hash": req.version_hash,
-                                "error": req.error,
+                                "error": req.err,
                             }
-                        })
-                        .to_string()
-                        .as_bytes()
-                        .to_vec(),
+                        }))
+                        .unwrap(),
                     },
                 );
 
@@ -215,7 +216,7 @@ fn handle_message(
             }
         }
     } else {
-        match serde_json::from_slice::<Resp>(message.body())? {
+        match message.body().try_into()? {
             Resp::LocalResponse(_) => {
                 // don't need to handle these at the moment
             }

--- a/kinode/packages/app_store/app_store/src/lib.rs
+++ b/kinode/packages/app_store/app_store/src/lib.rs
@@ -78,7 +78,12 @@ fn init(our: Address) {
             }
             Ok(message) => {
                 if let Err(e) = handle_message(&our, &mut state, &mut http_server, &message) {
-                    print_to_terminal(1, &format!("main: error handling message: {e:?}"));
+                    let error_message = format!("error handling message: {e:?}");
+                    print_to_terminal(1, &error_message);
+                    Response::new()
+                        .body(AppStoreResponse::HandlingError(error_message))
+                        .send()
+                        .unwrap();
                 }
             }
         }

--- a/kinode/packages/app_store/app_store/src/utils.rs
+++ b/kinode/packages/app_store/app_store/src/utils.rs
@@ -114,7 +114,7 @@ pub fn new_package(
 
     let download_resp = serde_json::from_slice::<DownloadResponses>(&resp.body())?;
 
-    if let DownloadResponses::Error(e) = download_resp {
+    if let DownloadResponses::Err(e) = download_resp {
         return Err(anyhow::anyhow!("failed to add download: {:?}", e));
     }
     Ok(())

--- a/kinode/packages/app_store/chain/Cargo.toml
+++ b/kinode/packages/app_store/chain/Cargo.toml
@@ -12,6 +12,7 @@ alloy-sol-types = "0.7.6"
 anyhow = "1.0"
 bincode = "1.3.3"
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.9.0" }
+process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/kinode/packages/app_store/chain/src/lib.rs
+++ b/kinode/packages/app_store/chain/src/lib.rs
@@ -91,11 +91,11 @@ fn init(our: Address) {
     loop {
         match await_message() {
             Err(send_error) => {
-                print_to_terminal(1, &format!("got network error: {send_error}"));
+                print_to_terminal(1, &format!("chain: got network error: {send_error}"));
             }
             Ok(message) => {
                 if let Err(e) = handle_message(&our, &mut state, &message) {
-                    print_to_terminal(1, &format!("error handling message: {:?}", e));
+                    print_to_terminal(1, &format!("chain: error handling message: {:?}", e));
                 }
             }
         }

--- a/kinode/packages/app_store/chain/src/lib.rs
+++ b/kinode/packages/app_store/chain/src/lib.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 wit_bindgen::generate!({
     path: "target/wit",
     generate_unused_types: true,
-    world: "app-store-sys-v0",
+    world: "app-store-sys-v1",
     additional_derives: [serde::Deserialize, serde::Serialize],
 });
 

--- a/kinode/packages/app_store/download/Cargo.toml
+++ b/kinode/packages/app_store/download/Cargo.toml
@@ -9,6 +9,7 @@ simulation-mode = []
 [dependencies]
 anyhow = "1.0"
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.9.0" }
+process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = "0.24.0"

--- a/kinode/packages/app_store/download/src/lib.rs
+++ b/kinode/packages/app_store/download/src/lib.rs
@@ -7,7 +7,7 @@ use kinode_process_lib::{
 wit_bindgen::generate!({
     path: "target/wit",
     generate_unused_types: true,
-    world: "app-store-sys-v0",
+    world: "app-store-sys-v1",
     additional_derives: [PartialEq, serde::Deserialize, serde::Serialize],
 });
 

--- a/kinode/packages/app_store/downloads/Cargo.toml
+++ b/kinode/packages/app_store/downloads/Cargo.toml
@@ -9,6 +9,7 @@ simulation-mode = []
 [dependencies]
 anyhow = "1.0"
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "1c495ad" }
+process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/kinode/packages/app_store/downloads/src/lib.rs
+++ b/kinode/packages/app_store/downloads/src/lib.rs
@@ -83,7 +83,7 @@ fn init(our: Address) {
     loop {
         match await_message() {
             Err(send_error) => {
-                print_to_terminal(1, &format!("got network error: {send_error}"));
+                print_to_terminal(1, &format!("downloads: got network error: {send_error}"));
             }
             Ok(message) => {
                 if let Err(e) = handle_message(
@@ -94,7 +94,7 @@ fn init(our: Address) {
                     &mut tmp,
                     &mut auto_updates,
                 ) {
-                    print_to_terminal(1, &format!("error handling message: {:?}", e));
+                    print_to_terminal(1, &format!("downloads: error handling message: {:?}", e));
                 }
             }
         }

--- a/kinode/packages/app_store/downloads/src/lib.rs
+++ b/kinode/packages/app_store/downloads/src/lib.rs
@@ -94,7 +94,14 @@ fn init(our: Address) {
                     &mut tmp,
                     &mut auto_updates,
                 ) {
-                    print_to_terminal(1, &format!("downloads: error handling message: {:?}", e));
+                    let error_message = format!("error handling message: {e:?}");
+                    print_to_terminal(1, &error_message);
+                    Response::new()
+                        .body(DownloadResponses::Err(DownloadError::HandlingError(
+                            error_message,
+                        )))
+                        .send()
+                        .unwrap();
                 }
             }
         }

--- a/kinode/packages/app_store/downloads/src/lib.rs
+++ b/kinode/packages/app_store/downloads/src/lib.rs
@@ -23,7 +23,7 @@ use sha2::{Digest, Sha256};
 wit_bindgen::generate!({
     path: "target/wit",
     generate_unused_types: true,
-    world: "app-store-sys-v0",
+    world: "app-store-sys-v1",
     additional_derives: [serde::Deserialize, serde::Serialize],
 });
 

--- a/kinode/packages/app_store/downloads/src/lib.rs
+++ b/kinode/packages/app_store/downloads/src/lib.rs
@@ -24,7 +24,7 @@ wit_bindgen::generate!({
     path: "target/wit",
     generate_unused_types: true,
     world: "app-store-sys-v1",
-    additional_derives: [serde::Deserialize, serde::Serialize],
+    additional_derives: [serde::Deserialize, serde::Serialize, process_macros::SerdeJsonInto],
 });
 
 mod ft_worker_lib;
@@ -32,7 +32,7 @@ mod ft_worker_lib;
 pub const VFS_TIMEOUT: u64 = 5; // 5s
 pub const APP_SHARE_TIMEOUT: u64 = 120; // 120s
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, process_macros::SerdeJsonInto)]
 #[serde(untagged)] // untagged as a meta-type for all incoming responses
 pub enum Resp {
     Download(DownloadResponses),
@@ -114,7 +114,7 @@ fn handle_message(
     auto_updates: &mut HashSet<(PackageId, String)>,
 ) -> anyhow::Result<()> {
     if message.is_request() {
-        match serde_json::from_slice::<DownloadRequests>(message.body())? {
+        match message.body().try_into()? {
             DownloadRequests::LocalDownload(download_request) => {
                 // we want to download a package.
                 if !message.is_local(our) {
@@ -158,13 +158,11 @@ fn handle_message(
                 )?;
 
                 Request::to((&download_from, "downloads", "app_store", "sys"))
-                    .body(serde_json::to_vec(&DownloadRequests::RemoteDownload(
-                        RemoteDownloadRequest {
-                            package_id,
-                            desired_version_hash,
-                            worker_address: our_worker.to_string(),
-                        },
-                    ))?)
+                    .body(DownloadRequests::RemoteDownload(RemoteDownloadRequest {
+                        package_id,
+                        desired_version_hash,
+                        worker_address: our_worker.to_string(),
+                    }))
                     .send()?;
             }
             DownloadRequests::RemoteDownload(download_request) => {
@@ -187,11 +185,11 @@ fn handle_message(
                     &target_worker,
                 )?;
             }
-            DownloadRequests::Progress(progress) => {
+            DownloadRequests::Progress(ref progress) => {
                 // forward progress to main:app_store:sys,
                 // pushed to UI via websockets
                 let _ = Request::to(("our", "main", "app_store", "sys"))
-                    .body(serde_json::to_vec(&progress)?)
+                    .body(progress)
                     .send();
             }
             DownloadRequests::DownloadComplete(req) => {
@@ -253,7 +251,7 @@ fn handle_message(
 
                 let resp = DownloadResponses::GetFiles(files);
 
-                Response::new().body(serde_json::to_string(&resp)?).send()?;
+                Response::new().body(&resp).send()?;
             }
             DownloadRequests::RemoveFile(remove_req) => {
                 if !message.is_local(our) {
@@ -273,9 +271,7 @@ fn handle_message(
                 let manifest_path = format!("{}/{}.json", package_dir, version_hash);
                 let _ = vfs::remove_file(&manifest_path, None);
                 Response::new()
-                    .body(serde_json::to_vec(&Resp::Download(
-                        DownloadResponses::Success,
-                    ))?)
+                    .body(Resp::Download(DownloadResponses::Success))
                     .send()?;
             }
             DownloadRequests::AddDownload(add_req) => {
@@ -310,9 +306,7 @@ fn handle_message(
                 }
 
                 Response::new()
-                    .body(serde_json::to_vec(&Resp::Download(
-                        DownloadResponses::Success,
-                    ))?)
+                    .body(Resp::Download(DownloadResponses::Success))
                     .send()?;
             }
             DownloadRequests::StartMirroring(package_id) => {
@@ -320,9 +314,7 @@ fn handle_message(
                 state.mirroring.insert(package_id);
                 set_state(&serde_json::to_vec(&state)?);
                 Response::new()
-                    .body(serde_json::to_vec(&Resp::Download(
-                        DownloadResponses::Success,
-                    ))?)
+                    .body(Resp::Download(DownloadResponses::Success))
                     .send()?;
             }
             DownloadRequests::StopMirroring(package_id) => {
@@ -330,9 +322,7 @@ fn handle_message(
                 state.mirroring.remove(&package_id);
                 set_state(&serde_json::to_vec(&state)?);
                 Response::new()
-                    .body(serde_json::to_vec(&Resp::Download(
-                        DownloadResponses::Success,
-                    ))?)
+                    .body(Resp::Download(DownloadResponses::Success))
                     .send()?;
             }
             DownloadRequests::AutoUpdate(auto_update_request) => {
@@ -369,9 +359,7 @@ fn handle_message(
 
                 // kick off local download to ourselves.
                 Request::to(("our", "downloads", "app_store", "sys"))
-                    .body(serde_json::to_vec(&DownloadRequests::LocalDownload(
-                        download_request,
-                    ))?)
+                    .body(DownloadRequests::LocalDownload(download_request))
                     .send()?;
 
                 auto_updates.insert((process_lib_package_id, version_hash));
@@ -379,7 +367,7 @@ fn handle_message(
             _ => {}
         }
     } else {
-        match serde_json::from_slice::<Resp>(message.body())? {
+        match message.body().try_into()? {
             Resp::Download(download_response) => {
                 // these are handled in line.
                 print_to_terminal(
@@ -403,13 +391,13 @@ fn handle_message(
                                 &format!("error handling http_client response: {:?}", e),
                             );
                             Request::to(("our", "main", "app_store", "sys"))
-                                .body(serde_json::to_vec(&DownloadRequests::DownloadComplete(
+                                .body(DownloadRequests::DownloadComplete(
                                     DownloadCompleteRequest {
                                         package_id: download_request.package_id.clone(),
                                         version_hash: download_request.desired_version_hash.clone(),
-                                        error: Some(e),
+                                        err: Some(e),
                                     },
-                                ))?)
+                                ))
                                 .send()?;
                         }
                     }
@@ -462,14 +450,11 @@ fn handle_receive_http_download(
     extract_and_write_manifest(&bytes, &manifest_path).map_err(|_| DownloadError::VfsError)?;
 
     Request::to(("our", "main", "app_store", "sys"))
-        .body(
-            serde_json::to_vec(&DownloadCompleteRequest {
-                package_id: download_request.package_id.clone(),
-                version_hash,
-                error: None,
-            })
-            .unwrap(),
-        )
+        .body(DownloadCompleteRequest {
+            package_id: download_request.package_id.clone(),
+            version_hash,
+            err: None,
+        })
         .send()
         .unwrap();
 

--- a/kinode/packages/app_store/ft_worker/Cargo.toml
+++ b/kinode/packages/app_store/ft_worker/Cargo.toml
@@ -10,6 +10,7 @@ simulation-mode = []
 anyhow = "1.0"
 bincode = "1.3.3"
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "1c495ad" }
+process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/kinode/packages/app_store/ft_worker/src/lib.rs
+++ b/kinode/packages/app_store/ft_worker/src/lib.rs
@@ -16,7 +16,7 @@ pub mod ft_worker_lib;
 wit_bindgen::generate!({
     path: "target/wit",
     generate_unused_types: true,
-    world: "app-store-sys-v0",
+    world: "app-store-sys-v1",
     additional_derives: [serde::Deserialize, serde::Serialize],
 });
 

--- a/kinode/packages/app_store/install/Cargo.toml
+++ b/kinode/packages/app_store/install/Cargo.toml
@@ -9,6 +9,7 @@ simulation-mode = []
 [dependencies]
 anyhow = "1.0"
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.9.0" }
+process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = "0.24.0"

--- a/kinode/packages/app_store/install/src/lib.rs
+++ b/kinode/packages/app_store/install/src/lib.rs
@@ -8,7 +8,7 @@ use kinode_process_lib::{
 wit_bindgen::generate!({
     path: "target/wit",
     generate_unused_types: true,
-    world: "app-store-sys-v0",
+    world: "app-store-sys-v1",
     additional_derives: [PartialEq, serde::Deserialize, serde::Serialize],
 });
 

--- a/kinode/packages/app_store/uninstall/Cargo.toml
+++ b/kinode/packages/app_store/uninstall/Cargo.toml
@@ -9,6 +9,7 @@ simulation-mode = []
 [dependencies]
 anyhow = "1.0"
 kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", tag = "v0.9.0" }
+process_macros = { git = "https://github.com/kinode-dao/process_macros", rev = "626e501" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = "0.24.0"

--- a/kinode/packages/app_store/uninstall/src/lib.rs
+++ b/kinode/packages/app_store/uninstall/src/lib.rs
@@ -7,7 +7,7 @@ wit_bindgen::generate!({
     path: "target/wit",
     generate_unused_types: true,
     world: "app-store-sys-v1",
-    additional_derives: [PartialEq, serde::Deserialize, serde::Serialize],
+    additional_derives: [PartialEq, serde::Deserialize, serde::Serialize, process_macros::SerdeJsonInto],
 });
 
 call_init!(init);
@@ -33,22 +33,19 @@ fn init(our: Address) {
 
     let Ok(Ok(Message::Response { body, .. })) =
         Request::to((our.node(), ("main", "app_store", "sys")))
-            .body(
-                serde_json::to_vec(&LocalRequest::Uninstall(
-                    crate::kinode::process::main::PackageId {
-                        package_name: package_id.package_name.clone(),
-                        publisher_node: package_id.publisher_node.clone(),
-                    },
-                ))
-                .unwrap(),
-            )
+            .body(LocalRequest::Uninstall(
+                crate::kinode::process::main::PackageId {
+                    package_name: package_id.package_name.clone(),
+                    publisher_node: package_id.publisher_node.clone(),
+                },
+            ))
             .send_and_await_response(5)
     else {
         println!("uninstall: failed to get a response from app_store..!");
         return;
     };
 
-    let Ok(response) = serde_json::from_slice::<LocalResponse>(&body) else {
+    let Ok(response) = body.try_into() else {
         println!("uninstall: failed to parse response from app_store..!");
         return;
     };

--- a/kinode/packages/app_store/uninstall/src/lib.rs
+++ b/kinode/packages/app_store/uninstall/src/lib.rs
@@ -6,7 +6,7 @@ use kinode_process_lib::{
 wit_bindgen::generate!({
     path: "target/wit",
     generate_unused_types: true,
-    world: "app-store-sys-v0",
+    world: "app-store-sys-v1",
     additional_derives: [PartialEq, serde::Deserialize, serde::Serialize],
 });
 

--- a/kinode/packages/chess/Cargo.toml
+++ b/kinode/packages/chess/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+resolver = "2"
+members = [
+    "chess",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/kinode/packages/homepage/Cargo.toml
+++ b/kinode/packages/homepage/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+resolver = "2"
+members = [
+    "homepage",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/kinode/packages/kino_updates/Cargo.toml
+++ b/kinode/packages/kino_updates/Cargo.toml
@@ -1,0 +1,11 @@
+[workspace]
+resolver = "2"
+members = [
+    "blog",
+    "globe",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/kinode/packages/kns_indexer/Cargo.toml
+++ b/kinode/packages/kns_indexer/Cargo.toml
@@ -1,0 +1,12 @@
+[workspace]
+resolver = "2"
+members = [
+    "get_block",
+    "kns_indexer",
+    "state",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/kinode/packages/settings/Cargo.toml
+++ b/kinode/packages/settings/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+resolver = "2"
+members = [
+    "settings",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/kinode/packages/terminal/Cargo.toml
+++ b/kinode/packages/terminal/Cargo.toml
@@ -9,7 +9,6 @@ members = [
     "kfetch",
     "kill",
     "m",
-    "namehash_to_name",
     "net_diagnostics",
     "peer",
     "peers",

--- a/kinode/packages/terminal/Cargo.toml
+++ b/kinode/packages/terminal/Cargo.toml
@@ -1,0 +1,23 @@
+[workspace]
+resolver = "2"
+members = [
+    "alias",
+    "cat",
+    "echo",
+    "help",
+    "hi",
+    "kfetch",
+    "kill",
+    "m",
+    "namehash_to_name",
+    "net_diagnostics",
+    "peer",
+    "peers",
+    "terminal",
+    "top",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/kinode/packages/tester/Cargo.toml
+++ b/kinode/packages/tester/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+resolver = "2"
+members = [
+    "tester",
+]
+
+[profile.release]
+panic = "abort"
+opt-level = "s"
+lto = true

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -1556,7 +1556,7 @@ pub struct Erc721Properties {
     pub screenshots: Option<Vec<String>>,
     pub wit_version: Option<u32>,
     pub dependencies: Option<Vec<String>>,
-    pub api_includes: Option<Vec<PathBuf>>,
+    pub api_includes: Option<Vec<std::path::PathBuf>>,
 }
 
 /// the type that gets deserialized from each entry in the array in `manifest.json`

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -1544,6 +1544,7 @@ pub struct Erc721Metadata {
 /// - `screenshots`: An optional field containing a list of URLs to screenshots of the package.
 /// - `wit_version`: An optional field containing the version of the WIT standard that the package adheres to.
 /// - `dependencies`: An optional field containing a list of `PackageId`s: API dependencies.
+/// - `api_includes`: An optional field containing a list of `PathBuf`s: additional files to include in the `api.zip`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Erc721Properties {
     pub package_name: String,
@@ -1555,6 +1556,7 @@ pub struct Erc721Properties {
     pub screenshots: Option<Vec<String>>,
     pub wit_version: Option<u32>,
     pub dependencies: Option<Vec<String>>,
+    pub api_includes: Option<Vec<PathBuf>>,
 }
 
 /// the type that gets deserialized from each entry in the array in `manifest.json`


### PR DESCRIPTION
## Problem

1. app_store can error without sending a response, which can hang, e.g., `kit`
2. app_store doesn't make use of process_macros

## Solution

1. Add HandlingError & SendError variants
2. Use process_macros

## Testing

```
# Get `kit` https://github.com/kinode-dao/kit/pull/221/commits/f9f9ce8b056d9412e91f9401d2d32c56eb8699e2 or earlier
cargo install --git https://github.com/kinode-dao/kit --rev f9f9ce8

# Start a package & then remove it
kit n chat
kit b chat
kit s chat
kit r chat
```

`kit r` hangs because[ f9f9ce8](https://github.com/kinode-dao/kit/pull/221/commits/f9f9ce8b056d9412e91f9401d2d32c56eb8699e2) and earlier had a bug and app_store does not issue a Response and so HTTP server never issues an HTTP Response and so `kit` hangs.

## Docs Update

None

## Notes

process_macros required some reworking of variant names. Rust compiler got mad about `::Error` variants alongside [the `TryFrom` `type Error` definitions in process_macros (whcih are required for TryFrom)](https://github.com/kinode-dao/process_macros/blob/master/src/lib.rs#L24). Solved by changing `::Error` variant names to `::Err`. We should probably document this somewhere.