### PR TITLE
terminal: dont crash if no size

### DIFF
--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -52,7 +52,7 @@ pub async fn terminal(
 ) -> anyhow::Result<()> {
     let (stdout, _maybe_raw_mode) = utils::startup(&our, version, is_detached)?;
 
-    let (win_cols, win_rows) = crossterm::terminal::size().expect("terminal: couldn't fetch size");
+    let (win_cols, win_rows) = crossterm::terminal::size().unwrap_or_else(|_| (0, 0));
 
     let current_line = format!("{} > ", our.name);
     let prompt_len: usize = our.name.len() + 3;

--- a/kinode/src/terminal/utils.rs
+++ b/kinode/src/terminal/utils.rs
@@ -36,7 +36,7 @@ pub fn startup(
         crossterm::terminal::SetTitle(format!("kinode {}", our.name))
     )?;
 
-    let (win_cols, _) = crossterm::terminal::size().expect("terminal: couldn't fetch size");
+    let (win_cols, _) = crossterm::terminal::size().unwrap_or_else(|_| (0, 0));
 
     // print initial splash screen, large if there's room, small otherwise
     if win_cols >= 90 {

--- a/kinode/src/terminal/utils.rs
+++ b/kinode/src/terminal/utils.rs
@@ -323,5 +323,9 @@ pub fn truncate_in_place(
     if end > s.len() {
         return s.to_string();
     }
-    prompt.to_string() + &s[(prompt_len + line_col - cursor_col as usize)..end]
+    let start = prompt_len + line_col - cursor_col as usize;
+    if start >= end {
+        return prompt.to_string();
+    }
+    prompt.to_string() + &s[start..end]
 }


### PR DESCRIPTION
## Problem

Terminal crashes Kinode core when running in CI workflow

![image](https://github.com/user-attachments/assets/013b2e95-8a5f-4270-a7b7-ae7111edc37a)


## Solution

Don't crash.

## Testing

It builds; haven't tested in CI yet.

## Docs Update

None

## Notes

None