### PR TITLE
make docs app serve http dynamically

### DIFF
--- a/kinode/packages/docs/docs/src/lib.rs
+++ b/kinode/packages/docs/docs/src/lib.rs
@@ -1,8 +1,5 @@
 use kinode_process_lib::{
-    await_message, call_init,
-    homepage::add_to_homepage,
-    http::server::{HttpBindingConfig, HttpServer},
-    println, Address,
+    await_message, call_init, homepage, http, println, vfs, Address, LazyLoadBlob,
 };
 
 wit_bindgen::generate!({
@@ -16,17 +13,82 @@ call_init!(init);
 fn init(our: Address) {
     println!("begin");
 
-    let mut server = HttpServer::new(5);
+    let mut server = http::server::HttpServer::new(5);
+    // Serve the docs book dynamically from /docs:docs:sys/
     server
-        .serve_ui(&our, "ui", vec!["/"], HttpBindingConfig::default())
-        .unwrap();
+        .bind_http_path("/", http::server::HttpBindingConfig::default())
+        .expect("failed to bind /");
 
-    add_to_homepage("Docs", Some(ICON), Some("index.html"), None);
+    homepage::add_to_homepage("Docs", Some(ICON), Some("index.html"), None);
 
     loop {
         match await_message() {
             Err(send_error) => println!("got SendError: {send_error}"),
-            Ok(ref _message) => println!("got message"),
+            Ok(ref message) => {
+                // handle http requests
+                // no need to validate source since capabilities limit to vfs/http_server
+                let Ok(request) = server.parse_request(message.body()) else {
+                    continue;
+                };
+
+                server.handle_request(
+                    request,
+                    |incoming| {
+                        // client frontend sent an HTTP request, process it and
+                        // return an HTTP response
+                        // these functions can reuse the logic from handle_local_request
+                        // after converting the request into the appropriate format!
+                        match incoming.method().unwrap_or_default() {
+                            http::Method::GET => {
+                                // serve the page they requested
+                                match vfs::File::new(
+                                    format!(
+                                        "{}/pkg/ui{}",
+                                        our.package_id(),
+                                        incoming.path().unwrap_or_default()
+                                    ),
+                                    5,
+                                )
+                                .read()
+                                {
+                                    Ok(file) => {
+                                        let mime_type = format!(
+                                            "text/{}",
+                                            incoming
+                                                .path()
+                                                .unwrap_or_default()
+                                                .split('.')
+                                                .last()
+                                                .unwrap_or("plain")
+                                        );
+                                        (
+                                            http::server::HttpResponse::new(http::StatusCode::OK)
+                                                .header("Content-Type", mime_type),
+                                            Some(LazyLoadBlob::new(None::<String>, file)),
+                                        )
+                                    }
+                                    Err(e) => (
+                                        http::server::HttpResponse::new(
+                                            http::StatusCode::NOT_FOUND,
+                                        )
+                                        .header("Content-Type", "text/html"),
+                                        Some(LazyLoadBlob::new(None::<String>, e.to_string())),
+                                    ),
+                                }
+                            }
+                            _ => (
+                                http::server::HttpResponse::new(
+                                    http::StatusCode::METHOD_NOT_ALLOWED,
+                                ),
+                                None,
+                            ),
+                        }
+                    },
+                    |_channel_id, _message_type, _message| {
+                        // client frontend sent a websocket message, ignore
+                    },
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

Docs app was making a ton of static bindings, leading to startup-cruft and excess memory usage (not truly an issue, but this way is *cleaner*)

## Solution

Dynamically serve docs as HTTP requests occur

## Testing

Use the app!

## Docs Update
N/A
## Notes
N/A