### PR TITLE
add logging

### DIFF
--- a/kinode/src/kernel/process.rs
+++ b/kinode/src/kernel/process.rs
@@ -102,11 +102,8 @@ async fn make_table_and_wasi(
         ("LOGDIR", format!("{}/log", path_prefix)),
     ] {
         // TODO make guarantees about this
-        if let Ok(Ok(())) = tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            fs::create_dir_all(&path),
-        )
-        .await
+        if let Ok(Ok(())) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), fs::create_dir_all(&path)).await
         {
             if let Ok(wasi_tempdir) =
                 Dir::open_ambient_dir(path.clone(), wasi_common::sync::ambient_authority())


### PR DESCRIPTION
## Problem

It would be nice to have logging for processes.

## Solution

Implement some helper functions for `tracing` to make it easy to log.

## Testing

TODO

## Docs Update

TODO

## Notes

Connected to https://github.com/kinode-dao/process_lib/pull/96

Note that this PR is not strictly necessary. The entirety of changes could be in userspace if instead of using WASI to write to the `.log` file we used the vfs:

https://github.com/kinode-dao/process_lib/blob/acc4a67b594d3042c4cc66157b6cce397d73ac77/src/logging.rs#L28-L40

Considering making the change.