### PR TITLE
kernel: output import/export errors

### DIFF
--- a/kinode/src/kernel/process.rs
+++ b/kinode/src/kernel/process.rs
@@ -285,12 +285,17 @@ pub async fn make_process_loop(
                         .send(&send_to_terminal)
                         .await;
                 }
-                Err(_) => {
+                Err(e) => {
                     let stderr = wasi_stderr.contents().into();
                     let stderr = String::from_utf8(stderr)?;
+                    let output = if stderr != String::new() {
+                        stderr
+                    } else {
+                        format!("{}", e.root_cause())
+                    };
                     t::Printout::new(
                         0,
-                        format!("\x1b[38;5;196mprocess {our} ended with error:\x1b[0m\n{stderr}",),
+                        format!("\x1b[38;5;196mprocess {our} ended with error:\x1b[0m\n{output}"),
                     )
                     .send(&send_to_terminal)
                     .await;
@@ -313,12 +318,17 @@ pub async fn make_process_loop(
                         .send(&send_to_terminal)
                         .await;
                 }
-                Err(_) => {
+                Err(e) => {
                     let stderr = wasi_stderr.contents().into();
                     let stderr = String::from_utf8(stderr)?;
+                    let output = if stderr != String::new() {
+                        stderr
+                    } else {
+                        format!("{}", e.root_cause())
+                    };
                     t::Printout::new(
                         0,
-                        format!("\x1b[38;5;196mprocess {our} ended with error:\x1b[0m\n{stderr}",),
+                        format!("\x1b[38;5;196mprocess {our} ended with error:\x1b[0m\n{output}"),
                     )
                     .send(&send_to_terminal)
                     .await;

--- a/kinode/src/kernel/process.rs
+++ b/kinode/src/kernel/process.rs
@@ -288,7 +288,7 @@ pub async fn make_process_loop(
                 Err(e) => {
                     let stderr = wasi_stderr.contents().into();
                     let stderr = String::from_utf8(stderr)?;
-                    let output = if stderr != String::new() {
+                    let output = if !stderr.is_empty() {
                         stderr
                     } else {
                         format!("{}", e.root_cause())

--- a/kinode/src/kernel/standard_host.rs
+++ b/kinode/src/kernel/standard_host.rs
@@ -402,6 +402,12 @@ async fn send_and_await_response(
             process.process.metadata.our.process
         ));
     }
+    if t::Address::de_wit(target.clone()) == process.process.metadata.our {
+        return Err(anyhow::anyhow!(
+            "kernel: got invalid send_and_await_response() Request from and to {:?}: cannot await a Request to `our`: will deadlock",
+            process.process.metadata.our.process
+        ));
+    }
     let id = process
         .process
         .send_request(source, target, request, None, blob)

--- a/kinode/src/kernel/standard_host.rs
+++ b/kinode/src/kernel/standard_host.rs
@@ -404,7 +404,7 @@ async fn send_and_await_response(
     }
     if t::Address::de_wit(target.clone()) == process.process.metadata.our {
         return Err(anyhow::anyhow!(
-            "kernel: got invalid send_and_await_response() Request from and to {:?}: cannot await a Request to `our`: will deadlock",
+            "kernel: got invalid send_and_await_response() Request from and to {}: cannot await a Request to `our`: will deadlock",
             process.process.metadata.our,
         ));
     }

--- a/kinode/src/kernel/standard_host.rs
+++ b/kinode/src/kernel/standard_host.rs
@@ -405,7 +405,7 @@ async fn send_and_await_response(
     if t::Address::de_wit(target.clone()) == process.process.metadata.our {
         return Err(anyhow::anyhow!(
             "kernel: got invalid send_and_await_response() Request from and to {:?}: cannot await a Request to `our`: will deadlock",
-            process.process.metadata.our.process
+            process.process.metadata.our,
         ));
     }
     let id = process

--- a/kinode/src/kernel/standard_host_v0.rs
+++ b/kinode/src/kernel/standard_host_v0.rs
@@ -409,6 +409,12 @@ async fn send_and_await_response(
             process.process.metadata.our.process
         ));
     }
+    if t::Address::de_wit_v0(target.clone()) == process.process.metadata.our {
+        return Err(anyhow::anyhow!(
+            "kernel: got invalid send_and_await_response() Request from and to {:?}: cannot await a Request to `our`: will deadlock",
+            process.process.metadata.our.process
+        ));
+    }
     let id = process
         .process
         .send_request_v0(source, target, request, None, blob)

--- a/kinode/src/kernel/standard_host_v0.rs
+++ b/kinode/src/kernel/standard_host_v0.rs
@@ -411,7 +411,7 @@ async fn send_and_await_response(
     }
     if t::Address::de_wit_v0(target.clone()) == process.process.metadata.our {
         return Err(anyhow::anyhow!(
-            "kernel: got invalid send_and_await_response() Request from and to {:?}: cannot await a Request to `our`: will deadlock",
+            "kernel: got invalid send_and_await_response() Request from and to {}: cannot await a Request to `our`: will deadlock",
             process.process.metadata.our,
         ));
     }

--- a/kinode/src/kernel/standard_host_v0.rs
+++ b/kinode/src/kernel/standard_host_v0.rs
@@ -412,7 +412,7 @@ async fn send_and_await_response(
     if t::Address::de_wit_v0(target.clone()) == process.process.metadata.our {
         return Err(anyhow::anyhow!(
             "kernel: got invalid send_and_await_response() Request from and to {:?}: cannot await a Request to `our`: will deadlock",
-            process.process.metadata.our.process
+            process.process.metadata.our,
         ));
     }
     let id = process


### PR DESCRIPTION
## Problem

1. Resolves #548
2. Kernel import/export errors not output

## Solution

1. Return helpful error if `target == our` for `send_and_await()`
2. If no `stderr` from process, print `call_init()`s error root cause

## Testing

Run a process that `send_and_await_response()`s to itself on master and here.

## Docs Update

None

## Notes

Error print looks like:
```
Wed 14:13 process diligence.os@hq:hq:uncentered.os ended with error:
kernel: got invalid send_and_await_response() Request from and to ProcessId { process_name: "hq", package_name: "hq", publisher_node: "uncentered.os" }: cannot await a Request to `our`: will deadlock
```