### PR TITLE
app store: only do work to populate apps once

### DIFF
--- a/kinode/packages/app_store/app_store/src/http_api.rs
+++ b/kinode/packages/app_store/app_store/src/http_api.rs
@@ -45,12 +45,7 @@ pub fn init_frontend(our: &Address, http_server: &mut server::HttpServer) {
             .expect("failed to bind http path");
     }
     http_server
-        .serve_ui(
-            &our,
-            "ui",
-            vec!["/", "/app/:id", "/publish", "/download/:id", "my-downloads"],
-            config.clone(),
-        )
+        .serve_ui(&our, "ui", vec!["/"], config.clone())
         .expect("failed to serve static UI");
 
     http_server

--- a/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
+++ b/kinode/packages/kns_indexer/kns_indexer/src/lib.rs
@@ -275,10 +275,10 @@ fn handle_pending_notes(
             for (note, attempt) in notes.drain(..) {
                 if attempt >= MAX_PENDING_ATTEMPTS {
                     // skip notes that have exceeded max attempts
-                    print_to_terminal(
-                        1,
-                        &format!("dropping note from block {block} after {attempt} attempts"),
-                    );
+                    // print_to_terminal(
+                    //     1,
+                    //     &format!("dropping note from block {block} after {attempt} attempts"),
+                    // );
                     continue;
                 }
                 if let Err(e) = handle_note(state, &note) {
@@ -288,10 +288,10 @@ fn handle_pending_notes(
                         }
                         Some(ee) => match ee {
                             KnsError::NoParentError => {
-                                print_to_terminal(
-                                    1,
-                                    &format!("note still awaiting mint; attempt {attempt}"),
-                                );
+                                // print_to_terminal(
+                                //     1,
+                                //     &format!("note still awaiting mint; attempt {attempt}"),
+                                // );
                                 keep_notes.push((note, attempt + 1));
                             }
                         },
@@ -439,10 +439,10 @@ fn handle_log(
             if let Err(e) = handle_note(state, &decoded) {
                 if let Some(KnsError::NoParentError) = e.downcast_ref::<KnsError>() {
                     if let Some(block_number) = log.block_number {
-                        print_to_terminal(
-                            1,
-                            &format!("adding note to pending_notes for block {block_number}"),
-                        );
+                        // print_to_terminal(
+                        //     1,
+                        //     &format!("adding note to pending_notes for block {block_number}"),
+                        // );
                         pending_notes
                             .entry(block_number)
                             .or_default()


### PR DESCRIPTION
## Problem

Currently the app store tries to fetch a bunch of metadata during initial log ingestion, leading to unnecessary errors

## Solution

Only fetch metadata if we are ingesting a log *after* the startup fetch. After the startup fetch, do another pass to fetch metadata for each listing once

## Testing

```
1. start node
2. check app store
```

## Docs Update

N/A

## Notes

I think we'll want to go back to storing some data on disk soon so we don't need to re-fetch logs on every boot. We've made things more robust since we removed caching.
