### PR TITLE
terminal: add log rotation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The `sys` publisher is not a real node ID, but it's also not a special case valu
 - CTRL+J to toggle debug mode
 - CTRL+S to step through events in debug mode
 
-- CTRL+L to toggle logging mode, which writes all terminal output to the `.terminal_log` file. Off by default, this will write all events and verbose prints with timestamps.
+- CTRL+L to toggle logging mode, which writes all terminal output to the `.terminal_log` file. On by default, this will write all events and verbose prints with timestamps.
 
 - CTRL+A to jump to beginning of input
 - CTRL+E to jump to end of input

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -78,7 +78,7 @@ async fn main() {
     let password = matches.get_one::<String>("password");
 
     // logging mode is toggled at runtime by CTRL+L
-    let is_logging = *matches.get_one::<bool>("logging").unwrap();
+    let is_logging = !*matches.get_one::<bool>("logging-off").unwrap();
 
     // detached determines whether terminal is interactive
     let detached = *matches.get_one::<bool>("detached").unwrap();
@@ -653,7 +653,7 @@ fn build_command() -> Command {
                 .value_parser(value_parser!(u8)),
         )
         .arg(
-            arg!(-l --logging <IS_LOGGING> "Run in logging mode (toggled at runtime by CTRL+L): write all terminal output to .terminal_log file")
+            arg!(-l --"logging-off" <IS_NOT_LOGGING> "Run in non-logging mode (toggled at runtime by CTRL+L): do not write all terminal output to file in .terminal_logs directory")
                 .action(clap::ArgAction::SetTrue),
         )
         .arg(

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -79,6 +79,8 @@ async fn main() {
 
     // logging mode is toggled at runtime by CTRL+L
     let is_logging = !*matches.get_one::<bool>("logging-off").unwrap();
+    let max_log_size = matches.get_one::<u64>("max-log-size");
+    let number_log_files = matches.get_one::<u64>("number-log-files");
 
     // detached determines whether terminal is interactive
     let detached = *matches.get_one::<bool>("detached").unwrap();
@@ -427,6 +429,8 @@ async fn main() {
             detached,
             verbose_mode,
             is_logging,
+            max_log_size.copied(),
+            number_log_files.copied(),
         ) => {
             match quit {
                 Ok(()) => {
@@ -666,7 +670,15 @@ fn build_command() -> Command {
                 .action(clap::ArgAction::SetTrue),
         )
         .arg(arg!(--rpc <RPC> "Add a WebSockets RPC URL at boot"))
-        .arg(arg!(--password <PASSWORD> "Node password (in double quotes)"));
+        .arg(arg!(--password <PASSWORD> "Node password (in double quotes)"))
+        .arg(
+            arg!(--"max-log-size" <MAX_LOG_SIZE_BYTES> "Max size of all logs in bytes; setting to 0 -> no size limit (default 16MB)")
+                .value_parser(value_parser!(u64)),
+        )
+        .arg(
+            arg!(--"number-log-files" <NUMBER_LOG_FILES> "Number of logs to rotate (default 4)")
+                .value_parser(value_parser!(u64)),
+        );
 
     #[cfg(feature = "simulation-mode")]
     let app = app

--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -182,6 +182,8 @@ pub async fn terminal(
     is_detached: bool,
     verbose_mode: u8,
     is_logging: bool,
+    max_log_size: Option<u64>,
+    number_log_files: Option<u64>,
 ) -> anyhow::Result<()> {
     let (stdout, _maybe_raw_mode) = utils::splash(&our, version, is_detached)?;
 
@@ -214,11 +216,11 @@ pub async fn terminal(
 
     // if CTRL+L is used to turn on logging, all prints to terminal
     // will also be written with their full timestamp to the .terminal_log file.
-    // logging mode is always off by default. TODO add a boot flag to change this.
+    // logging mode is always on by default
     let log_dir_path = std::fs::canonicalize(&home_directory_path)
         .expect("terminal: could not get path for .terminal_logs dir")
         .join(".terminal_logs");
-    let logger = utils::Logger::new(log_dir_path);
+    let logger = utils::Logger::new(log_dir_path, max_log_size, number_log_files);
 
     let mut state = State {
         stdout,

--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -22,8 +22,8 @@ pub mod utils;
 
 struct State {
     pub stdout: std::io::Stdout,
-    /// handle for writing to on-disk log (disabled by default, triggered by CTRL+L)
-    pub log_writer: BufWriter<std::fs::File>,
+    /// handle and settings for on-disk log (disabled by default, triggered by CTRL+L)
+    pub logger: Logger,
     /// in-memory searchable command history that persists itself on disk (default size: 1000)
     pub command_history: utils::CommandHistory,
     /// terminal window width, 0 is leftmost column
@@ -215,19 +215,14 @@ pub async fn terminal(
     // if CTRL+L is used to turn on logging, all prints to terminal
     // will also be written with their full timestamp to the .terminal_log file.
     // logging mode is always off by default. TODO add a boot flag to change this.
-    let log_path = std::fs::canonicalize(&home_directory_path)
-        .expect("terminal: could not get path for .terminal_log file")
-        .join(".terminal_log");
-    let log_handle = OpenOptions::new()
-        .append(true)
-        .create(true)
-        .open(&log_path)
-        .expect("terminal: could not open/create .terminal_log");
-    let log_writer = BufWriter::new(log_handle);
+    let log_dir_path = std::fs::canonicalize(&home_directory_path)
+        .expect("terminal: could not get path for .terminal_logs dir")
+        .join(".terminal_logs");
+    let logger = Logger::new();
 
     let mut state = State {
         stdout,
-        log_writer,
+        logger,
         command_history,
         win_cols,
         win_rows,
@@ -320,15 +315,9 @@ fn handle_printout(printout: Printout, state: &mut State) -> anyhow::Result<()> 
     // lock here so that runtime can still use println! without freezing..
     // can lock before loop later if we want to reduce overhead
     let mut stdout = state.stdout.lock();
-    let now = Local::now();
     // always write print to log if in logging mode
     if state.logging_mode {
-        writeln!(
-            state.log_writer,
-            "[{}] {}",
-            now.to_rfc2822(),
-            printout.content
-        )?;
+        state.logger.write(printout.content)?;
     }
     // skip writing print to terminal if it's of a greater
     // verbosity level than our current mode

--- a/kinode/src/terminal/utils.rs
+++ b/kinode/src/terminal/utils.rs
@@ -9,6 +9,9 @@ use std::{
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
+const DEFAULT_MAX_LOGS_BYTES: u64 = 16_000_000;
+const DEFAULT_NUMBER_LOG_FILES: u64 = 4;
+
 pub struct RawMode;
 impl RawMode {
     fn new() -> std::io::Result<Self> {
@@ -339,7 +342,7 @@ pub struct Logger {
     log_writer: BufWriter<std::fs::File>,
 }
 
-enum LoggerStrategy {
+pub enum LoggerStrategy {
     Rotating {
         max_log_dir_bytes: u64,
         number_log_files: u64,
@@ -350,8 +353,8 @@ enum LoggerStrategy {
 impl LoggerStrategy {
     fn default() -> Self {
         LoggerStrategy::Rotating {
-            max_log_dir_bytes: 1_000_000_000,
-            number_log_files: 4,
+            max_log_dir_bytes: DEFAULT_MAX_LOGS_BYTES,
+            number_log_files: DEFAULT_NUMBER_LOG_FILES,
         }
     }
 }


### PR DESCRIPTION
## Problem

Terminal log balloons infinitely

## Solution

Add log rotation by default. Default behavior is to have a maximum total log size of 1GB spread across 4 logs. When a new log is created, remove oldest log.

## Testing

```
# Create package that will loop prints to logs

kit n foo

# Edit to add
# `
# loop {
#     println!("lol");
# }
# `
vi foo/foo/src/lib.rs

# Run it
kit f -r ~/git/kinode

# Enable logging: Ctrl + L

# Install
kit bs foo
```

## Docs Update

TODO

## Notes

Context: https://discord.com/channels/1186394868336038080/1186421052071477428/1288173581083082793 and above

Should logging be on by default? I tend to think yes

Current settings are for 1GB total logs on disk split b/w four files