### PR TITLE
add `fd_manager` runtime module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,6 +3665,7 @@ dependencies = [
  "kit",
  "lazy_static",
  "lib",
+ "libc",
  "nohash-hasher",
  "open",
  "public-ip",

--- a/kinode/Cargo.toml
+++ b/kinode/Cargo.toml
@@ -62,6 +62,7 @@ indexmap = "2.4"
 jwt = "0.16"
 lib = { path = "../lib" }
 lazy_static = "1.4.0"
+libc = "0.2"
 nohash-hasher = "0.2.0"
 open = "5.1.4"
 public-ip = "0.2.2"

--- a/kinode/packages/app_store/app_store/src/http_api.rs
+++ b/kinode/packages/app_store/app_store/src/http_api.rs
@@ -474,7 +474,10 @@ fn serve_paths(
                 &our.node().to_string(),
             ) {
                 Ok(_) => {
-                    println!("successfully installed package: {:?}", process_package_id);
+                    println!(
+                        "successfully installed {}:{}",
+                        process_package_id.package_name, process_package_id.publisher_node
+                    );
                     Ok((StatusCode::CREATED, None, vec![]))
                 }
                 Err(e) => Ok((

--- a/kinode/packages/app_store/app_store/src/lib.rs
+++ b/kinode/packages/app_store/app_store/src/lib.rs
@@ -261,8 +261,8 @@ fn handle_local_request(
             match utils::install(&package_id, metadata, &version_hash, state, &our.node) {
                 Ok(()) => {
                     println!(
-                        "successfully installed package: {:?}",
-                        &package_id.to_process_lib()
+                        "successfully installed {}:{}",
+                        package_id.package_name, package_id.publisher_node
                     );
                     LocalResponse::InstallResponse(InstallResponse::Success)
                 }

--- a/kinode/packages/terminal/pkg/manifest.json
+++ b/kinode/packages/terminal/pkg/manifest.json
@@ -5,12 +5,7 @@
         "on_exit": "Restart",
         "request_networking": true,
         "request_capabilities": [
-            "net:distro:sys",
-            "filesystem:distro:sys",
-            "http_server:distro:sys",
-            "http_client:distro:sys",
-            "kernel:distro:sys",
-            "vfs:distro:sys",
+            "chess:chess:sys",
             "eth:distro:sys",
             {
                 "process": "eth:distro:sys",
@@ -18,10 +13,16 @@
                     "root": true
                 }
             },
-            "sqlite:distro:sys",
-            "kv:distro:sys",
-            "chess:chess:sys",
+            "fd_manager:distro:sys",
+            "filesystem:distro:sys",
+            "http_server:distro:sys",
+            "http_client:distro:sys",
+            "kernel:distro:sys",
             "kns_indexer:kns_indexer:sys",
+            "kv:distro:sys",
+            "net:distro:sys",
+            "sqlite:distro:sys",
+            "vfs:distro:sys",
             {
                 "process": "vfs:distro:sys",
                 "params": {
@@ -30,6 +31,6 @@
             }
         ],
         "grant_capabilities": [],
-        "public": true
+        "public": false
     }
 ]

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -267,11 +267,7 @@ async fn update_max_fds(state: &mut State) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn send_cull(
-    our_node: &str,
-    send_to_loop: &MessageSender,
-    state: &State,
-) {
+async fn send_cull(our_node: &str, send_to_loop: &MessageSender, state: &State) {
     let message = Message::Request(Request {
         inherit: false,
         expects_response: None,

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -184,22 +184,21 @@ async fn handle_message(
             } else {
                 state.total_fds -= number_closed;
             }
-            state
-                .fds
-                .entry(km.source.process)
-                .and_modify(|e| {
-                    if e < &mut number_closed {
-                        return_value.as_mut().unwrap().push_str(&format!(
-                            " !!process claims to have closed more fds ({}) than it had open: {}!!",
-                            number_closed,
-                            e,
-                        ));
-                        *e = 0;
-                    } else {
-                        *e -= number_closed;
-                    }
-                    return_value.as_mut().unwrap().push_str(&format!(" {e} left"));
-                });
+            state.fds.entry(km.source.process).and_modify(|e| {
+                if e < &mut number_closed {
+                    return_value.as_mut().unwrap().push_str(&format!(
+                        " !!process claims to have closed more fds ({}) than it had open: {}!!",
+                        number_closed, e,
+                    ));
+                    *e = 0;
+                } else {
+                    *e -= number_closed;
+                }
+                return_value
+                    .as_mut()
+                    .unwrap()
+                    .push_str(&format!(" {e} left"));
+            });
             return_value
         }
         FdManagerRequest::Cull { .. } => {

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -1,6 +1,6 @@
 use lib::types::core::{
-    Address, FdManagerError, FdManagerRequest, KernelMessage, Message, MessageReceiver, MessageSender,
-    PrintSender, Printout, ProcessId, Request, FD_MANAGER_PROCESS_ID,
+    Address, FdManagerError, FdManagerRequest, KernelMessage, Message, MessageReceiver,
+    MessageSender, PrintSender, Printout, ProcessId, Request, FD_MANAGER_PROCESS_ID,
 };
 use std::{collections::HashMap, sync::Arc};
 
@@ -203,7 +203,11 @@ fn get_max_fd_limit() -> anyhow::Result<u64> {
     }
 }
 
-pub async fn send_fd_manager_open(our: &Address, number_opened: u64, send_to_loop: &MessageSender) -> anyhow::Result<()> {
+pub async fn send_fd_manager_open(
+    our: &Address,
+    number_opened: u64,
+    send_to_loop: &MessageSender,
+) -> anyhow::Result<()> {
     let message = Message::Request(Request {
         inherit: false,
         expects_response: None,
@@ -215,7 +219,11 @@ pub async fn send_fd_manager_open(our: &Address, number_opened: u64, send_to_loo
     Ok(())
 }
 
-pub async fn send_fd_manager_close(our: &Address, number_closed: u64, send_to_loop: &MessageSender) -> anyhow::Result<()> {
+pub async fn send_fd_manager_close(
+    our: &Address,
+    number_closed: u64,
+    send_to_loop: &MessageSender,
+) -> anyhow::Result<()> {
     let message = Message::Request(Request {
         inherit: false,
         expects_response: None,
@@ -227,7 +235,11 @@ pub async fn send_fd_manager_close(our: &Address, number_closed: u64, send_to_lo
     Ok(())
 }
 
-async fn send_to_fd_manager(our: &Address, message: Message, send_to_loop: &MessageSender) -> anyhow::Result<()> {
+async fn send_to_fd_manager(
+    our: &Address,
+    message: Message,
+    send_to_loop: &MessageSender,
+) -> anyhow::Result<()> {
     KernelMessage::builder()
         .id(rand::random())
         .source(our.clone())

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -1,0 +1,192 @@
+use lib::types::core::{
+    KernelMessage, Message, MessageReceiver, MessageSender, PrintSender,
+    Printout, ProcessId, Request, FdManagerRequest, FdManagerError, FD_MANAGER_PROCESS_ID,
+};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+};
+
+const DEFAULT_MAX_OPEN_FDS: u64 = 180;
+const DEFAULT_FDS_AS_FRACTION_OF_ULIMIT_PERCENTAGE: u64 = 60;
+const DEFAULT_UPDATE_ULIMIT_SECS: u64 = 3600;
+const DEFAULT_CULL_FRACTION_DENOMINATOR: u64 = 2;
+
+struct State {
+    fds: HashMap<ProcessId, u64>,
+    mode: Mode,
+    total_fds: u64,
+    max_fds: u64,
+    cull_fraction_denominator: u64,
+}
+
+enum Mode {
+    /// don't update the max_fds except by user input
+    StaticMax,
+    /// check the system's ulimit periodically and update max_fds accordingly
+    DynamicMax {
+        max_fds_as_fraction_of_ulimit_percentage: u64,
+        update_ulimit_secs: u64,
+    }
+}
+
+impl State {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn default() -> Self {
+        Self {
+            fds: HashMap::new(),
+            mode: Mode::default(),
+            total_fds: 0,
+            max_fds: DEFAULT_MAX_OPEN_FDS,
+            cull_fraction_denominator: DEFAULT_CULL_FRACTION_DENOMINATOR,
+        }
+    }
+
+    fn update_max_fds_from_ulimit(&mut self, ulimit_max_fds: u64) {
+        let Mode::DynamicMax { ref max_fds_as_fraction_of_ulimit_percentage, .. } = self.mode else {
+            return;
+        };
+        self.max_fds = ulimit_max_fds * max_fds_as_fraction_of_ulimit_percentage / 100;
+    }
+}
+
+impl Mode {
+    fn default() -> Self {
+        Self::DynamicMax {
+            max_fds_as_fraction_of_ulimit_percentage: DEFAULT_FDS_AS_FRACTION_OF_ULIMIT_PERCENTAGE,
+            update_ulimit_secs: DEFAULT_UPDATE_ULIMIT_SECS,
+        }
+    }
+}
+
+/// The fd_manager entrypoint.
+pub async fn fd_manager(
+    our_node: Arc<String>,
+    send_to_loop: MessageSender,
+    send_to_terminal: PrintSender,
+    mut recv_from_loop: MessageReceiver,
+) -> anyhow::Result<()> {
+    let mut state = State::new();
+    let mut interval = {
+        // in code block to release the reference into state
+        let Mode::DynamicMax { ref update_ulimit_secs, .. } = state.mode else {
+            return Ok(())
+        };
+        tokio::time::interval(tokio::time::Duration::from_secs(
+            update_ulimit_secs.clone()
+        ))
+    };
+    let our_node = our_node.as_str();
+    loop {
+        tokio::select! {
+            Some(message) = recv_from_loop.recv() => {
+                handle_message(message, &mut interval, &mut state)?;
+            }
+            _ = interval.tick() => {
+                update_max_fds(&send_to_terminal, &mut state).await?;
+            }
+        }
+
+        if state.total_fds >= state.max_fds {
+            send_cull(our_node, &send_to_loop, &state).await?;
+        }
+    }
+}
+
+fn handle_message(km: KernelMessage, _interval: &mut tokio::time::Interval, state: &mut State) -> anyhow::Result<()> {
+    let Message::Request(Request {
+        body,
+        ..
+    }) = km.message else {
+        return Err(FdManagerError::NotARequest.into());
+    };
+    let request: FdManagerRequest = serde_json::from_slice(&body)
+        .map_err(|_e| FdManagerError::BadRequest)?;
+    match request {
+        FdManagerRequest::OpenFds { number_opened } => {
+            state.total_fds += number_opened;
+            state.fds
+                .entry(km.source.process)
+                .and_modify(|e| *e += number_opened)
+                .or_insert(number_opened);
+        }
+        FdManagerRequest::CloseFds { mut number_closed } => {
+            assert!(state.total_fds >= number_closed);
+            state.total_fds -= number_closed;
+            state.fds
+                .entry(km.source.process)
+                .and_modify(|e| {
+                    assert!(e >= &mut number_closed);
+                    *e -= number_closed
+                })
+                .or_insert(number_closed);
+        }
+        FdManagerRequest::Cull { .. } => {
+            return Err(FdManagerError::FdManagerWasSentCull.into());
+        }
+        FdManagerRequest::UpdateMaxFdsAsFractionOfUlimitPercentage(_new) => {
+            unimplemented!();
+        }
+        FdManagerRequest::UpdateUpdateUlimitSecs(_new) => {
+            unimplemented!();
+        }
+        FdManagerRequest::UpdateCullFractionDenominator(_new) => {
+            unimplemented!();
+        }
+    }
+    Ok(())
+}
+
+async fn update_max_fds(send_to_terminal: &PrintSender, state: &mut State) -> anyhow::Result<()> {
+    let ulimit_max_fds = match get_max_fd_limit() {
+        Ok(ulimit_max_fds) => ulimit_max_fds,
+        Err(_) => {
+            Printout::new(1, "Couldn't update max fd limit: ulimit failed")
+                .send(send_to_terminal).await;
+            return Ok(());
+        }
+    };
+    state.update_max_fds_from_ulimit(ulimit_max_fds);
+    Ok(())
+}
+
+async fn send_cull(our_node: &str, send_to_loop: &MessageSender, state: &State) -> anyhow::Result<()> {
+    let message = Message::Request(Request {
+        inherit: false,
+        expects_response: None,
+        body: serde_json::to_vec(&FdManagerRequest::Cull {
+            cull_fraction_denominator: state.cull_fraction_denominator.clone(),
+        }).unwrap(),
+        metadata: None,
+        capabilities: vec![],
+    });
+    for process_id in state.fds.keys() {
+        KernelMessage::builder()
+            .id(rand::random())
+            .source((our_node.clone(), FD_MANAGER_PROCESS_ID.clone()))
+            .target((our_node.clone(), process_id.clone()))
+            .message(message.clone())
+            .build()
+            .unwrap()
+            .send(send_to_loop)
+            .await;
+    }
+    Ok(())
+}
+
+fn get_max_fd_limit() -> anyhow::Result<u64> {
+    let mut rlim = libc::rlimit {
+        rlim_cur: 0, // Current limit
+        rlim_max: 0, // Maximum limit value
+    };
+
+    // RLIMIT_NOFILE is the resource indicating the maximum file descriptor number.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &mut rlim) } == 0 {
+        Ok(rlim.rlim_cur as u64)
+    } else {
+        Err(anyhow::anyhow!("Failed to get the resource limit."))
+    }
+}

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -1,5 +1,5 @@
 use lib::types::core::{
-    Address, FdManagerError, FdManagerRequest, FdManagerResponse, KernelMessage, Message,
+    Address, FdManagerError, FdManagerRequest, FdManagerResponse, FdsLimit, KernelMessage, Message,
     MessageReceiver, MessageSender, PrintSender, Printout, ProcessId, Request,
     FD_MANAGER_PROCESS_ID,
 };
@@ -8,14 +8,12 @@ use std::{collections::HashMap, sync::Arc};
 const DEFAULT_MAX_OPEN_FDS: u64 = 180;
 const DEFAULT_FDS_AS_FRACTION_OF_ULIMIT_PERCENTAGE: u64 = 60;
 const DEFAULT_UPDATE_ULIMIT_SECS: u64 = 3600;
-const DEFAULT_CULL_FRACTION_DENOMINATOR: u64 = 2;
+const _DEFAULT_CULL_FRACTION_DENOMINATOR: u64 = 2;
 
 struct State {
-    fds: HashMap<ProcessId, u64>,
+    fds_limits: HashMap<ProcessId, FdsLimit>,
     mode: Mode,
-    total_fds: u64,
     max_fds: u64,
-    cull_fraction_denominator: u64,
 }
 
 enum Mode {
@@ -35,14 +33,12 @@ impl State {
 
     fn default(static_max_fds: Option<u64>) -> Self {
         Self {
-            fds: HashMap::new(),
+            fds_limits: HashMap::new(),
             mode: Mode::default(static_max_fds),
-            total_fds: 0,
             max_fds: match static_max_fds {
                 Some(max) => max,
                 None => DEFAULT_MAX_OPEN_FDS,
             },
-            cull_fraction_denominator: DEFAULT_CULL_FRACTION_DENOMINATOR,
         }
     }
 
@@ -91,11 +87,11 @@ pub async fn fd_manager(
         };
         tokio::time::interval(tokio::time::Duration::from_secs(*update_ulimit_secs))
     };
-    let our_node = our_node.as_str();
     loop {
         tokio::select! {
             Some(message) = recv_from_loop.recv() => {
                 match handle_message(
+                    &our_node,
                     message,
                     &mut interval,
                     &mut state,
@@ -120,23 +116,11 @@ pub async fn fd_manager(
                 }
             }
         }
-
-        if state.total_fds >= state.max_fds {
-            Printout::new(
-                2,
-                format!(
-                    "Have {} open >= {} max fds; sending Cull Request...",
-                    state.total_fds, state.max_fds,
-                ),
-            )
-            .send(&send_to_terminal)
-            .await;
-            send_cull(our_node, &send_to_loop, &state).await;
-        }
     }
 }
 
 async fn handle_message(
+    our_node: &str,
     km: KernelMessage,
     _interval: &mut tokio::time::Interval,
     state: &mut State,
@@ -153,56 +137,37 @@ async fn handle_message(
     let request: FdManagerRequest =
         serde_json::from_slice(&body).map_err(|_e| FdManagerError::BadRequest)?;
     let return_value = match request {
-        FdManagerRequest::OpenFds { number_opened } => {
-            state.total_fds += number_opened;
-            state
-                .fds
-                .entry(km.source.process)
-                .and_modify(|e| *e += number_opened)
-                .or_insert(number_opened);
+        FdManagerRequest::RequestFdsLimit => {
+            // divide max_fds by number of processes requesting fds limits,
+            // then send each process its new limit
+            // TODO can weight different processes differently
+            let per_process_limit = state.max_fds / (state.fds_limits.len() + 1) as u64;
+            state.fds_limits.insert(
+                km.source.process,
+                FdsLimit {
+                    limit: per_process_limit,
+                    hit_count: 0,
+                },
+            );
+            state.fds_limits.iter_mut().for_each(|(_process, limit)| {
+                limit.limit = per_process_limit;
+                limit.hit_count = 0;
+            });
+            send_all_fds_limits(our_node, send_to_loop, state).await;
+
             None
         }
-        FdManagerRequest::CloseFds { mut number_closed } => {
-            if !state.fds.contains_key(&km.source.process) {
-                return Err(anyhow::anyhow!(
-                    "{} attempted to CloseFds {} but does not have any open!",
-                    km.source.process,
-                    number_closed,
-                ));
-            }
-            let mut return_value = Some(format!(
-                "{} closed {} of {} total;",
-                km.source.process, number_closed, state.total_fds,
-            ));
-            if state.total_fds < number_closed {
-                return_value.as_mut().unwrap().push_str(&format!(
-                    " !!process claims to have closed more fds ({}) than we have open for all processes ({})!!",
-                    number_closed,
-                    state.total_fds,
-                ));
-                state.total_fds = 0;
-            } else {
-                state.total_fds -= number_closed;
-            }
-            state.fds.entry(km.source.process).and_modify(|e| {
-                if e < &mut number_closed {
-                    return_value.as_mut().unwrap().push_str(&format!(
-                        " !!process claims to have closed more fds ({}) than it had open: {}!!",
-                        number_closed, e,
-                    ));
-                    *e = 0;
-                } else {
-                    *e -= number_closed;
-                }
-                return_value
-                    .as_mut()
-                    .unwrap()
-                    .push_str(&format!(" ({e} left to process after close)"));
+        FdManagerRequest::FdsLimitHit => {
+            // sender process hit its fd limit
+            // TODO react to this
+            state.fds_limits.get_mut(&km.source.process).map(|limit| {
+                limit.hit_count += 1;
             });
-            return_value
+            Some(format!("{} hit its fd limit", km.source.process))
         }
-        FdManagerRequest::Cull { .. } => {
-            return Err(FdManagerError::FdManagerWasSentCull.into());
+        FdManagerRequest::FdsLimit(_) => {
+            // should only send this, never receive it
+            return Err(FdManagerError::FdManagerWasSentLimit.into());
         }
         FdManagerRequest::UpdateMaxFdsAsFractionOfUlimitPercentage(new) => {
             match state.mode {
@@ -224,8 +189,8 @@ async fn handle_message(
             }
             None
         }
-        FdManagerRequest::UpdateCullFractionDenominator(new) => {
-            state.cull_fraction_denominator = new;
+        FdManagerRequest::UpdateCullFractionDenominator(_new) => {
+            // state.cull_fraction_denominator = new;
             None
         }
         FdManagerRequest::GetState => {
@@ -237,7 +202,7 @@ async fn handle_message(
                     .message(Message::Response((
                         lib::core::Response {
                             body: serde_json::to_vec(&FdManagerResponse::GetState(
-                                state.fds.clone(),
+                                state.fds_limits.clone(),
                             ))
                             .unwrap(),
                             inherit: false,
@@ -253,7 +218,7 @@ async fn handle_message(
             }
             None
         }
-        FdManagerRequest::GetProcessFdCount(process) => {
+        FdManagerRequest::GetProcessFdLimit(process) => {
             if expects_response.is_some() {
                 KernelMessage::builder()
                     .id(km.id)
@@ -261,8 +226,12 @@ async fn handle_message(
                     .target(km.rsvp.unwrap_or(km.source))
                     .message(Message::Response((
                         lib::core::Response {
-                            body: serde_json::to_vec(&FdManagerResponse::GetProcessFdCount(
-                                *state.fds.get(&process).unwrap_or(&0),
+                            body: serde_json::to_vec(&FdManagerResponse::GetProcessFdLimit(
+                                state
+                                    .fds_limits
+                                    .get(&process)
+                                    .map(|limit| limit.limit)
+                                    .unwrap_or(0),
                             ))
                             .unwrap(),
                             inherit: false,
@@ -289,23 +258,19 @@ async fn update_max_fds(state: &mut State) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn send_cull(our_node: &str, send_to_loop: &MessageSender, state: &State) {
-    let message = Message::Request(Request {
-        inherit: false,
-        expects_response: None,
-        body: serde_json::to_vec(&FdManagerRequest::Cull {
-            cull_fraction_denominator: state.cull_fraction_denominator.clone(),
-        })
-        .unwrap(),
-        metadata: None,
-        capabilities: vec![],
-    });
-    for process_id in state.fds.keys() {
+async fn send_all_fds_limits(our_node: &str, send_to_loop: &MessageSender, state: &State) {
+    for (process_id, limit) in &state.fds_limits {
         KernelMessage::builder()
             .id(rand::random())
             .source((our_node, FD_MANAGER_PROCESS_ID.clone()))
             .target((our_node, process_id.clone()))
-            .message(message.clone())
+            .message(Message::Request(Request {
+                inherit: false,
+                expects_response: None,
+                body: serde_json::to_vec(&FdManagerRequest::FdsLimit(limit.limit)).unwrap(),
+                metadata: None,
+                capabilities: vec![],
+            }))
             .build()
             .unwrap()
             .send(send_to_loop)
@@ -327,43 +292,29 @@ fn get_max_fd_limit() -> anyhow::Result<u64> {
     }
 }
 
-pub async fn send_fd_manager_open(
-    our: &Address,
-    number_opened: u64,
-    send_to_loop: &MessageSender,
-) -> anyhow::Result<()> {
+pub async fn send_fd_manager_request_fds_limit(our: &Address, send_to_loop: &MessageSender) {
     let message = Message::Request(Request {
         inherit: false,
         expects_response: None,
-        body: serde_json::to_vec(&FdManagerRequest::OpenFds { number_opened }).unwrap(),
+        body: serde_json::to_vec(&FdManagerRequest::RequestFdsLimit).unwrap(),
         metadata: None,
         capabilities: vec![],
     });
-    send_to_fd_manager(our, message, send_to_loop).await?;
-    Ok(())
+    send_to_fd_manager(our, message, send_to_loop).await
 }
 
-pub async fn send_fd_manager_close(
-    our: &Address,
-    number_closed: u64,
-    send_to_loop: &MessageSender,
-) -> anyhow::Result<()> {
+pub async fn send_fd_manager_hit_fds_limit(our: &Address, send_to_loop: &MessageSender) {
     let message = Message::Request(Request {
         inherit: false,
         expects_response: None,
-        body: serde_json::to_vec(&FdManagerRequest::CloseFds { number_closed }).unwrap(),
+        body: serde_json::to_vec(&FdManagerRequest::FdsLimitHit).unwrap(),
         metadata: None,
         capabilities: vec![],
     });
-    send_to_fd_manager(our, message, send_to_loop).await?;
-    Ok(())
+    send_to_fd_manager(our, message, send_to_loop).await
 }
 
-async fn send_to_fd_manager(
-    our: &Address,
-    message: Message,
-    send_to_loop: &MessageSender,
-) -> anyhow::Result<()> {
+async fn send_to_fd_manager(our: &Address, message: Message, send_to_loop: &MessageSender) {
     KernelMessage::builder()
         .id(rand::random())
         .source(our.clone())
@@ -372,6 +323,5 @@ async fn send_to_fd_manager(
         .build()
         .unwrap()
         .send(send_to_loop)
-        .await;
-    Ok(())
+        .await
 }

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -163,6 +163,13 @@ async fn handle_message(
             None
         }
         FdManagerRequest::CloseFds { mut number_closed } => {
+            if !state.fds.contains_key(&km.source.process) {
+                return Err(anyhow::anyhow!(
+                    "{} attempted to CloseFds {} but does not have any open!",
+                    km.source.process,
+                    number_closed,
+                ));
+            }
             let mut return_value = Some(format!(
                 "{} closed {} of {}",
                 km.source.process, number_closed, state.total_fds,
@@ -191,8 +198,7 @@ async fn handle_message(
                     } else {
                         *e -= number_closed;
                     }
-                })
-                .or_insert(number_closed);
+                });
             return_value
         }
         FdManagerRequest::Cull { .. } => {

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -55,7 +55,7 @@ impl State {
 
     fn update_all_fds_limits(&mut self) {
         let len = self.fds_limits.len() as u64;
-        let per_process_limit = self.max_fds / len;
+        let per_process_limit = self.max_fds / std::cmp::max(len, 1);
         for limit in self.fds_limits.values_mut() {
             limit.limit = per_process_limit;
             // reset hit count when updating limits

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -197,7 +197,7 @@ async fn handle_message(
                 return_value
                     .as_mut()
                     .unwrap()
-                    .push_str(&format!(" {e} left"));
+                    .push_str(&format!(" ({e} left to process after close)"));
             });
             return_value
         }

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -104,9 +104,8 @@ pub async fn fd_manager(
                 2,
                 format!(
                     "Have {} open >= {} max fds; sending Cull Request...",
-                    state.total_fds,
-                    state.max_fds,
-                )
+                    state.total_fds, state.max_fds,
+                ),
             )
             .send(&send_to_terminal)
             .await;
@@ -139,9 +138,7 @@ fn handle_message(
             assert!(state.total_fds >= number_closed);
             let return_value = Some(format!(
                 "{} closed {} of {}",
-                km.source.process,
-                number_closed,
-                state.total_fds,
+                km.source.process, number_closed, state.total_fds,
             ));
             state.total_fds -= number_closed;
             state

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -171,12 +171,12 @@ async fn handle_message(
                 ));
             }
             let mut return_value = Some(format!(
-                "{} closed {} of {}",
+                "{} closed {} of {} total;",
                 km.source.process, number_closed, state.total_fds,
             ));
             if state.total_fds < number_closed {
                 return_value.as_mut().unwrap().push_str(&format!(
-                    "\n!!process claims to have closed more fds ({}) than we have open for all processes ({})!!",
+                    " !!process claims to have closed more fds ({}) than we have open for all processes ({})!!",
                     number_closed,
                     state.total_fds,
                 ));
@@ -190,7 +190,7 @@ async fn handle_message(
                 .and_modify(|e| {
                     if e < &mut number_closed {
                         return_value.as_mut().unwrap().push_str(&format!(
-                            "\n!!process claims to have closed more fds ({}) than it had open: {}!!",
+                            " !!process claims to have closed more fds ({}) than it had open: {}!!",
                             number_closed,
                             e,
                         ));
@@ -198,6 +198,7 @@ async fn handle_message(
                     } else {
                         *e -= number_closed;
                     }
+                    return_value.as_mut().unwrap().push_str(&format!(" {e} left"));
                 });
             return_value
         }

--- a/kinode/src/kv.rs
+++ b/kinode/src/kv.rs
@@ -70,11 +70,9 @@ impl KvState {
     }
 
     pub async fn remove_db(&mut self, package_id: PackageId, db: String) {
-        let db_path = format!("{}/{}/{}", self.kv_path.as_str(), package_id, db);
         self.open_kvs.remove(&(package_id.clone(), db.to_string()));
         let mut access_order = self.access_order.lock().await;
         access_order.remove(&(package_id, db));
-        let _ = fs::remove_dir_all(&db_path).await;
     }
 
     pub async fn remove_least_recently_used_dbs(&mut self, n: u64) {
@@ -498,6 +496,11 @@ async fn check_caps(
             state
                 .remove_db(request.package_id.clone(), request.db.clone())
                 .await;
+
+            let _ = fs::remove_dir_all(format!(
+                "{}/{}/{}",
+                state.kv_path, request.package_id, request.db
+            ));
 
             Ok(())
         }

--- a/kinode/src/kv.rs
+++ b/kinode/src/kv.rs
@@ -1,8 +1,10 @@
+use crate::vfs::UniqueQueue;
 use dashmap::DashMap;
 use lib::types::core::{
-    Address, CapMessage, CapMessageSender, Capability, KernelMessage, KvAction, KvError, KvRequest,
-    KvResponse, LazyLoadBlob, Message, MessageReceiver, MessageSender, PackageId, PrintSender,
-    Printout, ProcessId, Request, Response, KV_PROCESS_ID,
+    Address, CapMessage, CapMessageSender, Capability, FdManagerRequest, KernelMessage, KvAction,
+    KvError, KvRequest, KvResponse, LazyLoadBlob, Message, MessageReceiver, MessageSender,
+    PackageId, PrintSender, Printout, ProcessId, Request, Response, FD_MANAGER_PROCESS_ID,
+    KV_PROCESS_ID,
 };
 use rocksdb::OptimisticTransactionDB;
 use std::{
@@ -10,6 +12,80 @@ use std::{
     sync::Arc,
 };
 use tokio::{fs, sync::Mutex};
+
+#[derive(Clone)]
+struct KvState {
+    our: Arc<Address>,
+    kv_path: Arc<String>,
+    send_to_loop: MessageSender,
+    send_to_terminal: PrintSender,
+    open_kvs: Arc<DashMap<(PackageId, String), OptimisticTransactionDB>>,
+    /// access order of dbs, used to cull if we hit the fds limit
+    access_order: Arc<Mutex<UniqueQueue<(PackageId, String)>>>,
+    txs: Arc<DashMap<u64, Vec<(KvAction, Option<Vec<u8>>)>>>,
+    fds_limit: u64,
+}
+
+impl KvState {
+    pub fn new(
+        our: Address,
+        send_to_terminal: PrintSender,
+        send_to_loop: MessageSender,
+        home_directory_path: String,
+    ) -> Self {
+        Self {
+            our: Arc::new(our),
+            kv_path: Arc::new(format!("{home_directory_path}/kv")),
+            send_to_loop,
+            send_to_terminal,
+            open_kvs: Arc::new(DashMap::new()),
+            access_order: Arc::new(Mutex::new(UniqueQueue::new())),
+            txs: Arc::new(DashMap::new()),
+            fds_limit: 10,
+        }
+    }
+
+    pub async fn open_db(&mut self, package_id: PackageId, db: String) -> Result<(), KvError> {
+        let key = (package_id.clone(), db.clone());
+        if self.open_kvs.contains_key(&key) {
+            return Ok(());
+        }
+
+        if self.open_kvs.len() as u64 >= self.fds_limit {
+            // close least recently used db
+            let key = self.access_order.lock().await.pop_front().unwrap();
+            self.remove_db(key.0, key.1).await;
+        }
+
+        let db_path = format!("{}/{}/{}", self.kv_path.as_str(), package_id, db);
+        fs::create_dir_all(&db_path).await?;
+
+        self.open_kvs.insert(
+            key,
+            OptimisticTransactionDB::open_default(&db_path).map_err(rocks_to_kv_err)?,
+        );
+        let mut access_order = self.access_order.lock().await;
+        access_order.push_back((package_id, db));
+        Ok(())
+    }
+
+    pub async fn remove_db(&mut self, package_id: PackageId, db: String) {
+        let db_path = format!("{}/{}/{}", self.kv_path.as_str(), package_id, db);
+        self.open_kvs.remove(&(package_id.clone(), db.to_string()));
+        let mut access_order = self.access_order.lock().await;
+        access_order.remove(&(package_id, db));
+        let _ = fs::remove_dir_all(&db_path).await;
+    }
+
+    pub async fn remove_least_recently_used_dbs(&mut self, n: u64) {
+        for _ in 0..n {
+            let mut lock = self.access_order.lock().await;
+            let key = lock.pop_front().unwrap();
+            drop(lock);
+            self.remove_db(key.0, key.1).await;
+        }
+    }
+}
 
 pub async fn kv(
     our_node: Arc<String>,
@@ -19,28 +95,41 @@ pub async fn kv(
     send_to_caps_oracle: CapMessageSender,
     home_directory_path: String,
 ) -> anyhow::Result<()> {
-    let kv_path = Arc::new(format!("{home_directory_path}/kv"));
-    if let Err(e) = fs::create_dir_all(&*kv_path).await {
+    let our = Address::new(our_node.as_str(), KV_PROCESS_ID.clone());
+
+    crate::fd_manager::send_fd_manager_request_fds_limit(&our, &send_to_loop).await;
+
+    let mut state = KvState::new(our, send_to_terminal, send_to_loop, home_directory_path);
+
+    if let Err(e) = fs::create_dir_all(state.kv_path.as_str()).await {
         panic!("failed creating kv dir! {e:?}");
     }
-
-    let open_kvs: Arc<DashMap<(PackageId, String), OptimisticTransactionDB>> =
-        Arc::new(DashMap::new());
-    let txs: Arc<DashMap<u64, Vec<(KvAction, Option<Vec<u8>>)>>> = Arc::new(DashMap::new());
 
     let process_queues: HashMap<ProcessId, Arc<Mutex<VecDeque<KernelMessage>>>> = HashMap::new();
 
     while let Some(km) = recv_from_loop.recv().await {
-        if *our_node != km.source.node {
+        if state.our.node != km.source.node {
             Printout::new(
                 1,
                 format!(
-                    "kv: got request from {}, but requests must come from our node {our_node}",
-                    km.source.node
+                    "kv: got request from {}, but requests must come from our node {}",
+                    km.source.node, state.our.node,
                 ),
             )
-            .send(&send_to_terminal)
+            .send(&state.send_to_terminal)
             .await;
+            continue;
+        }
+
+        if km.source.process == *FD_MANAGER_PROCESS_ID {
+            if let Err(e) = handle_fd_request(km, &mut state).await {
+                Printout::new(
+                    1,
+                    format!("kv: got request from fd_manager that errored: {e:?}"),
+                )
+                .send(&state.send_to_terminal)
+                .await;
+            };
             continue;
         }
 
@@ -55,13 +144,8 @@ pub async fn kv(
         }
 
         // clone Arcs
-        let our_node = our_node.clone();
-        let send_to_loop = send_to_loop.clone();
-        let send_to_terminal = send_to_terminal.clone();
+        let mut state = state.clone();
         let send_to_caps_oracle = send_to_caps_oracle.clone();
-        let open_kvs = open_kvs.clone();
-        let txs = txs.clone();
-        let kv_path = kv_path.clone();
 
         tokio::spawn(async move {
             let mut queue_lock = queue.lock().await;
@@ -69,23 +153,13 @@ pub async fn kv(
                 let (km_id, km_rsvp) =
                     (km.id.clone(), km.rsvp.clone().unwrap_or(km.source.clone()));
 
-                if let Err(e) = handle_request(
-                    &our_node,
-                    km,
-                    open_kvs,
-                    txs,
-                    &send_to_loop,
-                    &send_to_caps_oracle,
-                    &kv_path,
-                )
-                .await
-                {
+                if let Err(e) = handle_request(km, &mut state, &send_to_caps_oracle).await {
                     Printout::new(1, format!("kv: {e}"))
-                        .send(&send_to_terminal)
+                        .send(&state.send_to_terminal)
                         .await;
                     KernelMessage::builder()
                         .id(km_id)
-                        .source((our_node.as_str(), KV_PROCESS_ID.clone()))
+                        .source(state.our.as_ref().clone())
                         .target(km_rsvp)
                         .message(Message::Response((
                             Response {
@@ -98,7 +172,7 @@ pub async fn kv(
                         )))
                         .build()
                         .unwrap()
-                        .send(&send_to_loop)
+                        .send(&state.send_to_loop)
                         .await;
                 }
             }
@@ -108,13 +182,9 @@ pub async fn kv(
 }
 
 async fn handle_request(
-    our_node: &str,
     km: KernelMessage,
-    open_kvs: Arc<DashMap<(PackageId, String), OptimisticTransactionDB>>,
-    txs: Arc<DashMap<u64, Vec<(KvAction, Option<Vec<u8>>)>>>,
-    send_to_loop: &MessageSender,
+    state: &mut KvState,
     send_to_caps_oracle: &CapMessageSender,
-    kv_path: &str,
 ) -> Result<(), KvError> {
     let KernelMessage {
         id,
@@ -145,15 +215,12 @@ async fn handle_request(
         }
     };
 
-    check_caps(
-        our_node,
-        &source,
-        &open_kvs,
-        send_to_caps_oracle,
-        &request,
-        kv_path,
-    )
-    .await?;
+    check_caps(&source, state, send_to_caps_oracle, &request).await?;
+
+    // always open to ensure db exists
+    state
+        .open_db(request.package_id.clone(), request.db.clone())
+        .await?;
 
     let (body, bytes) = match &request.action {
         KvAction::Open => {
@@ -165,7 +232,7 @@ async fn handle_request(
             (serde_json::to_vec(&KvResponse::Ok).unwrap(), None)
         }
         KvAction::Get { key } => {
-            let db = match open_kvs.get(&(request.package_id, request.db)) {
+            let db = match state.open_kvs.get(&(request.package_id, request.db)) {
                 None => {
                     return Err(KvError::NoDb);
                 }
@@ -190,14 +257,14 @@ async fn handle_request(
         }
         KvAction::BeginTx => {
             let tx_id = rand::random::<u64>();
-            txs.insert(tx_id, Vec::new());
+            state.txs.insert(tx_id, Vec::new());
             (
                 serde_json::to_vec(&KvResponse::BeginTx { tx_id }).unwrap(),
                 None,
             )
         }
         KvAction::Set { key, tx_id } => {
-            let db = match open_kvs.get(&(request.package_id, request.db)) {
+            let db = match state.open_kvs.get(&(request.package_id, request.db)) {
                 None => {
                     return Err(KvError::NoDb);
                 }
@@ -214,7 +281,7 @@ async fn handle_request(
                     db.put(key, blob.bytes).map_err(rocks_to_kv_err)?;
                 }
                 Some(tx_id) => {
-                    let mut tx = match txs.get_mut(tx_id) {
+                    let mut tx = match state.txs.get_mut(tx_id) {
                         None => {
                             return Err(KvError::NoTx);
                         }
@@ -227,7 +294,7 @@ async fn handle_request(
             (serde_json::to_vec(&KvResponse::Ok).unwrap(), None)
         }
         KvAction::Delete { key, tx_id } => {
-            let db = match open_kvs.get(&(request.package_id, request.db)) {
+            let db = match state.open_kvs.get(&(request.package_id, request.db)) {
                 None => {
                     return Err(KvError::NoDb);
                 }
@@ -238,7 +305,7 @@ async fn handle_request(
                     db.delete(key).map_err(rocks_to_kv_err)?;
                 }
                 Some(tx_id) => {
-                    let mut tx = match txs.get_mut(tx_id) {
+                    let mut tx = match state.txs.get_mut(tx_id) {
                         None => {
                             return Err(KvError::NoTx);
                         }
@@ -250,14 +317,14 @@ async fn handle_request(
             (serde_json::to_vec(&KvResponse::Ok).unwrap(), None)
         }
         KvAction::Commit { tx_id } => {
-            let db = match open_kvs.get(&(request.package_id, request.db)) {
+            let db = match state.open_kvs.get(&(request.package_id, request.db)) {
                 None => {
                     return Err(KvError::NoDb);
                 }
                 Some(db) => db,
             };
 
-            let txs = match txs.remove(tx_id).map(|(_, tx)| tx) {
+            let txs = match state.txs.remove(tx_id).map(|(_, tx)| tx) {
                 None => {
                     return Err(KvError::NoTx);
                 }
@@ -291,7 +358,7 @@ async fn handle_request(
         }
         KvAction::Backup => {
             // looping through open dbs and flushing their memtables
-            for db_ref in open_kvs.iter() {
+            for db_ref in state.open_kvs.iter() {
                 let db = db_ref.value();
                 db.flush().map_err(rocks_to_kv_err)?;
             }
@@ -302,7 +369,7 @@ async fn handle_request(
     if let Some(target) = km.rsvp.or_else(|| expects_response.map(|_| source)) {
         KernelMessage::builder()
             .id(id)
-            .source((our_node, KV_PROCESS_ID.clone()))
+            .source(state.our.as_ref().clone())
             .target(target)
             .message(Message::Response((
                 Response {
@@ -319,7 +386,7 @@ async fn handle_request(
             }))
             .build()
             .unwrap()
-            .send(send_to_loop)
+            .send(&state.send_to_loop)
             .await;
     }
 
@@ -327,12 +394,10 @@ async fn handle_request(
 }
 
 async fn check_caps(
-    our_node: &str,
     source: &Address,
-    open_kvs: &Arc<DashMap<(PackageId, String), OptimisticTransactionDB>>,
+    state: &mut KvState,
     send_to_caps_oracle: &CapMessageSender,
     request: &KvRequest,
-    kv_path: &str,
 ) -> Result<(), KvError> {
     let (send_cap_bool, recv_cap_bool) = tokio::sync::oneshot::channel();
     let src_package_id = PackageId::new(source.process.package(), source.process.publisher());
@@ -346,10 +411,7 @@ async fn check_caps(
                 .send(CapMessage::Has {
                     on: source.process.clone(),
                     cap: Capability {
-                        issuer: Address {
-                            node: our_node.to_string(),
-                            process: KV_PROCESS_ID.clone(),
-                        },
+                        issuer: state.our.as_ref().clone(),
                         params: serde_json::json!({
                             "kind": "write",
                             "db": request.db.to_string(),
@@ -372,10 +434,7 @@ async fn check_caps(
                 .send(CapMessage::Has {
                     on: source.process.clone(),
                     cap: Capability {
-                        issuer: Address {
-                            node: our_node.to_string(),
-                            process: KV_PROCESS_ID.clone(),
-                        },
+                        issuer: state.our.as_ref().clone(),
                         params: serde_json::json!({
                             "kind": "read",
                             "db": request.db.to_string(),
@@ -403,7 +462,7 @@ async fn check_caps(
             add_capability(
                 "read",
                 &request.db.to_string(),
-                &our_node,
+                &state.our,
                 &source,
                 send_to_caps_oracle,
             )
@@ -411,22 +470,22 @@ async fn check_caps(
             add_capability(
                 "write",
                 &request.db.to_string(),
-                &our_node,
+                &state.our,
                 &source,
                 send_to_caps_oracle,
             )
             .await?;
 
-            if open_kvs.contains_key(&(request.package_id.clone(), request.db.clone())) {
+            if state
+                .open_kvs
+                .contains_key(&(request.package_id.clone(), request.db.clone()))
+            {
                 return Ok(());
             }
 
-            let db_path = format!("{}/{}/{}", kv_path, request.package_id, request.db);
-            fs::create_dir_all(&db_path).await?;
-
-            let db = OptimisticTransactionDB::open_default(&db_path).map_err(rocks_to_kv_err)?;
-
-            open_kvs.insert((request.package_id.clone(), request.db.clone()), db);
+            state
+                .open_db(request.package_id.clone(), request.db.clone())
+                .await?;
             Ok(())
         }
         KvAction::RemoveDb { .. } => {
@@ -436,28 +495,51 @@ async fn check_caps(
                 });
             }
 
-            let db_path = format!("{}/{}/{}", kv_path, request.package_id, request.db);
-            open_kvs.remove(&(request.package_id.clone(), request.db.clone()));
+            state
+                .remove_db(request.package_id.clone(), request.db.clone())
+                .await;
 
-            fs::remove_dir_all(&db_path).await?;
             Ok(())
         }
         KvAction::Backup { .. } => Ok(()),
     }
 }
 
+async fn handle_fd_request(km: KernelMessage, state: &mut KvState) -> anyhow::Result<()> {
+    let Message::Request(Request { body, .. }) = km.message else {
+        return Err(anyhow::anyhow!("not a request"));
+    };
+
+    let request: FdManagerRequest = serde_json::from_slice(&body)?;
+
+    match request {
+        FdManagerRequest::FdsLimit(new_fds_limit) => {
+            state.fds_limit = new_fds_limit;
+            if state.open_kvs.len() as u64 >= state.fds_limit {
+                crate::fd_manager::send_fd_manager_hit_fds_limit(&state.our, &state.send_to_loop)
+                    .await;
+                state
+                    .remove_least_recently_used_dbs(state.open_kvs.len() as u64 - state.fds_limit)
+                    .await;
+            }
+        }
+        _ => {
+            return Err(anyhow::anyhow!("non-Cull FdManagerRequest"));
+        }
+    }
+
+    Ok(())
+}
+
 async fn add_capability(
     kind: &str,
     db: &str,
-    our_node: &str,
+    our: &Address,
     source: &Address,
     send_to_caps_oracle: &CapMessageSender,
 ) -> Result<(), KvError> {
     let cap = Capability {
-        issuer: Address {
-            node: our_node.to_string(),
-            process: KV_PROCESS_ID.clone(),
-        },
+        issuer: our.clone(),
         params: serde_json::json!({ "kind": kind, "db": db }).to_string(),
     };
     let (send_cap_bool, recv_cap_bool) = tokio::sync::oneshot::channel();

--- a/kinode/src/kv.rs
+++ b/kinode/src/kv.rs
@@ -410,14 +410,14 @@ async fn check_caps(
             send_to_caps_oracle
                 .send(CapMessage::Has {
                     on: source.process.clone(),
-                    cap: Capability {
-                        issuer: state.our.as_ref().clone(),
-                        params: serde_json::json!({
+                    cap: Capability::new(
+                        state.our.as_ref().clone(),
+                        serde_json::json!({
                             "kind": "write",
                             "db": request.db.to_string(),
                         })
                         .to_string(),
-                    },
+                    ),
                     responder: send_cap_bool,
                 })
                 .await?;
@@ -433,14 +433,14 @@ async fn check_caps(
             send_to_caps_oracle
                 .send(CapMessage::Has {
                     on: source.process.clone(),
-                    cap: Capability {
-                        issuer: state.our.as_ref().clone(),
-                        params: serde_json::json!({
+                    cap: Capability::new(
+                        state.our.as_ref().clone(),
+                        serde_json::json!({
                             "kind": "read",
                             "db": request.db.to_string(),
                         })
                         .to_string(),
-                    },
+                    ),
                     responder: send_cap_bool,
                 })
                 .await?;

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -377,6 +377,7 @@ async fn main() {
         kernel_message_sender.clone(),
         print_sender.clone(),
         fd_manager_receiver,
+        matches.get_one::<u64>("soft-ulimit").copied(),
     ));
     tasks.spawn(kv::kv(
         our_name_arc.clone(),
@@ -713,6 +714,10 @@ fn build_command() -> Command {
         .arg(
             arg!(--"max-passthroughs" <MAX_PASSTHROUGHS> "Maximum number of passthroughs serve as a router (default 0)")
                 .value_parser(value_parser!(u32)),
+        )
+        .arg(
+            arg!(--"soft-ulimit" <SOFT_ULIMIT> "Enforce a static maximum number of file descriptors (default fetched from system)")
+                .value_parser(value_parser!(u64)),
         );
 
     #[cfg(feature = "simulation-mode")]

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc;
 mod eth;
 #[cfg(feature = "simulation-mode")]
 mod fakenet;
-mod fd_manager;
+pub mod fd_manager;
 mod http;
 mod kernel;
 mod keygen;

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -49,8 +49,8 @@ const WS_MIN_PORT: u16 = 9_000;
 const TCP_MIN_PORT: u16 = 10_000;
 const MAX_PORT: u16 = 65_535;
 
-const DEFAULT_MAX_PEERS: u32 = 32;
-const DEFAULT_MAX_PASSTHROUGHS: u32 = 0;
+const DEFAULT_MAX_PEERS: u64 = 32;
+const DEFAULT_MAX_PASSTHROUGHS: u64 = 0;
 
 /// default routers as a eth-provider fallback
 const DEFAULT_ETH_PROVIDERS: &str = include_str!("eth/default_providers_mainnet.json");
@@ -358,10 +358,10 @@ async fn main() {
         net_message_receiver,
         *matches.get_one::<bool>("reveal-ip").unwrap_or(&true),
         *matches
-            .get_one::<u32>("max-peers")
+            .get_one::<u64>("max-peers")
             .unwrap_or(&DEFAULT_MAX_PEERS),
         *matches
-            .get_one::<u32>("max-passthroughs")
+            .get_one::<u64>("max-passthroughs")
             .unwrap_or(&DEFAULT_MAX_PASSTHROUGHS),
     ));
     tasks.spawn(state::state_sender(

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -353,6 +353,8 @@ async fn main() {
         print_sender.clone(),
         net_message_receiver,
         *matches.get_one::<bool>("reveal-ip").unwrap_or(&true),
+        *matches.get_one::<u32>("max-peers").unwrap_or(&100),
+        *matches.get_one::<u32>("max-passthroughs").unwrap_or(&0),
     ));
     tasks.spawn(state::state_sender(
         our_name_arc.clone(),
@@ -695,6 +697,14 @@ fn build_command() -> Command {
         .arg(
             arg!(--"number-log-files" <NUMBER_LOG_FILES> "Number of logs to rotate (default 4)")
                 .value_parser(value_parser!(u64)),
+        )
+        .arg(
+            arg!(--"max-peers" <MAX_PEERS> "Maximum number of peers to hold active connections with (default 100)")
+                .value_parser(value_parser!(u32)),
+        )
+        .arg(
+            arg!(--"max-passthroughs" <MAX_PASSTHROUGHS> "Maximum number of passthroughs serve as a router (default 0)")
+                .value_parser(value_parser!(u32)),
         );
 
     #[cfg(feature = "simulation-mode")]

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -48,6 +48,10 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 const WS_MIN_PORT: u16 = 9_000;
 const TCP_MIN_PORT: u16 = 10_000;
 const MAX_PORT: u16 = 65_535;
+
+const DEFAULT_MAX_PEERS: u32 = 32;
+const DEFAULT_MAX_PASSTHROUGHS: u32 = 0;
+
 /// default routers as a eth-provider fallback
 const DEFAULT_ETH_PROVIDERS: &str = include_str!("eth/default_providers_mainnet.json");
 #[cfg(not(feature = "simulation-mode"))]
@@ -353,8 +357,12 @@ async fn main() {
         print_sender.clone(),
         net_message_receiver,
         *matches.get_one::<bool>("reveal-ip").unwrap_or(&true),
-        *matches.get_one::<u32>("max-peers").unwrap_or(&100),
-        *matches.get_one::<u32>("max-passthroughs").unwrap_or(&0),
+        *matches
+            .get_one::<u32>("max-peers")
+            .unwrap_or(&DEFAULT_MAX_PEERS),
+        *matches
+            .get_one::<u32>("max-passthroughs")
+            .unwrap_or(&DEFAULT_MAX_PASSTHROUGHS),
     ));
     tasks.spawn(state::state_sender(
         our_name_arc.clone(),
@@ -699,7 +707,7 @@ fn build_command() -> Command {
                 .value_parser(value_parser!(u64)),
         )
         .arg(
-            arg!(--"max-peers" <MAX_PEERS> "Maximum number of peers to hold active connections with (default 100)")
+            arg!(--"max-peers" <MAX_PEERS> "Maximum number of peers to hold active connections with (default 32)")
                 .value_parser(value_parser!(u32)),
         )
         .arg(

--- a/kinode/src/net/connect.rs
+++ b/kinode/src/net/connect.rs
@@ -151,7 +151,7 @@ pub async fn handle_failed_connection(
         &format!("net: failed to connect to {}", peer_id.name),
     )
     .await;
-    drop(data.peers.remove(&peer_id.name));
+    data.peers.remove(&peer_id.name).await;
     peer_rx.close();
     while let Some(km) = peer_rx.recv().await {
         utils::error_offline(km, &ext.network_error_tx).await;

--- a/kinode/src/net/connect.rs
+++ b/kinode/src/net/connect.rs
@@ -17,7 +17,7 @@ pub async fn send_to_peer(ext: &IdentityExt, data: &NetData, km: KernelMessage) 
         let (mut peer, peer_rx) = Peer::new(peer_id.clone(), false);
         // send message to be routed
         peer.send(km);
-        data.peers.insert(peer_id.name.clone(), peer);
+        data.peers.insert(peer_id.name.clone(), peer).await;
         tokio::spawn(connect_to_peer(
             ext.clone(),
             data.clone(),

--- a/kinode/src/net/indirect.rs
+++ b/kinode/src/net/indirect.rs
@@ -30,7 +30,7 @@ pub async fn connect_to_router(router_id: &Identity, ext: &IdentityExt, data: &N
     )
     .await;
     let (peer, peer_rx) = Peer::new(router_id.clone(), false);
-    data.peers.insert(router_id.name.clone(), peer);
+    data.peers.insert(router_id.name.clone(), peer).await;
     if let Some((_ip, port)) = router_id.tcp_routing() {
         match tcp::init_direct(ext, data, &router_id, *port, true, peer_rx).await {
             Ok(()) => {

--- a/kinode/src/net/indirect.rs
+++ b/kinode/src/net/indirect.rs
@@ -36,6 +36,7 @@ pub async fn connect_to_router(router_id: &Identity, ext: &IdentityExt, data: &N
             identity: router_id.clone(),
             routing_for: false,
             sender: peer_tx.clone(),
+            last_message: 0,
         },
     );
     if let Some((_ip, port)) = router_id.tcp_routing() {

--- a/kinode/src/net/mod.rs
+++ b/kinode/src/net/mod.rs
@@ -331,7 +331,7 @@ async fn handle_fdman(km: &KernelMessage, request_body: &[u8], data: &NetData) {
     if km.source.process != *lib::core::FD_MANAGER_PROCESS_ID {
         return;
     }
-    let Ok(req) = rmp_serde::from_slice::<lib::core::FdManagerRequest>(request_body) else {
+    let Ok(req) = serde_json::from_slice::<lib::core::FdManagerRequest>(request_body) else {
         return;
     };
     match req {

--- a/kinode/src/net/mod.rs
+++ b/kinode/src/net/mod.rs
@@ -45,7 +45,7 @@ pub async fn networking(
     // start by initializing the structs where we'll store PKI in memory
     // and store a mapping of peers we have an active route for
     let pki: OnchainPKI = Arc::new(DashMap::new());
-    let peers: Peers = Arc::new(DashMap::new());
+    let peers: Peers = Peers(Arc::new(DashMap::new()));
     // only used by routers
     let pending_passthroughs: PendingPassthroughs = Arc::new(DashMap::new());
 
@@ -171,6 +171,7 @@ async fn handle_local_request(
                 NetAction::GetPeers => (
                     NetResponse::Peers(
                         data.peers
+                            .0
                             .iter()
                             .map(|p| p.identity.clone())
                             .collect::<Vec<Identity>>(),
@@ -189,10 +190,11 @@ async fn handle_local_request(
                     ));
                     printout.push_str(&format!("our Identity: {:#?}\r\n", ext.our));
                     printout.push_str(&format!(
-                        "we have connections with {} peers:\r\n",
-                        data.peers.len()
+                        "we have connections with {} peers ({} max):\r\n",
+                        data.peers.0.len(),
+                        utils::MAX_PEERS,
                     ));
-                    for peer in data.peers.iter() {
+                    for peer in data.peers.0.iter() {
                         printout.push_str(&format!(
                             "    {}, routing_for={}\r\n",
                             peer.identity.name, peer.routing_for,

--- a/kinode/src/net/mod.rs
+++ b/kinode/src/net/mod.rs
@@ -6,12 +6,7 @@ use types::{
     ActivePassthroughs, IdentityExt, NetData, OnchainPKI, Peers, PendingPassthroughs, TCP_PROTOCOL,
     WS_PROTOCOL,
 };
-use {
-    dashmap::DashMap,
-    ring::signature::Ed25519KeyPair,
-    std::sync::Arc,
-    tokio::task::JoinSet,
-};
+use {dashmap::DashMap, ring::signature::Ed25519KeyPair, std::sync::Arc, tokio::task::JoinSet};
 
 mod connect;
 mod indirect;

--- a/kinode/src/net/mod.rs
+++ b/kinode/src/net/mod.rs
@@ -7,7 +7,7 @@ use types::{
     WS_PROTOCOL,
 };
 use {
-    dashmap::{DashMap, DashSet},
+    dashmap::DashMap,
     ring::signature::Ed25519KeyPair,
     std::sync::Arc,
     tokio::task::JoinSet,
@@ -58,7 +58,7 @@ pub async fn networking(
     let peers: Peers = Peers::new(max_peers, ext.kernel_message_tx.clone());
     // only used by routers
     let pending_passthroughs: PendingPassthroughs = Arc::new(DashMap::new());
-    let active_passthroughs: ActivePassthroughs = Arc::new(DashSet::new());
+    let active_passthroughs: ActivePassthroughs = Arc::new(DashMap::new());
 
     let net_data = NetData {
         pki,
@@ -246,7 +246,7 @@ async fn handle_local_request(
                             data.active_passthroughs.len()
                         ));
                         for p in data.active_passthroughs.iter() {
-                            printout.push_str(&format!("    {} -> {}\r\n", p.0, p.1));
+                            printout.push_str(&format!("    {} -> {}\r\n", p.key().0, p.key().1));
                         }
                     }
 

--- a/kinode/src/net/mod.rs
+++ b/kinode/src/net/mod.rs
@@ -55,7 +55,7 @@ pub async fn networking(
     // start by initializing the structs where we'll store PKI in memory
     // and store a mapping of peers we have an active route for
     let pki: OnchainPKI = Arc::new(DashMap::new());
-    let peers: Peers = Peers::new(max_peers);
+    let peers: Peers = Peers::new(max_peers, ext.kernel_message_tx.clone());
     // only used by routers
     let pending_passthroughs: PendingPassthroughs = Arc::new(DashMap::new());
     let active_passthroughs: ActivePassthroughs = Arc::new(DashSet::new());
@@ -340,7 +340,7 @@ async fn handle_fdman(km: &KernelMessage, request_body: &[u8], data: &NetData) {
         } => {
             // we are requested to cull a fraction of our peers!
             // TODO cull passthroughs too?
-            data.peers.cull(cull_fraction_denominator);
+            data.peers.cull(cull_fraction_denominator).await;
         }
         _ => return,
     }

--- a/kinode/src/net/mod.rs
+++ b/kinode/src/net/mod.rs
@@ -1,6 +1,9 @@
-use lib::types::core::{
-    Identity, KernelMessage, MessageReceiver, MessageSender, NetAction, NetResponse,
-    NetworkErrorSender, NodeRouting, PrintSender,
+use lib::{
+    core::Address,
+    types::core::{
+        Identity, KernelMessage, MessageReceiver, MessageSender, NetAction, NetResponse,
+        NetworkErrorSender, NodeRouting, PrintSender, NET_PROCESS_ID,
+    },
 };
 use types::{
     ActivePassthroughs, IdentityExt, NetData, OnchainPKI, Peers, PendingPassthroughs, TCP_PROTOCOL,
@@ -34,10 +37,16 @@ pub async fn networking(
     kernel_message_rx: MessageReceiver,
     // only used if indirect -- TODO use
     _reveal_ip: bool,
-    max_peers: u32,
+    max_peers: u64,
     // only used by routers
-    max_passthroughs: u32,
+    max_passthroughs: u64,
 ) -> anyhow::Result<()> {
+    crate::fd_manager::send_fd_manager_request_fds_limit(
+        &Address::new(&our.name, NET_PROCESS_ID.clone()),
+        &kernel_message_tx,
+    )
+    .await;
+
     let ext = IdentityExt {
         our: Arc::new(our),
         our_ip: Arc::new(our_ip),
@@ -62,6 +71,7 @@ pub async fn networking(
         active_passthroughs,
         max_peers,
         max_passthroughs,
+        fds_limit: 100, // TODO blocking request to fd_manager to get max num of fds at boot
     };
 
     let mut tasks = JoinSet::<anyhow::Result<()>>::new();
@@ -116,12 +126,12 @@ pub async fn networking(
 async fn local_recv(
     ext: IdentityExt,
     mut kernel_message_rx: MessageReceiver,
-    data: NetData,
+    mut data: NetData,
 ) -> anyhow::Result<()> {
     while let Some(km) = kernel_message_rx.recv().await {
         if km.target.node == ext.our.name {
             // handle messages sent to us
-            handle_message(&ext, km, &data).await;
+            handle_message(&ext, km, &mut data).await;
         } else {
             connect::send_to_peer(&ext, &data, km).await;
         }
@@ -129,7 +139,7 @@ async fn local_recv(
     Err(anyhow::anyhow!("net: kernel message channel was dropped"))
 }
 
-async fn handle_message(ext: &IdentityExt, km: KernelMessage, data: &NetData) {
+async fn handle_message(ext: &IdentityExt, km: KernelMessage, data: &mut NetData) {
     match &km.message {
         lib::core::Message::Request(request) => handle_request(ext, &km, &request.body, data).await,
         lib::core::Message::Response((response, _context)) => {
@@ -142,7 +152,7 @@ async fn handle_request(
     ext: &IdentityExt,
     km: &KernelMessage,
     request_body: &[u8],
-    data: &NetData,
+    data: &mut NetData,
 ) {
     if km.source.node == ext.our.name {
         handle_local_request(ext, km, request_body, data).await;
@@ -158,7 +168,7 @@ async fn handle_local_request(
     ext: &IdentityExt,
     km: &KernelMessage,
     request_body: &[u8],
-    data: &NetData,
+    data: &mut NetData,
 ) {
     match rmp_serde::from_slice::<NetAction>(request_body) {
         Err(_e) => {
@@ -322,7 +332,7 @@ async fn handle_local_request(
     }
 }
 
-async fn handle_fdman(km: &KernelMessage, request_body: &[u8], data: &NetData) {
+async fn handle_fdman(km: &KernelMessage, request_body: &[u8], data: &mut NetData) {
     if km.source.process != *lib::core::FD_MANAGER_PROCESS_ID {
         return;
     }
@@ -330,12 +340,19 @@ async fn handle_fdman(km: &KernelMessage, request_body: &[u8], data: &NetData) {
         return;
     };
     match req {
-        lib::core::FdManagerRequest::Cull {
-            cull_fraction_denominator,
-        } => {
-            // we are requested to cull a fraction of our peers!
+        lib::core::FdManagerRequest::FdsLimit(fds_limit) => {
+            data.fds_limit = fds_limit;
+            if data.max_peers > fds_limit {
+                data.max_peers = fds_limit;
+            }
+            // TODO combine with max_peers check
+            if data.max_passthroughs > fds_limit {
+                data.max_passthroughs = fds_limit;
+            }
             // TODO cull passthroughs too?
-            data.peers.cull(cull_fraction_denominator).await;
+            if data.peers.peers().len() >= data.fds_limit as usize {
+                data.peers.cull(2).await;
+            }
         }
         _ => return,
     }

--- a/kinode/src/net/tcp/mod.rs
+++ b/kinode/src/net/tcp/mod.rs
@@ -222,6 +222,7 @@ async fn recv_connection(
             identity: their_id.clone(),
             routing_for: their_handshake.proxy_request,
             sender: peer_tx,
+            last_message: 0,
         },
     );
     tokio::spawn(utils::maintain_connection(
@@ -343,6 +344,7 @@ pub async fn recv_via_router(
                     identity: peer_id.clone(),
                     routing_for: false,
                     sender: peer_tx,
+                    last_message: 0,
                 },
             );
             // maintain direct connection

--- a/kinode/src/net/tcp/mod.rs
+++ b/kinode/src/net/tcp/mod.rs
@@ -175,8 +175,7 @@ async fn recv_connection(
             &ext.our_ip,
             from_id,
             target_id,
-            &data.peers,
-            &data.pending_passthroughs,
+            &data,
             PendingStream::Tcp(stream),
         )
         .await;
@@ -215,16 +214,9 @@ async fn recv_connection(
         &their_id,
     )?;
 
-    let (peer_tx, peer_rx) = mpsc::unbounded_channel();
-    data.peers.insert(
-        their_id.name.clone(),
-        Peer {
-            identity: their_id.clone(),
-            routing_for: their_handshake.proxy_request,
-            sender: peer_tx,
-            last_message: 0,
-        },
-    );
+    let (peer, peer_rx) = Peer::new(their_id.clone(), their_handshake.proxy_request);
+    data.peers.insert(their_id.name.clone(), peer);
+
     tokio::spawn(utils::maintain_connection(
         their_handshake.name,
         data.peers,
@@ -337,16 +329,8 @@ pub async fn recv_via_router(
     };
     match connect_with_handshake_via_router(&ext, &peer_id, &router_id, stream).await {
         Ok(connection) => {
-            let (peer_tx, peer_rx) = mpsc::unbounded_channel();
-            data.peers.insert(
-                peer_id.name.clone(),
-                Peer {
-                    identity: peer_id.clone(),
-                    routing_for: false,
-                    sender: peer_tx,
-                    last_message: 0,
-                },
-            );
+            let (peer, peer_rx) = Peer::new(peer_id.clone(), false);
+            data.peers.insert(peer_id.name.clone(), peer);
             // maintain direct connection
             tokio::spawn(utils::maintain_connection(
                 peer_id.name,

--- a/kinode/src/net/tcp/utils.rs
+++ b/kinode/src/net/tcp/utils.rs
@@ -93,7 +93,7 @@ pub async fn maintain_connection(
     }
 
     print_debug(&print_tx, &format!("net: connection lost with {peer_name}")).await;
-    peers.remove(&peer_name);
+    peers.remove(&peer_name).await;
 }
 
 async fn send_protocol_message(

--- a/kinode/src/net/tcp/utils.rs
+++ b/kinode/src/net/tcp/utils.rs
@@ -1,7 +1,7 @@
 use crate::net::{
     tcp::PeerConnection,
     types::{HandshakePayload, IdentityExt, Peers},
-    utils::{print_debug, print_loud, MESSAGE_MAX_SIZE},
+    utils::{print_debug, print_loud, IDLE_TIMEOUT, MESSAGE_MAX_SIZE},
 };
 use lib::types::core::{KernelMessage, MessageSender, NodeId, PrintSender};
 use {
@@ -82,9 +82,14 @@ pub async fn maintain_connection(
         }
     };
 
+    let timeout = tokio::time::sleep(IDLE_TIMEOUT);
+
     tokio::select! {
         _ = write => (),
         _ = read => (),
+        _ = timeout => {
+            print_debug(&print_tx, &format!("net: closing idle connection with {peer_name}")).await;
+        }
     }
 
     print_debug(&print_tx, &format!("net: connection lost with {peer_name}")).await;

--- a/kinode/src/net/types.rs
+++ b/kinode/src/net/types.rs
@@ -115,13 +115,12 @@ impl Peers {
         self.peers.remove(name)
     }
 
-    /// close the (peer count / fraction) oldest connections
-    pub async fn cull(&self, fraction: u64) {
-        let num_to_remove = (self.peers.len() as f64 / fraction as f64).ceil() as usize;
-        let mut to_remove = Vec::with_capacity(num_to_remove);
+    /// close the n oldest connections
+    pub async fn cull(&self, n: usize) {
+        let mut to_remove = Vec::with_capacity(n);
         let mut sorted_peers: Vec<_> = self.peers.iter().collect();
         sorted_peers.sort_by_key(|p| p.last_message);
-        to_remove.extend(sorted_peers.iter().take(num_to_remove));
+        to_remove.extend(sorted_peers.iter().take(n));
         for peer in to_remove {
             self.peers.remove(&peer.identity.name);
         }

--- a/kinode/src/net/types.rs
+++ b/kinode/src/net/types.rs
@@ -100,6 +100,18 @@ impl Peers {
     pub fn remove(&self, name: &str) -> Option<(String, Peer)> {
         self.peers.remove(name)
     }
+
+    /// close the (peer count / fraction) oldest connections
+    pub fn cull(&self, fraction: u64) {
+        let num_to_remove = (self.peers.len() as f64 / fraction as f64).ceil() as usize;
+        let mut to_remove = Vec::with_capacity(num_to_remove);
+        let mut sorted_peers: Vec<_> = self.peers.iter().collect();
+        sorted_peers.sort_by_key(|p| p.last_message);
+        to_remove.extend(sorted_peers.iter().take(num_to_remove));
+        for peer in to_remove {
+            self.peers.remove(&peer.identity.name);
+        }
+    }
 }
 
 pub type OnchainPKI = Arc<DashMap<String, Identity>>;

--- a/kinode/src/net/types.rs
+++ b/kinode/src/net/types.rs
@@ -1,6 +1,6 @@
-use crate::net::utils;
 use lib::types::core::{
-    Identity, KernelMessage, MessageSender, NetworkErrorSender, NodeId, PrintSender,
+    Address, Identity, KernelMessage, MessageSender, NetworkErrorSender, NodeId, PrintSender,
+    NET_PROCESS_ID,
 };
 use {
     dashmap::DashMap,
@@ -57,13 +57,13 @@ pub struct RoutingRequest {
 
 #[derive(Clone)]
 pub struct Peers {
-    max_peers: u32,
+    max_peers: u64,
     send_to_loop: MessageSender,
     peers: Arc<DashMap<String, Peer>>,
 }
 
 impl Peers {
-    pub fn new(max_peers: u32, send_to_loop: MessageSender) -> Self {
+    pub fn new(max_peers: u64, send_to_loop: MessageSender) -> Self {
         Self {
             max_peers,
             send_to_loop,
@@ -103,13 +103,15 @@ impl Peers {
                 .key()
                 .clone();
             self.peers.remove(&oldest);
-        } else {
-            utils::send_fd_manager_open(1, &self.send_to_loop).await;
+            crate::fd_manager::send_fd_manager_hit_fds_limit(
+                &Address::new("our", NET_PROCESS_ID.clone()),
+                &self.send_to_loop,
+            )
+            .await;
         }
     }
 
     pub async fn remove(&self, name: &str) -> Option<(String, Peer)> {
-        utils::send_fd_manager_close(1, &self.send_to_loop).await;
         self.peers.remove(name)
     }
 
@@ -123,7 +125,11 @@ impl Peers {
         for peer in to_remove {
             self.peers.remove(&peer.identity.name);
         }
-        utils::send_fd_manager_close(num_to_remove as u64, &self.send_to_loop).await;
+        crate::fd_manager::send_fd_manager_hit_fds_limit(
+            &Address::new("our", NET_PROCESS_ID.clone()),
+            &self.send_to_loop,
+        )
+        .await;
     }
 }
 
@@ -217,6 +223,7 @@ pub struct NetData {
     pub pending_passthroughs: PendingPassthroughs,
     /// only used by routers
     pub active_passthroughs: ActivePassthroughs,
-    pub max_peers: u32,
-    pub max_passthroughs: u32,
+    pub max_peers: u64,
+    pub max_passthroughs: u64,
+    pub fds_limit: u64,
 }

--- a/kinode/src/net/types.rs
+++ b/kinode/src/net/types.rs
@@ -94,10 +94,11 @@ impl Peers {
     /// remove the one with the oldest last_message.
     pub async fn insert(&self, name: String, peer: Peer) {
         self.peers.insert(name, peer);
-        utils::send_fd_manager_open(1, &self.send_to_loop).await;
         if self.peers.len() > self.max_peers as usize {
-            let oldest = self.peers.iter().min_by_key(|p| p.last_message).unwrap();
-            self.peers.remove(oldest.key());
+            let oldest = self.peers.iter().min_by_key(|p| p.last_message).unwrap().key().clone();
+            self.peers.remove(&oldest);
+        } else {
+            utils::send_fd_manager_open(1, &self.send_to_loop).await;
         }
     }
 

--- a/kinode/src/net/types.rs
+++ b/kinode/src/net/types.rs
@@ -95,7 +95,13 @@ impl Peers {
     pub async fn insert(&self, name: String, peer: Peer) {
         self.peers.insert(name, peer);
         if self.peers.len() > self.max_peers as usize {
-            let oldest = self.peers.iter().min_by_key(|p| p.last_message).unwrap().key().clone();
+            let oldest = self
+                .peers
+                .iter()
+                .min_by_key(|p| p.last_message)
+                .unwrap()
+                .key()
+                .clone();
             self.peers.remove(&oldest);
         } else {
             utils::send_fd_manager_open(1, &self.send_to_loop).await;

--- a/kinode/src/net/types.rs
+++ b/kinode/src/net/types.rs
@@ -3,7 +3,7 @@ use lib::types::core::{
     Identity, KernelMessage, MessageSender, NetworkErrorSender, NodeId, PrintSender,
 };
 use {
-    dashmap::{DashMap, DashSet},
+    dashmap::DashMap,
     ring::signature::Ed25519KeyPair,
     serde::{Deserialize, Serialize},
     std::sync::Arc,
@@ -132,7 +132,7 @@ pub type OnchainPKI = Arc<DashMap<String, Identity>>;
 /// (from, target) -> from's socket
 ///
 /// only used by routers
-pub type PendingPassthroughs = Arc<DashMap<(NodeId, NodeId), PendingStream>>;
+pub type PendingPassthroughs = Arc<DashMap<(NodeId, NodeId), (PendingStream, u64)>>;
 pub enum PendingStream {
     WebSocket(WebSocketStream<MaybeTlsStream<TcpStream>>),
     Tcp(TcpStream),
@@ -141,7 +141,7 @@ pub enum PendingStream {
 /// (from, target)
 ///
 /// only used by routers
-pub type ActivePassthroughs = Arc<DashSet<(NodeId, NodeId)>>;
+pub type ActivePassthroughs = Arc<DashMap<(NodeId, NodeId), (u64, KillSender)>>;
 
 impl PendingStream {
     pub fn is_ws(&self) -> bool {
@@ -151,6 +151,8 @@ impl PendingStream {
         matches!(self, PendingStream::Tcp(_))
     }
 }
+
+type KillSender = tokio::sync::mpsc::Sender<()>;
 
 pub struct Peer {
     pub identity: Identity,

--- a/kinode/src/net/utils.rs
+++ b/kinode/src/net/utils.rs
@@ -1,10 +1,10 @@
 use crate::net::types::{
-    HandshakePayload, OnchainPKI, Peers, PendingPassthroughs, PendingStream, RoutingRequest,
+    ActivePassthroughs, HandshakePayload, NetData, OnchainPKI, PendingStream, RoutingRequest,
     TCP_PROTOCOL, WS_PROTOCOL,
 };
 use lib::types::core::{
     Identity, KernelMessage, KnsUpdate, Message, MessageSender, NetAction, NetworkErrorSender,
-    NodeRouting, PrintSender, Printout, Request, Response, SendError, SendErrorKind,
+    NodeId, NodeRouting, PrintSender, Printout, Request, Response, SendError, SendErrorKind,
     WrappedSendError,
 };
 use {
@@ -30,24 +30,33 @@ pub const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 /// 30 minute idle timeout for connections
 pub const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1800);
 
-/// maximum number of peers (open connections, but does not include passthroughs we provide!)
-pub const MAX_PEERS: usize = 100;
-
 pub async fn create_passthrough(
     our: &Identity,
     our_ip: &str,
     from_id: Identity,
     target_id: Identity,
-    peers: &Peers,
-    pending_passthroughs: &PendingPassthroughs,
+    data: &NetData,
     socket_1: PendingStream,
 ) -> anyhow::Result<()> {
+    // if we already are at the max number of passthroughs, reject
+    if data.active_passthroughs.len() + data.pending_passthroughs.len()
+        >= data.max_passthroughs as usize
+    {
+        return Err(anyhow::anyhow!("max passthroughs reached"));
+    }
     // if the target has already generated a pending passthrough for this source,
     // immediately match them
-    if let Some(((_target, _from), pending_stream)) =
-        pending_passthroughs.remove(&(target_id.name.clone(), from_id.name.clone()))
+    if let Some(((from, target), pending_stream)) = data
+        .pending_passthroughs
+        .remove(&(target_id.name.clone(), from_id.name.clone()))
     {
-        tokio::spawn(maintain_passthrough(socket_1, pending_stream));
+        tokio::spawn(maintain_passthrough(
+            from,
+            target,
+            socket_1,
+            pending_stream,
+            data.active_passthroughs.clone(),
+        ));
         return Ok(());
     }
     if socket_1.is_tcp() {
@@ -63,7 +72,13 @@ pub async fn create_passthrough(
                     from_id.name
                 ));
             };
-            tokio::spawn(maintain_passthrough(socket_1, PendingStream::Tcp(stream_2)));
+            tokio::spawn(maintain_passthrough(
+                from_id.name,
+                target_id.name,
+                socket_1,
+                PendingStream::Tcp(stream_2),
+                data.active_passthroughs.clone(),
+            ));
             return Ok(());
         }
     } else if socket_1.is_ws() {
@@ -79,14 +94,17 @@ pub async fn create_passthrough(
                 ));
             };
             tokio::spawn(maintain_passthrough(
+                from_id.name,
+                target_id.name,
                 socket_1,
                 PendingStream::WebSocket(socket_2),
+                data.active_passthroughs.clone(),
             ));
             return Ok(());
         }
     }
     // create passthrough to indirect node that we do routing for
-    let target_peer = peers.get(&target_id.name).ok_or(anyhow::anyhow!(
+    let target_peer = data.peers.get(&target_id.name).ok_or(anyhow::anyhow!(
         "can't route to {}, not a peer, for passthrough requested by {}",
         target_id.name,
         from_id.name
@@ -119,12 +137,20 @@ pub async fn create_passthrough(
     // or if the target node connects to us with a matching passthrough.
     // TODO it is currently possible to have dangling passthroughs in the map
     // if the target is "connected" to us but nonresponsive.
-    pending_passthroughs.insert((from_id.name, target_id.name), socket_1);
+    data.pending_passthroughs
+        .insert((from_id.name, target_id.name), socket_1);
     Ok(())
 }
 
 /// cross the streams -- spawn on own task
-pub async fn maintain_passthrough(socket_1: PendingStream, socket_2: PendingStream) {
+pub async fn maintain_passthrough(
+    from: NodeId,
+    target: NodeId,
+    socket_1: PendingStream,
+    socket_2: PendingStream,
+    active_passthroughs: ActivePassthroughs,
+) {
+    active_passthroughs.insert((from.clone(), target.clone()));
     match (socket_1, socket_2) {
         (PendingStream::Tcp(socket_1), PendingStream::Tcp(socket_2)) => {
             // do not use bidirectional because if one side closes,
@@ -176,9 +202,9 @@ pub async fn maintain_passthrough(socket_1: PendingStream, socket_2: PendingStre
         }
         _ => {
             // these foolish combinations must never occur
-            return;
         }
     }
+    active_passthroughs.remove(&(from, target));
 }
 
 pub fn ingest_log(log: KnsUpdate, pki: &OnchainPKI) {

--- a/kinode/src/net/utils.rs
+++ b/kinode/src/net/utils.rs
@@ -27,6 +27,12 @@ pub const MESSAGE_MAX_SIZE: u32 = 10_485_800;
 
 pub const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// 30 minute idle timeout for connections
+pub const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1800);
+
+/// maximum number of peers (open connections, but does not include passthroughs we provide!)
+pub const MAX_PEERS: usize = 100;
+
 pub async fn create_passthrough(
     our: &Identity,
     our_ip: &str,

--- a/kinode/src/net/utils.rs
+++ b/kinode/src/net/utils.rs
@@ -52,23 +52,22 @@ pub async fn create_passthrough(
     if data.active_passthroughs.len() + data.pending_passthroughs.len()
         >= data.max_passthroughs as usize
     {
-        let oldest_active = data
-            .active_passthroughs
-            .iter()
-            .min_by_key(|p| p.0);
-        let (oldest_active_key, oldest_active_time, oldest_active_kill_sender) = match oldest_active {
+        let oldest_active = data.active_passthroughs.iter().min_by_key(|p| p.0);
+        let (oldest_active_key, oldest_active_time, oldest_active_kill_sender) = match oldest_active
+        {
             None => (None, get_now(), None),
             Some(oldest_active) => {
                 let (oldest_active_key, oldest_active_val) = oldest_active.pair();
                 let oldest_active_key = oldest_active_key.clone();
                 let (oldest_active_time, oldest_active_kill_sender) = oldest_active_val.clone();
-                (Some(oldest_active_key), oldest_active_time, Some(oldest_active_kill_sender))
+                (
+                    Some(oldest_active_key),
+                    oldest_active_time,
+                    Some(oldest_active_kill_sender),
+                )
             }
         };
-        let oldest_pending = data
-            .pending_passthroughs
-            .iter()
-            .min_by_key(|p| p.1);
+        let oldest_pending = data.pending_passthroughs.iter().min_by_key(|p| p.1);
         let (oldest_pending_key, oldest_pending_time) = match oldest_pending {
             None => (None, get_now()),
             Some(oldest_pending) => {
@@ -84,7 +83,8 @@ pub async fn create_passthrough(
             data.active_passthroughs.remove(&oldest_active_key.unwrap());
         } else {
             // pending key is oldest
-            data.pending_passthroughs.remove(&oldest_pending_key.unwrap());
+            data.pending_passthroughs
+                .remove(&oldest_pending_key.unwrap());
         }
     }
     // if the target has already generated a pending passthrough for this source,

--- a/kinode/src/net/utils.rs
+++ b/kinode/src/net/utils.rs
@@ -3,9 +3,9 @@ use crate::net::types::{
     RoutingRequest, TCP_PROTOCOL, WS_PROTOCOL,
 };
 use lib::types::core::{
-    Address, Identity, KernelMessage, KnsUpdate, Message, MessageSender, NetAction,
-    NetworkErrorSender, NodeId, NodeRouting, PrintSender, Printout, Request, Response, SendError,
-    SendErrorKind, WrappedSendError, NET_PROCESS_ID,
+    Identity, KernelMessage, KnsUpdate, Message, MessageSender, NetAction, NetworkErrorSender,
+    NodeId, NodeRouting, PrintSender, Printout, Request, Response, SendError, SendErrorKind,
+    WrappedSendError,
 };
 use {
     futures::{SinkExt, StreamExt},
@@ -425,18 +425,6 @@ pub async fn parse_hello_message(
         .unwrap()
         .send(kernel_message_tx)
         .await;
-}
-
-/// Send an OpenFds message to the fd_manager.
-pub async fn send_fd_manager_open(num_opened: u64, kernel_message_tx: &MessageSender) {
-    let our: Address = Address::new("our", NET_PROCESS_ID.clone());
-    let _ = crate::fd_manager::send_fd_manager_open(&our, num_opened, kernel_message_tx).await;
-}
-
-/// Send a CloseFds message to the fd_manager.
-pub async fn send_fd_manager_close(num_closed: u64, kernel_message_tx: &MessageSender) {
-    let our: Address = Address::new("our", NET_PROCESS_ID.clone());
-    let _ = crate::fd_manager::send_fd_manager_close(&our, num_closed, kernel_message_tx).await;
 }
 
 /// Create a terminal printout at verbosity level 0.

--- a/kinode/src/net/ws/mod.rs
+++ b/kinode/src/net/ws/mod.rs
@@ -187,16 +187,8 @@ pub async fn recv_via_router(
     };
     match connect_with_handshake_via_router(&ext, &peer_id, &router_id, socket).await {
         Ok(connection) => {
-            let (peer_tx, peer_rx) = mpsc::unbounded_channel();
-            data.peers.insert(
-                peer_id.name.clone(),
-                Peer {
-                    identity: peer_id.clone(),
-                    routing_for: false,
-                    sender: peer_tx,
-                    last_message: 0,
-                },
-            );
+            let (peer, peer_rx) = Peer::new(peer_id.clone(), false);
+            data.peers.insert(peer_id.name.clone(), peer);
             // maintain direct connection
             tokio::spawn(utils::maintain_connection(
                 peer_id.name,
@@ -233,8 +225,7 @@ async fn recv_connection(
             &ext.our_ip,
             from_id,
             target_id,
-            &data.peers,
-            &data.pending_passthroughs,
+            &data,
             PendingStream::WebSocket(socket),
         )
         .await;
@@ -273,16 +264,9 @@ async fn recv_connection(
         &their_id,
     )?;
 
-    let (peer_tx, peer_rx) = mpsc::unbounded_channel();
-    data.peers.insert(
-        their_id.name.clone(),
-        Peer {
-            identity: their_id.clone(),
-            routing_for: their_handshake.proxy_request,
-            sender: peer_tx,
-            last_message: 0,
-        },
-    );
+    let (peer, peer_rx) = Peer::new(their_id.clone(), their_handshake.proxy_request);
+    data.peers.insert(their_id.name.clone(), peer);
+
     tokio::spawn(utils::maintain_connection(
         their_handshake.name,
         data.peers,

--- a/kinode/src/net/ws/mod.rs
+++ b/kinode/src/net/ws/mod.rs
@@ -194,6 +194,7 @@ pub async fn recv_via_router(
                     identity: peer_id.clone(),
                     routing_for: false,
                     sender: peer_tx,
+                    last_message: 0,
                 },
             );
             // maintain direct connection
@@ -279,6 +280,7 @@ async fn recv_connection(
             identity: their_id.clone(),
             routing_for: their_handshake.proxy_request,
             sender: peer_tx,
+            last_message: 0,
         },
     );
     tokio::spawn(utils::maintain_connection(

--- a/kinode/src/net/ws/mod.rs
+++ b/kinode/src/net/ws/mod.rs
@@ -188,7 +188,7 @@ pub async fn recv_via_router(
     match connect_with_handshake_via_router(&ext, &peer_id, &router_id, socket).await {
         Ok(connection) => {
             let (peer, peer_rx) = Peer::new(peer_id.clone(), false);
-            data.peers.insert(peer_id.name.clone(), peer);
+            data.peers.insert(peer_id.name.clone(), peer).await;
             // maintain direct connection
             tokio::spawn(utils::maintain_connection(
                 peer_id.name,
@@ -221,8 +221,7 @@ async fn recv_connection(
         let (from_id, target_id) =
             validate_routing_request(&ext.our.name, first_message, &data.pki)?;
         return create_passthrough(
-            &ext.our,
-            &ext.our_ip,
+            &ext,
             from_id,
             target_id,
             &data,
@@ -265,7 +264,7 @@ async fn recv_connection(
     )?;
 
     let (peer, peer_rx) = Peer::new(their_id.clone(), their_handshake.proxy_request);
-    data.peers.insert(their_id.name.clone(), peer);
+    data.peers.insert(their_id.name.clone(), peer).await;
 
     tokio::spawn(utils::maintain_connection(
         their_handshake.name,

--- a/kinode/src/net/ws/utils.rs
+++ b/kinode/src/net/ws/utils.rs
@@ -1,6 +1,6 @@
 use crate::net::{
     types::{HandshakePayload, IdentityExt, Peers},
-    utils::{print_debug, print_loud, MESSAGE_MAX_SIZE},
+    utils::{print_debug, print_loud, IDLE_TIMEOUT, MESSAGE_MAX_SIZE},
     ws::{PeerConnection, WebSocket},
 };
 use lib::core::{KernelMessage, MessageSender, NodeId, PrintSender};
@@ -103,9 +103,14 @@ pub async fn maintain_connection(
         }
     };
 
+    let timeout = tokio::time::sleep(IDLE_TIMEOUT);
+
     tokio::select! {
         _ = write => (),
         _ = read => (),
+        _ = timeout => {
+            print_debug(&print_tx, &format!("net: closing idle connection with {peer_name}")).await;
+        }
     }
 
     print_debug(&print_tx, &format!("net: connection lost with {peer_name}")).await;

--- a/kinode/src/net/ws/utils.rs
+++ b/kinode/src/net/ws/utils.rs
@@ -114,7 +114,7 @@ pub async fn maintain_connection(
     }
 
     print_debug(&print_tx, &format!("net: connection lost with {peer_name}")).await;
-    peers.remove(&peer_name);
+    peers.remove(&peer_name).await;
 }
 
 async fn send_protocol_message(

--- a/kinode/src/sqlite.rs
+++ b/kinode/src/sqlite.rs
@@ -56,9 +56,9 @@ impl SqliteState {
     pub async fn open_db(&mut self, package_id: PackageId, db: String) -> Result<(), SqliteError> {
         let key = (package_id.clone(), db.clone());
         if self.open_dbs.contains_key(&key) {
-            // let mut access_order = self.access_order.lock().await;
-            // access_order.remove(&key);
-            // access_order.push_back(key);
+            let mut access_order = self.access_order.lock().await;
+            access_order.remove(&key);
+            access_order.push_back(key);
             return Ok(());
         }
 
@@ -515,10 +515,11 @@ async fn check_caps(
                 .remove_db(request.package_id.clone(), request.db.clone())
                 .await;
 
-            let _ = fs::remove_dir_all(format!(
+            fs::remove_dir_all(format!(
                 "{}/{}/{}",
                 state.sqlite_path, request.package_id, request.db
-            ));
+            ))
+            .await?;
 
             Ok(())
         }

--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -392,7 +392,9 @@ async fn handle_event(
                 cursor::MoveTo(0, height),
                 terminal::Clear(ClearType::CurrentLine)
             )?;
-            *win_cols = width - 1;
+            // since we subtract prompt_len from win_cols, win_cols must always
+            // be >= prompt_len
+            *win_cols = std::cmp::max(width - 1, current_line.prompt_len as u16);
             *win_rows = height;
             if current_line.cursor_col + current_line.prompt_len as u16 > *win_cols {
                 current_line.cursor_col = *win_cols - current_line.prompt_len as u16;

--- a/kinode/src/vfs.rs
+++ b/kinode/src/vfs.rs
@@ -165,7 +165,7 @@ impl Files {
             access_order: Arc::new(Mutex::new(UniqueQueue::new())),
             our,
             send_to_loop,
-            fds_limit: 100, // TODO blocking request to fd_manager to get max num of fds at boot
+            fds_limit: 10, // small hardcoded limit that gets replaced by fd_manager soon after boot
         }
     }
 
@@ -1031,9 +1031,7 @@ async fn handle_fd_request(km: KernelMessage, files: &mut Files) -> anyhow::Resu
                 crate::fd_manager::send_fd_manager_hit_fds_limit(&files.our, &files.send_to_loop)
                     .await;
                 files
-                    .close_least_recently_used_files(
-                        (files.open_files.len() as u64 - fds_limit) / 2,
-                    )
+                    .close_least_recently_used_files(files.open_files.len() as u64 - fds_limit)
                     .await?;
             }
         }

--- a/kinode/src/vfs.rs
+++ b/kinode/src/vfs.rs
@@ -19,9 +19,6 @@ use tokio::{
     sync::Mutex,
 };
 
-// Constants for file cleanup
-const MAX_OPEN_FILES: usize = 180;
-
 /// The main VFS service function.
 ///
 /// This function sets up the VFS, handles incoming requests, and manages file operations.

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -1720,6 +1720,8 @@ pub enum VfsError {
     NotFound { path: String },
     #[error("Creating directory failed at path: {path}: {error}")]
     CreateDirError { path: String, error: String },
+    #[error("Other error: {error}")]
+    Other { error: String },
 }
 
 impl VfsError {
@@ -1734,6 +1736,7 @@ impl VfsError {
             VfsError::BadJson { .. } => "NoJson",
             VfsError::NotFound { .. } => "NotFound",
             VfsError::CreateDirError { .. } => "CreateDirError",
+            VfsError::Other { .. } => "Other",
         }
     }
 }

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -2073,11 +2073,17 @@ impl KnsUpdate {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum FdManagerRequest {
     /// other process -> fd_manager
-    OpenFds { number_opened: u64 },
-    CloseFds { number_closed: u64 },
+    OpenFds {
+        number_opened: u64,
+    },
+    CloseFds {
+        number_closed: u64,
+    },
 
     /// fd_manager -> other process
-    Cull { cull_fraction_denominator: u64 },
+    Cull {
+        cull_fraction_denominator: u64,
+    },
 
     /// administrative
     UpdateMaxFdsAsFractionOfUlimitPercentage(u64),

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -8,16 +8,17 @@ use thiserror::Error;
 
 lazy_static::lazy_static! {
     pub static ref ETH_PROCESS_ID: ProcessId = ProcessId::new(Some("eth"), "distro", "sys");
+    pub static ref FD_MANAGER_PROCESS_ID: ProcessId = ProcessId::new(Some("fd_manager"), "distro", "sys");
     pub static ref HTTP_CLIENT_PROCESS_ID: ProcessId = ProcessId::new(Some("http_client"), "distro", "sys");
     pub static ref HTTP_SERVER_PROCESS_ID: ProcessId = ProcessId::new(Some("http_server"), "distro", "sys");
     pub static ref KERNEL_PROCESS_ID: ProcessId = ProcessId::new(Some("kernel"), "distro", "sys");
+    pub static ref KV_PROCESS_ID: ProcessId = ProcessId::new(Some("kv"), "distro", "sys");
+    pub static ref NET_PROCESS_ID: ProcessId = ProcessId::new(Some("net"), "distro", "sys");
+    pub static ref STATE_PROCESS_ID: ProcessId = ProcessId::new(Some("state"), "distro", "sys");
+    pub static ref SQLITE_PROCESS_ID: ProcessId = ProcessId::new(Some("sqlite"), "distro", "sys");
     pub static ref TERMINAL_PROCESS_ID: ProcessId = ProcessId::new(Some("terminal"), "terminal", "sys");
     pub static ref TIMER_PROCESS_ID: ProcessId = ProcessId::new(Some("timer"), "distro", "sys");
     pub static ref VFS_PROCESS_ID: ProcessId = ProcessId::new(Some("vfs"), "distro", "sys");
-    pub static ref STATE_PROCESS_ID: ProcessId = ProcessId::new(Some("state"), "distro", "sys");
-    pub static ref KV_PROCESS_ID: ProcessId = ProcessId::new(Some("kv"), "distro", "sys");
-    pub static ref SQLITE_PROCESS_ID: ProcessId = ProcessId::new(Some("sqlite"), "distro", "sys");
-    pub static ref FD_MANAGER_PROCESS_ID: ProcessId = ProcessId::new(Some("fd_manager"), "distro", "sys");
 }
 
 //
@@ -2076,22 +2077,32 @@ impl KnsUpdate {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum FdManagerRequest {
     /// other process -> fd_manager
-    OpenFds {
-        number_opened: u64,
-    },
-    CloseFds {
-        number_closed: u64,
-    },
+    OpenFds { number_opened: u64 },
+    /// other process -> fd_manager
+    CloseFds { number_closed: u64 },
 
     /// fd_manager -> other process
-    Cull {
-        cull_fraction_denominator: u64,
-    },
+    Cull { cull_fraction_denominator: u64 },
 
     /// administrative
     UpdateMaxFdsAsFractionOfUlimitPercentage(u64),
+    /// administrative
     UpdateUpdateUlimitSecs(u64),
+    /// administrative
     UpdateCullFractionDenominator(u64),
+
+    /// get a `HashMap` of all `ProcessId`s to their known number of open file descriptors.
+    GetState,
+    /// get the `u64` known number of file descriptors used by `ProcessId`.
+    GetProcessFdCount(ProcessId),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FdManagerResponse {
+    /// response to [`FdManagerRequest::GetState`]
+    GetState(HashMap<ProcessId, u64>),
+    /// response to [`FdManagerRequest::GetProcessFdCount`]
+    GetProcessFdCount(u64),
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
## Problem

We run out of file descriptors because things like TCP sockets consume them: #556

## Solution

Introduce a new runtime module: `fd_manager`. It is pretty simple: it just tracks the number allowed `fd`s. Runtime modules that consume `fd`s must notify `fd_manager` when they open or close an `fd`. Then, if the total amount of `fd`s passes some threshold, `fd_manager` sends out a Request to all runtime modules with open `fd`s to `Cull` their old `fd`s with a suggested fraction to cull. Runtime modules that consume `fd`s must, therefore, also implement logic to respond to a `Cull`.

## Testing

TODO

## Docs Update

TODO

## Notes

TODO list:

- [x] Write `fd_manager` skeleton
- [x] Write `fd_manager` helper `send_fd_manager_open(number_opened: u64)`
- [x] Write `fd_manager` helper `send_fd_manager_close(number_closed: u64)`
- [x] Update vfs to talk to `fd_manager`
- [x] Update sqlite to talk to `fd_manager`
- [x] Update kv to talk to `fd_manager`
- [x] Update net to talk to `fd_manager`
- [ ] Look for any other consumers of fds and update them to talk to `fd_manager`
- [ ] Test