### PR TITLE
net: add MAX_PEERS, add idle timeouts

### DIFF
--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -353,6 +353,8 @@ async fn main() {
         print_sender.clone(),
         net_message_receiver,
         *matches.get_one::<bool>("reveal-ip").unwrap_or(&true),
+        *matches.get_one::<u32>("max-peers").unwrap_or(&100),
+        *matches.get_one::<u32>("max-passthroughs").unwrap_or(&0),
     ));
     tasks.spawn(state::state_sender(
         our_name_arc.clone(),
@@ -695,6 +697,14 @@ fn build_command() -> Command {
         .arg(
             arg!(--"number-log-files" <NUMBER_LOG_FILES> "Number of logs to rotate (default 4)")
                 .value_parser(value_parser!(u64)),
+        )
+        .arg(
+            arg!(--"max-peers" <MAX_PEERS> "Maximum number of peers to hold active connections with (default 100)")
+                .value_parser(value_parser!(u32)),
+        )
+        .arg(
+            arg!(--"max-passthroughs" <MAX_PASSTHROUGHS> "Maximum number of passthroughs serve as a router (default 0)")
+                .value_parser(value_parser!(u32)),
         );
 
     #[cfg(feature = "simulation-mode")]

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -48,6 +48,10 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 const WS_MIN_PORT: u16 = 9_000;
 const TCP_MIN_PORT: u16 = 10_000;
 const MAX_PORT: u16 = 65_535;
+
+const DEFAULT_MAX_PEERS: u32 = 32;
+const DEFAULT_MAX_PASSTHROUGHS: u32 = 0;
+
 /// default routers as a eth-provider fallback
 const DEFAULT_ETH_PROVIDERS: &str = include_str!("eth/default_providers_mainnet.json");
 #[cfg(not(feature = "simulation-mode"))]
@@ -353,8 +357,12 @@ async fn main() {
         print_sender.clone(),
         net_message_receiver,
         *matches.get_one::<bool>("reveal-ip").unwrap_or(&true),
-        *matches.get_one::<u32>("max-peers").unwrap_or(&100),
-        *matches.get_one::<u32>("max-passthroughs").unwrap_or(&0),
+        *matches
+            .get_one::<u32>("max-peers")
+            .unwrap_or(&DEFAULT_MAX_PEERS),
+        *matches
+            .get_one::<u32>("max-passthroughs")
+            .unwrap_or(&DEFAULT_MAX_PASSTHROUGHS),
     ));
     tasks.spawn(state::state_sender(
         our_name_arc.clone(),
@@ -699,7 +707,7 @@ fn build_command() -> Command {
                 .value_parser(value_parser!(u64)),
         )
         .arg(
-            arg!(--"max-peers" <MAX_PEERS> "Maximum number of peers to hold active connections with (default 100)")
+            arg!(--"max-peers" <MAX_PEERS> "Maximum number of peers to hold active connections with (default 32)")
                 .value_parser(value_parser!(u32)),
         )
         .arg(

--- a/kinode/src/net/indirect.rs
+++ b/kinode/src/net/indirect.rs
@@ -36,6 +36,7 @@ pub async fn connect_to_router(router_id: &Identity, ext: &IdentityExt, data: &N
             identity: router_id.clone(),
             routing_for: false,
             sender: peer_tx.clone(),
+            last_message: 0,
         },
     );
     if let Some((_ip, port)) = router_id.tcp_routing() {

--- a/kinode/src/net/mod.rs
+++ b/kinode/src/net/mod.rs
@@ -45,7 +45,7 @@ pub async fn networking(
     // start by initializing the structs where we'll store PKI in memory
     // and store a mapping of peers we have an active route for
     let pki: OnchainPKI = Arc::new(DashMap::new());
-    let peers: Peers = Arc::new(DashMap::new());
+    let peers: Peers = Peers(Arc::new(DashMap::new()));
     // only used by routers
     let pending_passthroughs: PendingPassthroughs = Arc::new(DashMap::new());
 
@@ -171,6 +171,7 @@ async fn handle_local_request(
                 NetAction::GetPeers => (
                     NetResponse::Peers(
                         data.peers
+                            .0
                             .iter()
                             .map(|p| p.identity.clone())
                             .collect::<Vec<Identity>>(),
@@ -189,10 +190,11 @@ async fn handle_local_request(
                     ));
                     printout.push_str(&format!("our Identity: {:#?}\r\n", ext.our));
                     printout.push_str(&format!(
-                        "we have connections with {} peers:\r\n",
-                        data.peers.len()
+                        "we have connections with {} peers ({} max):\r\n",
+                        data.peers.0.len(),
+                        utils::MAX_PEERS,
                     ));
-                    for peer in data.peers.iter() {
+                    for peer in data.peers.0.iter() {
                         printout.push_str(&format!(
                             "    {}, routing_for={}\r\n",
                             peer.identity.name, peer.routing_for,

--- a/kinode/src/net/tcp/mod.rs
+++ b/kinode/src/net/tcp/mod.rs
@@ -222,6 +222,7 @@ async fn recv_connection(
             identity: their_id.clone(),
             routing_for: their_handshake.proxy_request,
             sender: peer_tx,
+            last_message: 0,
         },
     );
     tokio::spawn(utils::maintain_connection(
@@ -343,6 +344,7 @@ pub async fn recv_via_router(
                     identity: peer_id.clone(),
                     routing_for: false,
                     sender: peer_tx,
+                    last_message: 0,
                 },
             );
             // maintain direct connection

--- a/kinode/src/net/tcp/mod.rs
+++ b/kinode/src/net/tcp/mod.rs
@@ -175,8 +175,7 @@ async fn recv_connection(
             &ext.our_ip,
             from_id,
             target_id,
-            &data.peers,
-            &data.pending_passthroughs,
+            &data,
             PendingStream::Tcp(stream),
         )
         .await;
@@ -215,16 +214,9 @@ async fn recv_connection(
         &their_id,
     )?;
 
-    let (peer_tx, peer_rx) = mpsc::unbounded_channel();
-    data.peers.insert(
-        their_id.name.clone(),
-        Peer {
-            identity: their_id.clone(),
-            routing_for: their_handshake.proxy_request,
-            sender: peer_tx,
-            last_message: 0,
-        },
-    );
+    let (peer, peer_rx) = Peer::new(their_id.clone(), their_handshake.proxy_request);
+    data.peers.insert(their_id.name.clone(), peer);
+
     tokio::spawn(utils::maintain_connection(
         their_handshake.name,
         data.peers,
@@ -337,16 +329,8 @@ pub async fn recv_via_router(
     };
     match connect_with_handshake_via_router(&ext, &peer_id, &router_id, stream).await {
         Ok(connection) => {
-            let (peer_tx, peer_rx) = mpsc::unbounded_channel();
-            data.peers.insert(
-                peer_id.name.clone(),
-                Peer {
-                    identity: peer_id.clone(),
-                    routing_for: false,
-                    sender: peer_tx,
-                    last_message: 0,
-                },
-            );
+            let (peer, peer_rx) = Peer::new(peer_id.clone(), false);
+            data.peers.insert(peer_id.name.clone(), peer);
             // maintain direct connection
             tokio::spawn(utils::maintain_connection(
                 peer_id.name,

--- a/kinode/src/net/tcp/utils.rs
+++ b/kinode/src/net/tcp/utils.rs
@@ -1,7 +1,7 @@
 use crate::net::{
     tcp::PeerConnection,
     types::{HandshakePayload, IdentityExt, Peers},
-    utils::{print_debug, print_loud, MESSAGE_MAX_SIZE},
+    utils::{print_debug, print_loud, IDLE_TIMEOUT, MESSAGE_MAX_SIZE},
 };
 use lib::types::core::{KernelMessage, MessageSender, NodeId, PrintSender};
 use {
@@ -82,9 +82,14 @@ pub async fn maintain_connection(
         }
     };
 
+    let timeout = tokio::time::sleep(IDLE_TIMEOUT);
+
     tokio::select! {
         _ = write => (),
         _ = read => (),
+        _ = timeout => {
+            print_debug(&print_tx, &format!("net: closing idle connection with {peer_name}")).await;
+        }
     }
 
     print_debug(&print_tx, &format!("net: connection lost with {peer_name}")).await;

--- a/kinode/src/net/types.rs
+++ b/kinode/src/net/types.rs
@@ -100,6 +100,18 @@ impl Peers {
     pub fn remove(&self, name: &str) -> Option<(String, Peer)> {
         self.peers.remove(name)
     }
+
+    /// close the (peer count / fraction) oldest connections
+    pub fn cull(&self, fraction: u64) {
+        let num_to_remove = (self.peers.len() as f64 / fraction as f64).ceil() as usize;
+        let mut to_remove = Vec::with_capacity(num_to_remove);
+        let mut sorted_peers: Vec<_> = self.peers.iter().collect();
+        sorted_peers.sort_by_key(|p| p.last_message);
+        to_remove.extend(sorted_peers.iter().take(num_to_remove));
+        for peer in to_remove {
+            self.peers.remove(&peer.identity.name);
+        }
+    }
 }
 
 pub type OnchainPKI = Arc<DashMap<String, Identity>>;

--- a/kinode/src/net/utils.rs
+++ b/kinode/src/net/utils.rs
@@ -1,10 +1,10 @@
 use crate::net::types::{
-    HandshakePayload, OnchainPKI, Peers, PendingPassthroughs, PendingStream, RoutingRequest,
+    ActivePassthroughs, HandshakePayload, NetData, OnchainPKI, PendingStream, RoutingRequest,
     TCP_PROTOCOL, WS_PROTOCOL,
 };
 use lib::types::core::{
     Identity, KernelMessage, KnsUpdate, Message, MessageSender, NetAction, NetworkErrorSender,
-    NodeRouting, PrintSender, Printout, Request, Response, SendError, SendErrorKind,
+    NodeId, NodeRouting, PrintSender, Printout, Request, Response, SendError, SendErrorKind,
     WrappedSendError,
 };
 use {
@@ -30,24 +30,33 @@ pub const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 /// 30 minute idle timeout for connections
 pub const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1800);
 
-/// maximum number of peers (open connections, but does not include passthroughs we provide!)
-pub const MAX_PEERS: usize = 100;
-
 pub async fn create_passthrough(
     our: &Identity,
     our_ip: &str,
     from_id: Identity,
     target_id: Identity,
-    peers: &Peers,
-    pending_passthroughs: &PendingPassthroughs,
+    data: &NetData,
     socket_1: PendingStream,
 ) -> anyhow::Result<()> {
+    // if we already are at the max number of passthroughs, reject
+    if data.active_passthroughs.len() + data.pending_passthroughs.len()
+        >= data.max_passthroughs as usize
+    {
+        return Err(anyhow::anyhow!("max passthroughs reached"));
+    }
     // if the target has already generated a pending passthrough for this source,
     // immediately match them
-    if let Some(((_target, _from), pending_stream)) =
-        pending_passthroughs.remove(&(target_id.name.clone(), from_id.name.clone()))
+    if let Some(((from, target), pending_stream)) = data
+        .pending_passthroughs
+        .remove(&(target_id.name.clone(), from_id.name.clone()))
     {
-        tokio::spawn(maintain_passthrough(socket_1, pending_stream));
+        tokio::spawn(maintain_passthrough(
+            from,
+            target,
+            socket_1,
+            pending_stream,
+            data.active_passthroughs.clone(),
+        ));
         return Ok(());
     }
     if socket_1.is_tcp() {
@@ -63,7 +72,13 @@ pub async fn create_passthrough(
                     from_id.name
                 ));
             };
-            tokio::spawn(maintain_passthrough(socket_1, PendingStream::Tcp(stream_2)));
+            tokio::spawn(maintain_passthrough(
+                from_id.name,
+                target_id.name,
+                socket_1,
+                PendingStream::Tcp(stream_2),
+                data.active_passthroughs.clone(),
+            ));
             return Ok(());
         }
     } else if socket_1.is_ws() {
@@ -79,14 +94,17 @@ pub async fn create_passthrough(
                 ));
             };
             tokio::spawn(maintain_passthrough(
+                from_id.name,
+                target_id.name,
                 socket_1,
                 PendingStream::WebSocket(socket_2),
+                data.active_passthroughs.clone(),
             ));
             return Ok(());
         }
     }
     // create passthrough to indirect node that we do routing for
-    let target_peer = peers.get(&target_id.name).ok_or(anyhow::anyhow!(
+    let target_peer = data.peers.get(&target_id.name).ok_or(anyhow::anyhow!(
         "can't route to {}, not a peer, for passthrough requested by {}",
         target_id.name,
         from_id.name
@@ -119,12 +137,20 @@ pub async fn create_passthrough(
     // or if the target node connects to us with a matching passthrough.
     // TODO it is currently possible to have dangling passthroughs in the map
     // if the target is "connected" to us but nonresponsive.
-    pending_passthroughs.insert((from_id.name, target_id.name), socket_1);
+    data.pending_passthroughs
+        .insert((from_id.name, target_id.name), socket_1);
     Ok(())
 }
 
 /// cross the streams -- spawn on own task
-pub async fn maintain_passthrough(socket_1: PendingStream, socket_2: PendingStream) {
+pub async fn maintain_passthrough(
+    from: NodeId,
+    target: NodeId,
+    socket_1: PendingStream,
+    socket_2: PendingStream,
+    active_passthroughs: ActivePassthroughs,
+) {
+    active_passthroughs.insert((from.clone(), target.clone()));
     match (socket_1, socket_2) {
         (PendingStream::Tcp(socket_1), PendingStream::Tcp(socket_2)) => {
             // do not use bidirectional because if one side closes,
@@ -176,9 +202,9 @@ pub async fn maintain_passthrough(socket_1: PendingStream, socket_2: PendingStre
         }
         _ => {
             // these foolish combinations must never occur
-            return;
         }
     }
+    active_passthroughs.remove(&(from, target));
 }
 
 pub fn ingest_log(log: KnsUpdate, pki: &OnchainPKI) {

--- a/kinode/src/net/utils.rs
+++ b/kinode/src/net/utils.rs
@@ -27,6 +27,12 @@ pub const MESSAGE_MAX_SIZE: u32 = 10_485_800;
 
 pub const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// 30 minute idle timeout for connections
+pub const IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1800);
+
+/// maximum number of peers (open connections, but does not include passthroughs we provide!)
+pub const MAX_PEERS: usize = 100;
+
 pub async fn create_passthrough(
     our: &Identity,
     our_ip: &str,

--- a/kinode/src/net/ws/mod.rs
+++ b/kinode/src/net/ws/mod.rs
@@ -187,16 +187,8 @@ pub async fn recv_via_router(
     };
     match connect_with_handshake_via_router(&ext, &peer_id, &router_id, socket).await {
         Ok(connection) => {
-            let (peer_tx, peer_rx) = mpsc::unbounded_channel();
-            data.peers.insert(
-                peer_id.name.clone(),
-                Peer {
-                    identity: peer_id.clone(),
-                    routing_for: false,
-                    sender: peer_tx,
-                    last_message: 0,
-                },
-            );
+            let (peer, peer_rx) = Peer::new(peer_id.clone(), false);
+            data.peers.insert(peer_id.name.clone(), peer);
             // maintain direct connection
             tokio::spawn(utils::maintain_connection(
                 peer_id.name,
@@ -233,8 +225,7 @@ async fn recv_connection(
             &ext.our_ip,
             from_id,
             target_id,
-            &data.peers,
-            &data.pending_passthroughs,
+            &data,
             PendingStream::WebSocket(socket),
         )
         .await;
@@ -273,16 +264,9 @@ async fn recv_connection(
         &their_id,
     )?;
 
-    let (peer_tx, peer_rx) = mpsc::unbounded_channel();
-    data.peers.insert(
-        their_id.name.clone(),
-        Peer {
-            identity: their_id.clone(),
-            routing_for: their_handshake.proxy_request,
-            sender: peer_tx,
-            last_message: 0,
-        },
-    );
+    let (peer, peer_rx) = Peer::new(their_id.clone(), their_handshake.proxy_request);
+    data.peers.insert(their_id.name.clone(), peer);
+
     tokio::spawn(utils::maintain_connection(
         their_handshake.name,
         data.peers,

--- a/kinode/src/net/ws/mod.rs
+++ b/kinode/src/net/ws/mod.rs
@@ -194,6 +194,7 @@ pub async fn recv_via_router(
                     identity: peer_id.clone(),
                     routing_for: false,
                     sender: peer_tx,
+                    last_message: 0,
                 },
             );
             // maintain direct connection
@@ -279,6 +280,7 @@ async fn recv_connection(
             identity: their_id.clone(),
             routing_for: their_handshake.proxy_request,
             sender: peer_tx,
+            last_message: 0,
         },
     );
     tokio::spawn(utils::maintain_connection(

--- a/kinode/src/net/ws/utils.rs
+++ b/kinode/src/net/ws/utils.rs
@@ -1,6 +1,6 @@
 use crate::net::{
     types::{HandshakePayload, IdentityExt, Peers},
-    utils::{print_debug, print_loud, MESSAGE_MAX_SIZE},
+    utils::{print_debug, print_loud, IDLE_TIMEOUT, MESSAGE_MAX_SIZE},
     ws::{PeerConnection, WebSocket},
 };
 use lib::core::{KernelMessage, MessageSender, NodeId, PrintSender};
@@ -103,9 +103,14 @@ pub async fn maintain_connection(
         }
     };
 
+    let timeout = tokio::time::sleep(IDLE_TIMEOUT);
+
     tokio::select! {
         _ = write => (),
         _ = read => (),
+        _ = timeout => {
+            print_debug(&print_tx, &format!("net: closing idle connection with {peer_name}")).await;
+        }
     }
 
     print_debug(&print_tx, &format!("net: connection lost with {peer_name}")).await;


### PR DESCRIPTION
## Problem

networking module does not track number of pipes used, leading to potential overuse in combination with file-handler modules.

## Solution

add infra to `net:distro:sys` that tracks number of open connections, enables closing excess ones
- idle timeouts for open connections
- cap on max active peers, close longest-idle peer connection when hit
- etc etc

## Testing

highly involved - test networking at load under number of configs

## Docs Update

TODO
