### PR TITLE
app_store: fix auto_updates

### DIFF
--- a/kinode/packages/app_store/api/app_store:sys-v1.wit
+++ b/kinode/packages/app_store/api/app_store:sys-v1.wit
@@ -184,6 +184,8 @@ interface downloads {
         auto-update(auto-update-request),
         /// Notify that a download is complete
         download-complete(download-complete-request),
+        /// Auto-update-download complete
+        auto-download-complete(auto-download-complete-request),
         /// Get files for a package
         get-files(option<package-id>),
         /// Remove a file
@@ -241,6 +243,12 @@ interface downloads {
         package-id: package-id,
         version-hash: string,
         err: option<download-error>,
+    }
+
+    /// Request for an auto-download complete
+    record auto-download-complete-request {
+        download-info: download-complete-request,
+        manifest-hash: string,
     }
 
     /// Represents a hash mismatch error

--- a/kinode/packages/app_store/ui/src/components/PackageSelector.tsx
+++ b/kinode/packages/app_store/ui/src/components/PackageSelector.tsx
@@ -6,7 +6,7 @@ interface PackageSelectorProps {
 }
 
 const PackageSelector: React.FC<PackageSelectorProps> = ({ onPackageSelect }) => {
-    const { installed } = useAppsStore();
+    const { installed, fetchInstalled } = useAppsStore();
     const [selectedPackage, setSelectedPackage] = useState<string>("");
     const [customPackage, setCustomPackage] = useState<string>("");
     const [isCustomPackageSelected, setIsCustomPackageSelected] = useState(false);
@@ -17,6 +17,10 @@ const PackageSelector: React.FC<PackageSelectorProps> = ({ onPackageSelect }) =>
             onPackageSelect(packageName, publisherId);
         }
     }, [selectedPackage, onPackageSelect]);
+
+    useEffect(() => {
+        fetchInstalled();
+    }, []);
 
     const handlePackageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const value = e.target.value;

--- a/kinode/packages/app_store/ui/src/pages/PublishPage.tsx
+++ b/kinode/packages/app_store/ui/src/pages/PublishPage.tsx
@@ -12,7 +12,7 @@ const NAME_INVALID = "Package name must contain only valid characters (a-z, 0-9,
 
 export default function PublishPage() {
   const { openConnectModal } = useConnectModal();
-  const { ourApps, fetchOurApps, installed, downloads } = useAppsStore();
+  const { ourApps, fetchOurApps, downloads } = useAppsStore();
   const publicClient = usePublicClient();
 
   const { address, isConnected, isConnecting } = useAccount();

--- a/kinode/packages/app_store/ui/src/store/index.ts
+++ b/kinode/packages/app_store/ui/src/store/index.ts
@@ -218,12 +218,6 @@ const useAppsStore = create<AppsStore>()((set, get) => ({
       });
       if (res.status === HTTP_STATUS.CREATED) {
         await get().fetchInstalled();
-
-        // hacky: a small delay (500ms) before fetching homepage apps
-        // to give the app time to add itself to the homepage
-        // might make sense to add more state and do retry logic instead.
-        await new Promise(resolve => setTimeout(resolve, 500));
-
         await get().fetchHomepageApps();
       }
     } catch (error) {


### PR DESCRIPTION
## Problem

Auto updates were successfully downloading (given a mirroring publisher), but the install step failed at a missing manifest_hash.

## Solution

Define a new Request type within downloads::app_store that gets sent to main when an auto-download is complete

## Notes

Also includes some UI fixes: 
- publishpage wasn't properly fetching installedApps to populate the dropdown
- launch button loading indicator, poll every 500ms and timeout (no UI for app) after 5s 
