### PR TITLE
Reduce log spam in case of inexistent processes being messaged

### DIFF
--- a/kinode/src/kernel/mod.rs
+++ b/kinode/src/kernel/mod.rs
@@ -798,7 +798,7 @@ pub async fn kernel(
                     // networking capabilities.
                     let Some(persisted) = process_map.get(&kernel_message.target.process) else {
                         t::Printout::new(
-                            0,
+                            2,
                             format!(
                                 "event loop: got {} from network for {}, but process does not exist{}",
                                 match kernel_message.message {


### PR DESCRIPTION
## Problem

When an old process that doesn't exist anymore is being messaged by other processes, a line is printed in the terminal. With bigger applications, this results in >50 lines printed per second. Malicious nodes can also log spam the terminal of someone else that way. 

## Solution

Setting the log level of the message to 2. 

