### PR TITLE
app_store UI: enable uninstalling local (unlisted) packages

### DIFF
--- a/kinode/packages/app_store/ui/src/App.tsx
+++ b/kinode/packages/app_store/ui/src/App.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 
 import Header from "./components/Header";
-import { APP_DETAILS_PATH, DOWNLOAD_PATH, MY_DOWNLOADS_PATH, PUBLISH_PATH, STORE_PATH } from "./constants/path";
+import { APP_DETAILS_PATH, DOWNLOAD_PATH, MY_APPS_PATH, PUBLISH_PATH, STORE_PATH } from "./constants/path";
 
 import StorePage from "./pages/StorePage";
 import AppPage from "./pages/AppPage";
 import DownloadPage from "./pages/DownloadPage";
 import PublishPage from "./pages/PublishPage";
-import MyDownloadsPage from "./pages/MyDownloadsPage";
+import MyAppsPage from "./pages/MyAppsPage";
 
 
 const BASE_URL = import.meta.env.BASE_URL;
@@ -22,7 +22,7 @@ function App() {
         <Header />
         <Routes>
           <Route path={STORE_PATH} element={<StorePage />} />
-          <Route path={MY_DOWNLOADS_PATH} element={<MyDownloadsPage />} />
+          <Route path={MY_APPS_PATH} element={<MyAppsPage />} />
           <Route path={`${APP_DETAILS_PATH}/:id`} element={<AppPage />} />
           <Route path={PUBLISH_PATH} element={<PublishPage />} />
           <Route path={`${DOWNLOAD_PATH}/:id`} element={<DownloadPage />} />

--- a/kinode/packages/app_store/ui/src/components/Header.tsx
+++ b/kinode/packages/app_store/ui/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { STORE_PATH, PUBLISH_PATH, MY_DOWNLOADS_PATH } from '../constants/path';
+import { STORE_PATH, PUBLISH_PATH, MY_APPS_PATH } from '../constants/path';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { FaHome } from "react-icons/fa";
 
@@ -9,12 +9,12 @@ const Header: React.FC = () => {
         <header className="app-header">
             <div className="header-left">
                 <nav>
-                    <button onClick={() => window.location.href = '/'}>
+                    <button onClick={() => window.location.href = '/'} className="home-button">
                         <FaHome />
                     </button>
                     <Link to={STORE_PATH} className={location.pathname === STORE_PATH ? 'active' : ''}>Apps</Link>
                     <Link to={PUBLISH_PATH} className={location.pathname === PUBLISH_PATH ? 'active' : ''}>Publish</Link>
-                    <Link to={MY_DOWNLOADS_PATH} className={location.pathname === MY_DOWNLOADS_PATH ? 'active' : ''}>My Downloads</Link>
+                    <Link to={MY_APPS_PATH} className={location.pathname === MY_APPS_PATH ? 'active' : ''}>My Apps</Link>
                 </nav>
             </div>
             <div className="header-right">

--- a/kinode/packages/app_store/ui/src/constants/path.ts
+++ b/kinode/packages/app_store/ui/src/constants/path.ts
@@ -2,4 +2,4 @@ export const STORE_PATH = '/';
 export const PUBLISH_PATH = '/publish';
 export const APP_DETAILS_PATH = '/app';
 export const DOWNLOAD_PATH = '/download';
-export const MY_DOWNLOADS_PATH = '/my-downloads';
+export const MY_APPS_PATH = '/my-apps';

--- a/kinode/packages/app_store/ui/src/index.css
+++ b/kinode/packages/app_store/ui/src/index.css
@@ -136,6 +136,8 @@ td {
 .app-icon {
     width: 64px;
     height: 64px;
+    min-width: 64px;
+    min-height: 64px;
     object-fit: cover;
     border-radius: var(--border-radius);
 }
@@ -346,6 +348,13 @@ td {
     gap: 1rem;
     overflow-x: auto;
     padding-bottom: 1rem;
+}
+
+.home-button {
+    min-width: 48px;
+    min-height: 48px;
+    width: 48px;
+    height: 48px;
 }
 
 .app-screenshot {

--- a/kinode/packages/app_store/ui/vite.config.ts
+++ b/kinode/packages/app_store/ui/vite.config.ts
@@ -17,7 +17,7 @@ The format is "/" + "process_name:package_name:publisher_node"
 const BASE_URL = `/main:app_store:sys`;
 
 // This is the proxy URL, it must match the node you are developing against
-const PROXY_URL = (process.env.VITE_NODE_URL || 'http://127.0.0.1:8080').replace('localhost', '127.0.0.1');
+const PROXY_URL = (process.env.VITE_NODE_URL || 'http://127.0.0.1:8080');
 
 console.log('process.env.VITE_NODE_URL', process.env.VITE_NODE_URL, PROXY_URL);
 


### PR DESCRIPTION
## Problem

https://github.com/kinode-dao/kinode/issues/584

If an app was unlisted, there's currently no way for a user to uninstall an app (except using the uninstall script from the terminal)

## Solution

Adds a list of installed packages (disabling uninstall of core packages) in /my-apps (previously /my-downloads)

Still includes the downloaded zips and actions to install/delete those.

## Notes

Our basic vite configs work fine with subdomains, only trick is to go to 

```http://app-store-sys.localhost:3000/main:app_store:sys```

instead of 

```http://localhost:3000/main:app_store:sys```

might be a vite thing I can tweak so it doesn't throw you to the wrong url by default