### PR TITLE
add redirect param to login page for loads where user already has cookie

### DIFF
--- a/kinode/src/http/login.html
+++ b/kinode/src/http/login.html
@@ -231,6 +231,17 @@
         }
       });
     });
+
+    // Check for redirect parameter on page load
+    document.addEventListener("DOMContentLoaded", () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const redirectPath = urlParams.get('redirect');
+      if (redirectPath) {
+        // Ensure the redirect path starts with a slash
+        const path = redirectPath.startsWith('/') ? redirectPath : '/' + redirectPath;
+        window.location.href = path;
+      }
+    });
   </script>
 </body>
 


### PR DESCRIPTION
## Problem

Hosting service needs to usher user through login page when booting straight into an app

## Solution

Add function for login page to allow redirect parameter in url

## Testing

```
1. Boot a node, try navigating straight to app
2. Forced to log in
3. Instead, POST request to /login?redirect=x with credentials and then navigate straight through
```

