### PR TITLE
app_store improvements

### DIFF
--- a/kinode/packages/app_store/app_store/src/lib.rs
+++ b/kinode/packages/app_store/app_store/src/lib.rs
@@ -188,24 +188,20 @@ fn handle_message(
                     .unwrap_or(false);
 
                 if should_auto_install {
-                    print_to_terminal(1, "auto_install:main, manifest_hash match");
                     if let Err(e) =
                         utils::install(&package_id, None, &version_hash, state, &our.node)
                     {
                         if let Some(package) = state.packages.get_mut(&process_lib_package_id) {
                             package.pending_update_hash = Some(version_hash);
                         }
-                        print_to_terminal(1, &format!("error auto_installing package: {e}"));
+                        println!("error auto-installing package: {e}");
                     } else {
-                        println!(
-                            "auto_installed update for package: {:?}",
-                            &process_lib_package_id
-                        );
+                        println!("auto-installed update for package: {process_lib_package_id}");
                     }
                 } else {
                     if let Some(package) = state.packages.get_mut(&process_lib_package_id) {
                         package.pending_update_hash = Some(version_hash);
-                        print_to_terminal(1, "auto_install:main, manifest_hash do not match");
+                        println!("error auto-installing package: manifest hash mismatch");
                     }
                 }
             }

--- a/kinode/packages/app_store/app_store/src/state.rs
+++ b/kinode/packages/app_store/app_store/src/state.rs
@@ -54,7 +54,18 @@ pub struct PackageState {
     /// capabilities have changed. if they have changed, auto-install must fail
     /// and the user must approve the new capabilities.
     pub manifest_hash: Option<String>,
+    /// stores the version hash of a failed auto-install attempt, which can be
+    /// later installed by the user by approving new caps.
+    pub pending_update_hash: Option<String>,
 }
+
+// this seems cleaner to me right now with pending_update_hash, but given how we serialize
+// the state to disk right now, with installed_apis and packages being populated directly
+// from the filesystem, not sure I'd like to serialize the whole of this state (maybe separate out the pending one?)
+// another option would be to have the download_api recheck the manifest hash? but not sure...
+// arbitrary complexity here.
+
+// alternative is main loop doing this, storing it.
 
 /// this process's saved state
 pub struct State {
@@ -122,6 +133,7 @@ impl State {
                     verified: true,       // implicitly verified (TODO re-evaluate)
                     caps_approved: false, // must re-approve if you want to do something ??
                     manifest_hash: Some(manifest_hash),
+                    pending_update_hash: None, // ... this could be a separate state saved. don't want to reflect this info on-disk as a file.
                 },
             );
 

--- a/kinode/packages/app_store/app_store/src/utils.rs
+++ b/kinode/packages/app_store/app_store/src/utils.rs
@@ -225,6 +225,7 @@ pub fn install(
         verified: true, // sideloaded apps are implicitly verified because there is no "source" to verify against
         caps_approved: true, // TODO see if we want to auto-approve local installs
         manifest_hash: Some(manifest_hash),
+        pending_update_hash: None, // TODO: doublecheck if problematically overwrites auto_update state.
     };
 
     if let Ok(extracted) = extract_api(&process_package_id) {

--- a/kinode/packages/app_store/ui/src/components/Header.tsx
+++ b/kinode/packages/app_store/ui/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { STORE_PATH, PUBLISH_PATH, MY_APPS_PATH } from '../constants/path';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import { FaHome } from "react-icons/fa";
+import NotificationBay from './NotificationBay';
 
 const Header: React.FC = () => {
     return (
@@ -18,10 +19,10 @@ const Header: React.FC = () => {
                 </nav>
             </div>
             <div className="header-right">
+                <NotificationBay />
                 <ConnectButton />
             </div>
         </header>
     );
 };
-
 export default Header;

--- a/kinode/packages/app_store/ui/src/components/ManifestDisplay.tsx
+++ b/kinode/packages/app_store/ui/src/components/ManifestDisplay.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ManifestResponse, PackageManifestEntry } from '../types/Apps';
+import { FaChevronDown, FaChevronRight, FaGlobe, FaLock, FaShieldAlt } from 'react-icons/fa';
 
 interface ManifestDisplayProps {
     manifestResponse: ManifestResponse;
@@ -23,17 +24,59 @@ const transformCapabilities = (capabilities: any[]) => {
 };
 
 
-const renderManifest = (manifest: PackageManifestEntry) => (
-    <div className="manifest-item">
-        <p><strong>Process Name:</strong> {manifest.process_name}</p>
-        <p><strong>Requests Network Access:</strong> {manifest.request_networking ? 'Yes' : 'No'}</p>
-        <p><strong>Wants to Grant Capabilities:</strong> {transformCapabilities(manifest.grant_capabilities).join(', ') || 'None'}</p>
-        <p><strong>Is Public:</strong> {manifest.public ? 'Yes' : 'No'}</p>
-        <p><strong>Requests the Capabilities:</strong> {transformCapabilities(manifest.request_capabilities).join(', ') || 'None'}</p>
-        {/* <p><strong>Process Wasm Path:</strong> {manifest.process_wasm_path}</p> */}
-        {/* <p><strong>On Exit:</strong> {manifest.on_exit}</p> */}
-    </div>
-);
+const ProcessManifest: React.FC<{ manifest: PackageManifestEntry }> = ({ manifest }) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const hasCapabilities = manifest.request_capabilities.length > 0 || manifest.grant_capabilities.length > 0;
+
+    return (
+        <div className="process-manifest">
+            <button
+                className="process-header"
+                onClick={() => setIsExpanded(!isExpanded)}
+            >
+                {isExpanded ? <FaChevronDown /> : <FaChevronRight />}
+                <span className="process-name">{manifest.process_name}</span>
+                <div className="process-indicators">
+                    {manifest.request_networking && (
+                        <FaGlobe title="Requests Network Access" className="network-icon" />
+                    )}
+                    {hasCapabilities && (
+                        <FaShieldAlt title="Has Capability Requirements" className="capability-icon" />
+                    )}
+                    {!manifest.public && (
+                        <FaLock title="Private Process" className="private-icon" />
+                    )}
+                </div>
+            </button>
+
+            {isExpanded && (
+                <div className="process-details">
+                    {manifest.request_capabilities.length > 0 && (
+                        <div className="capability-section">
+                            <h4>Requested Capabilities:</h4>
+                            <ul>
+                                {transformCapabilities(manifest.request_capabilities).map((cap, i) => (
+                                    <li key={i}>{cap}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    {manifest.grant_capabilities.length > 0 && (
+                        <div className="capability-section">
+                            <h4>Granted Capabilities:</h4>
+                            <ul>
+                                {transformCapabilities(manifest.grant_capabilities).map((cap, i) => (
+                                    <li key={i}>{cap}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};
 
 const ManifestDisplay: React.FC<ManifestDisplayProps> = ({ manifestResponse }) => {
     if (!manifestResponse) {
@@ -45,9 +88,7 @@ const ManifestDisplay: React.FC<ManifestDisplayProps> = ({ manifestResponse }) =
     return (
         <div className="manifest-display">
             {parsedManifests.map((manifest, index) => (
-                <div key={index}>
-                    {renderManifest(manifest)}
-                </div>
+                <ProcessManifest key={index} manifest={manifest} />
             ))}
         </div>
     );

--- a/kinode/packages/app_store/ui/src/components/ManifestDisplay.tsx
+++ b/kinode/packages/app_store/ui/src/components/ManifestDisplay.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { ManifestResponse, PackageManifestEntry } from '../types/Apps';
+
+interface ManifestDisplayProps {
+    manifestResponse: ManifestResponse;
+}
+
+const capabilityMap: Record<string, string> = {
+    'vfs:distro:sys': 'Virtual Filesystem',
+    'http_client:distro:sys': 'HTTP Client',
+    'http_server:distro:sys': 'HTTP Server',
+    'eth:distro:sys': 'Ethereum RPC access',
+    'homepage:homepage:sys': 'Ability to add itself to homepage',
+    'main:app_store:sys': 'App Store',
+    'chain:app_store:sys': 'Chain',
+    'terminal:terminal:sys': 'Terminal',
+};
+
+// note: we can do some future regex magic mapping here too!
+// if includes("root") return WARNING
+const transformCapabilities = (capabilities: any[]) => {
+    return capabilities.map(cap => capabilityMap[cap] || cap);
+};
+
+
+const renderManifest = (manifest: PackageManifestEntry) => (
+    <div className="manifest-item">
+        <p><strong>Process Name:</strong> {manifest.process_name}</p>
+        <p><strong>Requests Network Access:</strong> {manifest.request_networking ? 'Yes' : 'No'}</p>
+        <p><strong>Wants to Grant Capabilities:</strong> {transformCapabilities(manifest.grant_capabilities).join(', ') || 'None'}</p>
+        <p><strong>Is Public:</strong> {manifest.public ? 'Yes' : 'No'}</p>
+        <p><strong>Requests the Capabilities:</strong> {transformCapabilities(manifest.request_capabilities).join(', ') || 'None'}</p>
+        {/* <p><strong>Process Wasm Path:</strong> {manifest.process_wasm_path}</p> */}
+        {/* <p><strong>On Exit:</strong> {manifest.on_exit}</p> */}
+    </div>
+);
+
+const ManifestDisplay: React.FC<ManifestDisplayProps> = ({ manifestResponse }) => {
+    if (!manifestResponse) {
+        return <p>No manifest data available.</p>;
+    }
+
+    const parsedManifests: PackageManifestEntry[] = JSON.parse(manifestResponse.manifest);
+
+    return (
+        <div className="manifest-display">
+            {parsedManifests.map((manifest, index) => (
+                <div key={index}>
+                    {renderManifest(manifest)}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default ManifestDisplay;

--- a/kinode/packages/app_store/ui/src/components/NotificationBay.tsx
+++ b/kinode/packages/app_store/ui/src/components/NotificationBay.tsx
@@ -1,0 +1,135 @@
+import React, { ReactNode, useState } from 'react';
+import { FaBell, FaChevronDown, FaChevronUp, FaTrash, FaTimes } from 'react-icons/fa';
+import useAppsStore from '../store';
+import { Notification, NotificationAction } from '../types/Apps';
+import { useNavigate } from 'react-router-dom';
+
+
+interface ModalProps {
+    children: ReactNode;
+    onClose: () => void;
+}
+
+const Modal: React.FC<ModalProps> = ({ children, onClose }) => {
+    return (
+        <div className="modal-overlay">
+            <div className="modal-content">
+                <button className="modal-close" onClick={onClose}>
+                    <FaTimes />
+                </button>
+                {children}
+            </div>
+        </div>
+    );
+};
+
+const NotificationBay: React.FC = () => {
+    const { notifications, removeNotification } = useAppsStore();
+    const [isExpanded, setIsExpanded] = useState(false);
+    const [modalContent, setModalContent] = useState<React.ReactNode | null>(null);
+    const navigate = useNavigate();
+
+    const handleActionClick = (action: NotificationAction) => {
+        switch (action.action.type) {
+            case 'modal':
+                const content = typeof action.action.modalContent === 'function'
+                    ? action.action.modalContent()
+                    : action.action.modalContent;
+                setModalContent(content);
+                break;
+            case 'click':
+                action.action.onClick?.();
+                break;
+            case 'redirect':
+                if (action.action.path) {
+                    navigate(action.action.path);
+                }
+                break;
+        }
+    };
+
+    const handleDismiss = (notificationId: string, event: React.MouseEvent) => {
+        event.stopPropagation(); // Prevent event bubbling
+        removeNotification(notificationId);
+    };
+
+    const renderNotification = (notification: Notification) => {
+        return (
+            <div key={notification.id} className={`notification-item ${notification.type}`}>
+                {notification.renderContent ? (
+                    notification.renderContent(notification)
+                ) : (
+                    <>
+                        <div className="notification-content">
+                            <p>{notification.message}</p>
+                            {notification.type === 'download' && notification.metadata?.progress && (
+                                <div className="progress-bar">
+                                    <div
+                                        className="progress"
+                                        style={{ width: `${notification.metadata.progress}%` }}
+                                    />
+                                </div>
+                            )}
+                        </div>
+
+                        {notification.actions && (
+                            <div className="notification-actions">
+                                {notification.actions.map((action, index) => (
+                                    <button
+                                        key={index}
+                                        onClick={() => handleActionClick(action)}
+                                        className={`action-button ${action.variant || 'secondary'}`}
+                                    >
+                                        {action.icon && <action.icon />}
+                                        {action.label}
+                                    </button>
+                                ))}
+                            </div>
+                        )}
+
+                        {!notification.persistent && (
+                            <button
+                                className="dismiss-button"
+                                onClick={(e) => handleDismiss(notification.id, e)}
+                            >
+                                <FaTrash />
+                            </button>
+                        )}
+                    </>
+                )}
+            </div>
+        );
+    };
+
+    return (
+        <>
+            <div className="notification-bay">
+                <button onClick={() => setIsExpanded(!isExpanded)} className="notification-button">
+                    <FaBell />
+                    {notifications.length > 0 && (
+                        <span className="badge">{notifications.length}</span>
+                    )}
+                    {isExpanded ? <FaChevronUp /> : <FaChevronDown />}
+                </button>
+
+                {isExpanded && (
+                    <div className="notification-details">
+                        {notifications.length === 0 ? (
+                            <p>All clear, no notifications!</p>
+                        ) : (
+                            notifications.map(renderNotification)
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {modalContent && (
+                <Modal onClose={() => setModalContent(null)}>
+                    {modalContent}
+                </Modal>
+            )}
+        </>
+    );
+};
+
+export default NotificationBay;

--- a/kinode/packages/app_store/ui/src/components/NotificationBay.tsx
+++ b/kinode/packages/app_store/ui/src/components/NotificationBay.tsx
@@ -25,6 +25,7 @@ const Modal: React.FC<ModalProps> = ({ children, onClose }) => {
 
 const NotificationBay: React.FC = () => {
     const { notifications, removeNotification } = useAppsStore();
+    const hasErrors = notifications.some(n => n.type === 'error');
     const [isExpanded, setIsExpanded] = useState(false);
     const [modalContent, setModalContent] = useState<React.ReactNode | null>(null);
     const navigate = useNavigate();
@@ -104,12 +105,16 @@ const NotificationBay: React.FC = () => {
     return (
         <>
             <div className="notification-bay">
-                <button onClick={() => setIsExpanded(!isExpanded)} className="notification-button">
+                <button
+                    onClick={() => setIsExpanded(!isExpanded)}
+                    className={`notification-button ${hasErrors ? 'has-errors' : ''}`}
+                >
                     <FaBell />
                     {notifications.length > 0 && (
-                        <span className="badge">{notifications.length}</span>
+                        <span className={`badge ${hasErrors ? 'error-badge' : ''}`}>
+                            {notifications.length}
+                        </span>
                     )}
-                    {isExpanded ? <FaChevronUp /> : <FaChevronDown />}
                 </button>
 
                 {isExpanded && (

--- a/kinode/packages/app_store/ui/src/components/index.ts
+++ b/kinode/packages/app_store/ui/src/components/index.ts
@@ -1,3 +1,5 @@
 export { default as Header } from './Header';
 export { default as MirrorSelector } from './MirrorSelector';
 export { default as PackageSelector } from './PackageSelector';
+export { default as ManifestDisplay } from './ManifestDisplay';
+export { default as NotificationBay } from './NotificationBay';

--- a/kinode/packages/app_store/ui/src/index.css
+++ b/kinode/packages/app_store/ui/src/index.css
@@ -49,6 +49,13 @@ a:hover {
     gap: 1rem;
 }
 
+.header-right {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    /* Provides consistent spacing between NotificationBay and ConnectButton */
+}
+
 .header-left h1 {
     margin: 0;
     font-size: 1.5rem;
@@ -432,4 +439,167 @@ td {
 
 .fa-spin {
     animation: spin 1s linear infinite;
+}
+
+.manifest-display {
+    background-color: light-dark(var(--tan), var(--tasteful-dark));
+    color: light-dark(var(--off-black), var(--off-white));
+    padding: 1rem;
+    border-radius: var(--border-radius);
+    margin-bottom: 1rem;
+}
+
+.manifest-item {
+    margin-bottom: 1rem;
+    padding: 1rem;
+    border: 1px solid var(--gray);
+    border-radius: var(--border-radius);
+    background-color: light-dark(var(--white), var(--off-black));
+}
+
+.manifest-item p {
+    margin: 0.5rem 0;
+}
+
+.notification-bay {
+    position: relative;
+    margin-right: 1rem;
+}
+
+.notification-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    color: light-dark(var(--off-black), var(--off-white));
+}
+
+.notification-details {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    width: 320px;
+    max-height: 400px;
+    overflow-y: auto;
+    background-color: light-dark(var(--white), var(--tasteful-dark));
+    border-radius: var(--border-radius);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+    padding: 0.5rem;
+}
+
+.badge {
+    background-color: var(--orange);
+    color: var(--white);
+    border-radius: 50%;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    min-width: 1.5rem;
+    text-align: center;
+}
+
+.notification-item {
+    display: flex;
+    align-items: center;
+    padding: 1rem;
+    margin: 0.5rem 0;
+    border-radius: var(--border-radius);
+    background-color: light-dark(var(--tan), var(--off-black));
+    color: light-dark(var(--off-black), var(--off-white));
+}
+
+.notification-item.error {
+    background-color: light-dark(#ffe6e6, #4a2020);
+}
+
+.notification-item.success {
+    background-color: light-dark(#e6ffe6, #204a20);
+}
+
+.notification-item.warning {
+    background-color: light-dark(#fff3e6, #4a3820);
+}
+
+.notification-item.download {
+    background-color: light-dark(#e6f3ff, #20304a);
+}
+
+.notification-content {
+    flex: 1;
+    margin-right: 1rem;
+}
+
+.notification-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-left: auto;
+}
+
+.dismiss-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: light-dark(var(--gray), var(--off-white));
+    padding: 0.25rem;
+}
+
+.dismiss-button:hover {
+    color: var(--orange);
+}
+
+.progress-bar {
+    margin-top: 0.5rem;
+    height: 4px;
+    background-color: light-dark(var(--white), var(--off-black));
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.progress {
+    height: 100%;
+    background-color: var(--orange);
+    transition: width 0.3s ease;
+}
+
+/* Modal styles */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1100;
+}
+
+.modal-content {
+    background-color: light-dark(var(--white), var(--tasteful-dark));
+    color: light-dark(var(--off-black), var(--off-white));
+    padding: 1.5rem;
+    border-radius: var(--border-radius);
+    position: relative;
+    max-width: 80%;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
+.modal-close {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: light-dark(var(--gray), var(--off-white));
+    padding: 0.25rem;
+}
+
+.modal-close:hover {
+    color: var(--orange);
 }

--- a/kinode/packages/app_store/ui/src/index.css
+++ b/kinode/packages/app_store/ui/src/index.css
@@ -442,23 +442,87 @@ td {
 }
 
 .manifest-display {
-    background-color: light-dark(var(--tan), var(--tasteful-dark));
+    background: light-dark(var(--white), var(--tasteful-dark));
+    border-radius: var(--border-radius);
+    padding: 1rem;
+    max-width: 600px;
+}
+
+.process-manifest {
+    margin-bottom: 0.5rem;
+    border: 1px solid light-dark(var(--gray), var(--off-black));
+    border-radius: var(--border-radius);
+    overflow: hidden;
+}
+
+.process-header {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    background: none;
+    border: none;
+    cursor: pointer;
     color: light-dark(var(--off-black), var(--off-white));
+    transition: background-color 0.2s;
+}
+
+.process-header:hover {
+    background: light-dark(var(--tan), var(--off-black));
+}
+
+.process-name {
+    flex: 1;
+    text-align: left;
+    font-weight: 500;
+}
+
+.process-indicators {
+    display: flex;
+    gap: 0.5rem;
+    color: light-dark(var(--gray), var(--off-white));
+}
+
+.network-icon {
+    color: var(--orange);
+}
+
+.capability-icon {
+    color: var(--blue);
+}
+
+.private-icon {
+    color: var(--gray);
+}
+
+.process-details {
     padding: 1rem;
-    border-radius: var(--border-radius);
+    background: light-dark(var(--tan), var(--off-black));
+    border-top: 1px solid light-dark(var(--gray), var(--off-black));
+}
+
+.capability-section {
     margin-bottom: 1rem;
 }
 
-.manifest-item {
-    margin-bottom: 1rem;
-    padding: 1rem;
-    border: 1px solid var(--gray);
-    border-radius: var(--border-radius);
-    background-color: light-dark(var(--white), var(--off-black));
+.capability-section:last-child {
+    margin-bottom: 0;
 }
 
-.manifest-item p {
-    margin: 0.5rem 0;
+.capability-section h4 {
+    margin: 0 0 0.5rem 0;
+    color: light-dark(var(--off-black), var(--off-white));
+}
+
+.capability-section ul {
+    margin: 0;
+    padding-left: 1.5rem;
+    color: light-dark(var(--gray), var(--off-white));
+}
+
+.capability-section li {
+    margin-bottom: 0.25rem;
 }
 
 .notification-bay {
@@ -602,4 +666,51 @@ td {
 
 .modal-close:hover {
     color: var(--orange);
+}
+
+.notification-button.has-errors {
+    animation: shake 0.82s cubic-bezier(.36, .07, .19, .97) both;
+}
+
+.badge.error-badge {
+    background-color: var(--error-red);
+    animation: pulse 2s infinite;
+}
+
+@keyframes shake {
+
+    10%,
+    90% {
+        transform: translate3d(-1px, 0, 0);
+    }
+
+    20%,
+    80% {
+        transform: translate3d(2px, 0, 0);
+    }
+
+    30%,
+    50%,
+    70% {
+        transform: translate3d(-4px, 0, 0);
+    }
+
+    40%,
+    60% {
+        transform: translate3d(4px, 0, 0);
+    }
+}
+
+@keyframes pulse {
+    0% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.6;
+    }
+
+    100% {
+        opacity: 1;
+    }
 }

--- a/kinode/packages/app_store/ui/src/store/index.ts
+++ b/kinode/packages/app_store/ui/src/store/index.ts
@@ -413,18 +413,26 @@ const useAppsStore = create<AppsStore>()((set, get) => ({
             }
           });
         } else if (data.kind === 'complete') {
-          const { package_id, version_hash } = data.data;
+          const { package_id, version_hash, error } = data.data;
           const appId = `${package_id.package_name}:${package_id.publisher_node}:${version_hash}`;
           get().clearActiveDownload(appId);
-
           get().removeNotification(`download-${appId}`);
 
-          get().addNotification({
-            id: `complete-${appId}`,
-            type: 'success',
-            message: `Download complete: ${package_id.package_name}`,
-            timestamp: Date.now(),
-          });
+          if (error) {
+            get().addNotification({
+              id: `error-${appId}`,
+              type: 'error',
+              message: `Download failed for ${package_id.package_name}: ${error}`,
+              timestamp: Date.now(),
+            });
+          } else {
+            get().addNotification({
+              id: `complete-${appId}`,
+              type: 'success',
+              message: `Download complete: ${package_id.package_name}`,
+              timestamp: Date.now(),
+            });
+          }
 
           get().fetchData(`${package_id.package_name}:${package_id.publisher_node}`);
         }

--- a/kinode/packages/app_store/ui/src/store/index.ts
+++ b/kinode/packages/app_store/ui/src/store/index.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { PackageState, AppListing, MirrorCheckFile, PackageManifest, DownloadItem, HomepageApp } from '../types/Apps'
+import { PackageState, AppListing, MirrorCheckFile, DownloadItem, HomepageApp, ManifestResponse, Notification } from '../types/Apps'
 import { HTTP_STATUS } from '../constants/http'
 import KinodeClientApi from "@kinode/client-api"
 import { WEBSOCKET_URL } from '../utils/ws'
@@ -13,6 +13,7 @@ interface AppsStore {
   downloads: Record<string, DownloadItem[]>
   ourApps: AppListing[]
   ws: KinodeClientApi
+  notifications: Notification[]
   homepageApps: HomepageApp[]
   activeDownloads: Record<string, { downloaded: number, total: number }>
 
@@ -29,11 +30,15 @@ interface AppsStore {
   fetchHomepageApps: () => Promise<void>
   getLaunchUrl: (id: string) => string | null
 
+  addNotification: (notification: Notification) => void;
+  removeNotification: (id: string) => void;
+  clearNotifications: () => void;
+
   installApp: (id: string, version_hash: string) => Promise<void>
   uninstallApp: (id: string) => Promise<void>
   downloadApp: (id: string, version_hash: string, downloadFrom: string) => Promise<void>
   removeDownload: (packageId: string, versionHash: string) => Promise<void>
-  getCaps: (id: string) => Promise<PackageManifest | null>
+  getManifest: (id: string, version_hash: string) => Promise<ManifestResponse | null>
   approveCaps: (id: string) => Promise<void>
   startMirroring: (id: string) => Promise<void>
   stopMirroring: (id: string) => Promise<void>
@@ -52,6 +57,7 @@ const useAppsStore = create<AppsStore>()((set, get) => ({
   ourApps: [],
   activeDownloads: {},
   homepageApps: [],
+  notifications: [],
 
 
   fetchData: async (id: string) => {
@@ -282,14 +288,14 @@ const useAppsStore = create<AppsStore>()((set, get) => ({
     }
   },
 
-  getCaps: async (id: string) => {
+  getManifest: async (id: string, version_hash: string) => {
     try {
-      const res = await fetch(`${BASE_URL}/apps/${id}/caps`);
+      const res = await fetch(`${BASE_URL}/manifest?id=${id}&version_hash=${version_hash}`);
       if (res.status === HTTP_STATUS.OK) {
-        return await res.json() as PackageManifest;
+        return await res.json() as ManifestResponse;
       }
     } catch (error) {
-      console.error("Error getting caps:", error);
+      console.error("Error getting manifest:", error);
     }
     return null;
   },
@@ -355,6 +361,18 @@ const useAppsStore = create<AppsStore>()((set, get) => ({
     }));
   },
 
+
+  addNotification: (notification) => set(state => ({
+    notifications: [...state.notifications, notification]
+  })),
+
+  removeNotification: (id) => set(state => ({
+    notifications: state.notifications.filter(n => n.id !== id)
+  })),
+
+  clearNotifications: () => set({ notifications: [] }),
+
+
   clearActiveDownload: (appId) => {
     set((state) => {
       const { [appId]: _, ...rest } = state.activeDownloads;
@@ -374,10 +392,40 @@ const useAppsStore = create<AppsStore>()((set, get) => ({
           const { package_id, version_hash, downloaded, total } = data.data;
           const appId = `${package_id.package_name}:${package_id.publisher_node}:${version_hash}`;
           get().setActiveDownload(appId, downloaded, total);
+
+          const existingNotification = get().notifications.find(
+            n => n.id === `download-${appId}`
+          );
+
+          if (existingNotification) {
+            get().removeNotification(`download-${appId}`);
+          }
+
+          get().addNotification({
+            id: `download-${appId}`,
+            type: 'download',
+            message: `Downloading ${package_id.package_name}`,
+            timestamp: Date.now(),
+            metadata: {
+              packageId: `${package_id.package_name}:${package_id.publisher_node}`,
+              versionHash: version_hash,
+              progress: Math.round((downloaded / total) * 100)
+            }
+          });
         } else if (data.kind === 'complete') {
           const { package_id, version_hash } = data.data;
           const appId = `${package_id.package_name}:${package_id.publisher_node}:${version_hash}`;
           get().clearActiveDownload(appId);
+
+          get().removeNotification(`download-${appId}`);
+
+          get().addNotification({
+            id: `complete-${appId}`,
+            type: 'success',
+            message: `Download complete: ${package_id.package_name}`,
+            timestamp: Date.now(),
+          });
+
           get().fetchData(`${package_id.package_name}:${package_id.publisher_node}`);
         }
       } catch (error) {

--- a/kinode/packages/app_store/ui/src/types/Apps.ts
+++ b/kinode/packages/app_store/ui/src/types/Apps.ts
@@ -1,3 +1,6 @@
+import { ReactNode } from "react";
+import { IconType } from "react-icons/lib";
+
 export interface PackageId {
     package_name: string;
     publisher_node: string;
@@ -59,9 +62,10 @@ export interface PackageState {
     our_version_hash: string;
     verified: boolean;
     caps_approved: boolean;
+    pending_update_hash?: string;
 }
 
-export interface PackageManifest {
+export interface PackageManifestEntry {
     process_name: string
     process_wasm_path: string
     on_exit: string
@@ -69,6 +73,12 @@ export interface PackageManifest {
     request_capabilities: any[]
     grant_capabilities: any[]
     public: boolean
+}
+
+export interface ManifestResponse {
+    package_id: PackageId;
+    version_hash: string;
+    manifest: string;
 }
 
 export interface HomepageApp {
@@ -83,3 +93,35 @@ export interface HomepageApp {
     order: number;
     favorite: boolean;
 }
+
+
+export type NotificationActionType = 'click' | 'modal' | 'popup' | 'redirect';
+
+export type NotificationAction = {
+    label: string;
+    icon?: IconType;
+    variant?: 'primary' | 'secondary' | 'danger';
+    action: {
+        type: NotificationActionType;
+        onClick?: () => void;
+        modalContent?: ReactNode | (() => ReactNode);
+        popupContent?: ReactNode | (() => ReactNode);
+        path?: string;
+    };
+};
+
+export type Notification = {
+    id: string;
+    type: 'error' | 'success' | 'warning' | 'info' | 'download' | 'install' | 'update';
+    message: string;
+    timestamp: number;
+    metadata?: {
+        packageId?: string;
+        versionHash?: string;
+        progress?: number;
+        error?: string;
+    };
+    actions?: NotificationAction[];
+    renderContent?: (notification: Notification) => ReactNode;
+    persistent?: boolean;
+};

--- a/kinode/packages/app_store/ui/src/utils/ws.ts
+++ b/kinode/packages/app_store/ui/src/utils/ws.ts
@@ -3,7 +3,7 @@ const BASE_URL = "/main:app_store:sys/";
 
 if (window.our) window.our.process = BASE_URL?.replace("/", "");
 
-export const PROXY_TARGET = `${(import.meta.env.VITE_NODE_URL || `http://localhost:8080`)}${BASE_URL}`;
+export const PROXY_TARGET = `${(import.meta.env.VITE_NODE_URL || `http://localhost:8080`).replace(/\/+$/, '')}${BASE_URL}`;
 
 // This env also has BASE_URL which should match the process + package name
 export const WEBSOCKET_URL = import.meta.env.DEV

--- a/kinode/packages/app_store/ui/vite.config.ts
+++ b/kinode/packages/app_store/ui/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig, ViteDevServer } from 'vite'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import react from '@vitejs/plugin-react'
 
@@ -17,9 +17,14 @@ The format is "/" + "process_name:package_name:publisher_node"
 const BASE_URL = `/main:app_store:sys`;
 
 // This is the proxy URL, it must match the node you are developing against
-const PROXY_URL = (process.env.VITE_NODE_URL || 'http://127.0.0.1:8080');
+const PROXY_URL = (process.env.VITE_NODE_URL || 'http://localhost:8080').replace(/\/$/, '');
+
+const DEV_SERVER_PORT = 3000; // Hardcoded port for the dev server...
 
 console.log('process.env.VITE_NODE_URL', process.env.VITE_NODE_URL, PROXY_URL);
+
+const openUrl = `${PROXY_URL.replace(/:\d+$/, '')}:${DEV_SERVER_PORT}${BASE_URL}`;
+console.log('Server will run at:', openUrl);
 
 export default defineConfig({
   plugins: [
@@ -37,7 +42,8 @@ export default defineConfig({
     }
   },
   server: {
-    open: true,
+    open: openUrl,
+    port: DEV_SERVER_PORT,
     proxy: {
       [`^${BASE_URL}/our.js`]: {
         target: PROXY_URL,


### PR DESCRIPTION
## Problem
https://github.com/kinode-dao/kinode/issues/592

+ current capabilities aren't displayed quite correctly.
+ no pending auto_updates notifications, ability to re-approve caps and install!
+ empty file gets written by receiving file_transfer_worker even if no chunks come in
+ upon sender not mirroring a version, or simply not having it available, no response bubbles up to receiver.

## Solution

WIP!
- ManifestDisplay with expandable processes and their requested caps (and other metadata) [x]
- NotificationBay, including errors and success messages [x]
- auto_updates as notifs too!
- non-await response sent by sender, receiver matches on context, and forwards via ws to UI in case of errors. [x]

## Notes
<img width="1524" alt="Screenshot 2024-11-08 at 17 25 47" src="https://github.com/user-attachments/assets/e3ab340e-f50b-49fd-9760-feeb2f1f9154">
<img width="422" alt="Screenshot 2024-11-08 at 17 25 31" src="https://github.com/user-attachments/assets/0555ce52-371d-4047-a341-2f50b4a0bff0">

