### PR TITLE
vfs: fix bad change from d3ee13e that broke caps

### DIFF
--- a/kinode/src/vfs.rs
+++ b/kinode/src/vfs.rs
@@ -343,7 +343,8 @@ async fn handle_request(
 
     // current prepend to filepaths needs to be: /package_id/drive/path
     let (package_id, drive, rest) = parse_package_and_drive(&request.path, &vfs_path)?;
-    let drive = format!("{package_id}/{drive}");
+    // must have prepended `/` here or else it messes up caps downstream, e.g. in run-tests
+    let drive = format!("/{package_id}/{drive}");
     let action = request.action;
     let path = PathBuf::from(&request.path);
 


### PR DESCRIPTION
## Problem

d3ee13e broke caps for `kit run-tests`

## Solution

Change it back

## Testing

None

## Docs Update

None

## Notes

None