### PR TITLE
docker: improve security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,27 @@ FROM downloader_${TARGETARCH} AS downloader
 
 FROM debian:12-slim
 
-RUN apt-get update && apt-get install openssl -y
+# Create a non-root user and group
+RUN groupadd -r kinode && \
+    useradd -r -g kinode -d /kinode-home/home/kinode kinode
+    #useradd -r -g kinode -d /kinode-home/home/kinode -s /bin/false kinode
+
+RUN apt-get update && \
+    apt-get install openssl -y && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create directory for kinode and set permissions
+RUN mkdir -p /kinode-home/home/kinode && \
+    chown -R kinode:kinode /kinode-home
 
 COPY --from=downloader /tmp/download/kinode /bin/kinode
+RUN chown kinode:kinode /bin/kinode && \
+    chmod 755 /bin/kinode
+
+# Switch to non-root user
+USER kinode
+
+WORKDIR /kinode-home
 
 ENTRYPOINT [ "/bin/kinode" ]
 CMD [ "/kinode-home" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ FROM debian:12-slim
 # Create a non-root user and group
 RUN groupadd -r kinode && \
     useradd -r -g kinode -d /kinode-home/home/kinode kinode
-    #useradd -r -g kinode -d /kinode-home/home/kinode -s /bin/false kinode
 
 RUN apt-get update && \
     apt-get install openssl -y && \

--- a/README.md
+++ b/README.md
@@ -202,20 +202,32 @@ To build a local Docker image, run the following command in this project root.
 
 ```bash
 # The `VERSION` may be replaced with the tag of a GitHub release
+export VERSION=0.9.8
 
 # Build for your system's architecture
-docker build . -t 0xlynett/kinode --build-arg VERSION=v0.9.1
+docker build . -t kinode-${VERSION} --build-arg VERSION=v${VERSION} --platform linux/amd64
 
 # Build a multiarch image
-docker buildx build . --platform arm64,amd64 --build-arg VERSION=v0.9.1 -t 0xlynett/kinode
+docker buildx build . -t kinode-${VERSION} --build-arg VERSION=v${VERSION} --platform arm64,amd64
 ```
 
-For example:
+To run, for example for a node named `helloworld.os`:
 
 ```bash
-docker volume create kinode-volume
+export NODENAME=helloworld.os
 
-docker run -d -p 8080:8080 -it --name my-kinode \
-    --mount type=volume,source=kinode-volume,destination=/kinode-home \
-    0xlynett/kinode
+docker volume create kinode-${NODENAME}
+
+docker run -p 8080:8080 --rm -it --name kinode-${VERSION}-${NODENAME} --mount type=volume,source=kinode-${NODENAME},destination=/kinode-home kinode-${VERSION}
+```
+
+which will launch your Kinode container attached to the terminal.
+Alternatively you can run it detached:
+```
+docker run -p 8080:8080 --rm -dt --name kinode-${VERSION}-${NODENAME} --mount type=volume,source=kinode-${NODENAME},destination=/kinode-home kinode-${VERSION}
+```
+Note that the `-t` flag *must* be passed.
+If it is not passed, you must pass the `--detached` argument to the Kinode binary, i.e.
+```
+docker run -p 8080:8080 --rm -d --name kinode-${VERSION}-${NODENAME} --mount type=volume,source=kinode-${NODENAME},destination=/kinode-home kinode-${VERSION} /kinode-home --detached
 ```

--- a/README.md
+++ b/README.md
@@ -218,16 +218,16 @@ export NODENAME=helloworld.os
 
 docker volume create kinode-${NODENAME}
 
-docker run -p 8080:8080 --rm -it --name kinode-${VERSION}-${NODENAME} --mount type=volume,source=kinode-${NODENAME},destination=/kinode-home kinode-${VERSION}
+docker run -p 8080:8080 --rm -it --name kinode-${NODENAME} --mount type=volume,source=kinode-${NODENAME},destination=/kinode-home kinode-${VERSION}
 ```
 
 which will launch your Kinode container attached to the terminal.
 Alternatively you can run it detached:
 ```
-docker run -p 8080:8080 --rm -dt --name kinode-${VERSION}-${NODENAME} --mount type=volume,source=kinode-${NODENAME},destination=/kinode-home kinode-${VERSION}
+docker run -p 8080:8080 --rm -dt --name kinode-${NODENAME} --mount type=volume,source=kinode-${NODENAME},destination=/kinode-home kinode-${VERSION}
 ```
 Note that the `-t` flag *must* be passed.
 If it is not passed, you must pass the `--detached` argument to the Kinode binary, i.e.
 ```
-docker run -p 8080:8080 --rm -d --name kinode-${VERSION}-${NODENAME} --mount type=volume,source=kinode-${NODENAME},destination=/kinode-home kinode-${VERSION} /kinode-home --detached
+docker run -p 8080:8080 --rm -d --name kinode-${NODENAME} --mount type=volume,source=kinode-${NODENAME},destination=/kinode-home kinode-${VERSION} /kinode-home --detached
 ```


### PR DESCRIPTION
## Problem

Docker image uses root and so can be used for privilege escalation.

## Solution

Don't use root: use a `USER` instead.

## Testing

None

## Docs Update

None

## Notes

`app_store` doesn't properly load metadata in when running Kinode within a Docker container. This occurs on main as well: I've opened #605 to track this.