### PR TITLE
kernel: dont replace `last_blob` with None

### DIFF
--- a/kinode/src/kernel/standard_host.rs
+++ b/kinode/src/kernel/standard_host.rs
@@ -99,7 +99,10 @@ impl process::ProcessState {
                     ref expects_response,
                     ..
                 }) => {
-                    self.last_blob = km.lazy_load_blob;
+                    if km.lazy_load_blob.is_some() {
+                        self.last_blob = km.lazy_load_blob;
+                        km.lazy_load_blob = None;
+                    }
                     km.lazy_load_blob = None;
                     if expects_response.is_some() || km.rsvp.is_some() {
                         // update prompting_message iff there is someone to reply to
@@ -109,13 +112,19 @@ impl process::ProcessState {
                 }
                 t::Message::Response(_) => match self.contexts.remove(&km.id) {
                     Some((context, _timeout_handle)) => {
-                        self.last_blob = km.lazy_load_blob;
+                        if km.lazy_load_blob.is_some() {
+                            self.last_blob = km.lazy_load_blob;
+                            km.lazy_load_blob = None;
+                        }
                         km.lazy_load_blob = None;
                         self.prompting_message = context.prompting_message;
                         (km, context.context)
                     }
                     None => {
-                        self.last_blob = km.lazy_load_blob;
+                        if km.lazy_load_blob.is_some() {
+                            self.last_blob = km.lazy_load_blob;
+                            km.lazy_load_blob = None;
+                        }
                         km.lazy_load_blob = None;
                         self.prompting_message = Some(km.clone());
                         (km, None)

--- a/kinode/src/kernel/standard_host_v0.rs
+++ b/kinode/src/kernel/standard_host_v0.rs
@@ -103,8 +103,10 @@ impl process::ProcessState {
                     ref expects_response,
                     ..
                 }) => {
-                    self.last_blob = km.lazy_load_blob;
-                    km.lazy_load_blob = None;
+                    if km.lazy_load_blob.is_some() {
+                        self.last_blob = km.lazy_load_blob;
+                        km.lazy_load_blob = None;
+                    }
                     if expects_response.is_some() || km.rsvp.is_some() {
                         // update prompting_message iff there is someone to reply to
                         self.prompting_message = Some(km.clone());
@@ -113,14 +115,18 @@ impl process::ProcessState {
                 }
                 t::Message::Response(_) => match self.contexts.remove(&km.id) {
                     Some((context, _timeout_handle)) => {
-                        self.last_blob = km.lazy_load_blob;
-                        km.lazy_load_blob = None;
+                        if km.lazy_load_blob.is_some() {
+                            self.last_blob = km.lazy_load_blob;
+                            km.lazy_load_blob = None;
+                        }
                         self.prompting_message = context.prompting_message;
                         (km, context.context)
                     }
                     None => {
-                        self.last_blob = km.lazy_load_blob;
-                        km.lazy_load_blob = None;
+                        if km.lazy_load_blob.is_some() {
+                            self.last_blob = km.lazy_load_blob;
+                            km.lazy_load_blob = None;
+                        }
                         self.prompting_message = Some(km.clone());
                         (km, None)
                     }


### PR DESCRIPTION
## Problem

Doing Request/Response under-the-hood like in process_lib can lead to confusing side-effects, like killing the `lazy_load_blob`.

## Solution

Keep around the `lazy_load_blob` instead of replacing it with `None`. It is only replaced when a Message is received with a non-`None` `lazy_load_blob`.

## Testing

TODO

## Docs Update

TODO

## Notes

None