### PR TITLE
terminal: per process verbosity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,7 +3965,7 @@ dependencies = [
 [[package]]
 name = "kinode_process_lib"
 version = "0.10.0"
-source = "git+https://github.com/kinode-dao/process_lib?rev=5d6e2af#5d6e2af88ef0716822cc1638be5b71a1ec9c4fb3"
+source = "git+https://github.com/kinode-dao/process_lib?rev=8a5b040#8a5b040dd699ae69d5bc1826fdd6e0bd5d84e766"
 dependencies = [
  "alloy 0.1.4",
  "alloy-primitives 0.7.7",
@@ -4265,7 +4265,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "kinode_process_lib 0.10.0 (git+https://github.com/kinode-dao/process_lib?rev=5d6e2af)",
+ "kinode_process_lib 0.10.0 (git+https://github.com/kinode-dao/process_lib?rev=8a5b040)",
  "regex",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ The `sys` publisher is not a real node ID, but it's also not a special case valu
 - UpArrow/DownArrow or CTRL+P/CTRL+N to move up and down through command history
 - CTRL+R to search history, CTRL+R again to toggle through search results, CTRL+G to cancel search
 
+- CTRL+W to set process-level verbosities that override the verbosity mode set with CTRL+V (0-3, 0 is default and lowest verbosity)
+
 ### Built-in terminal scripts
 
 The terminal package contains a number of built-in scripts.

--- a/kinode/packages/terminal/Cargo.lock
+++ b/kinode/packages/terminal/Cargo.lock
@@ -1682,7 +1682,7 @@ dependencies = [
 [[package]]
 name = "kinode_process_lib"
 version = "0.10.0"
-source = "git+https://github.com/kinode-dao/process_lib?rev=5d6e2af#5d6e2af88ef0716822cc1638be5b71a1ec9c4fb3"
+source = "git+https://github.com/kinode-dao/process_lib?rev=8a5b040#8a5b040dd699ae69d5bc1826fdd6e0bd5d84e766"
 dependencies = [
  "alloy",
  "alloy-primitives 0.7.7",
@@ -1762,7 +1762,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "kinode_process_lib 0.10.0 (git+https://github.com/kinode-dao/process_lib?rev=5d6e2af)",
+ "kinode_process_lib 0.10.0 (git+https://github.com/kinode-dao/process_lib?rev=8a5b040)",
  "regex",
  "serde",
  "serde_json",

--- a/kinode/packages/terminal/m/Cargo.toml
+++ b/kinode/packages/terminal/m/Cargo.toml
@@ -9,7 +9,7 @@ simulation-mode = []
 [dependencies]
 anyhow = "1.0"
 clap = "4.4"
-kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "5d6e2af" }
+kinode_process_lib = { git = "https://github.com/kinode-dao/process_lib", rev = "8a5b040" }
 regex = "1.10.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/kinode/src/eth/mod.rs
+++ b/kinode/src/eth/mod.rs
@@ -1136,10 +1136,11 @@ async fn check_for_root_cap(
 
 async fn verbose_print(print_tx: &PrintSender, content: &str) {
     let _ = print_tx
-        .send(Printout {
-            verbosity: 2,
-            content: content.to_string(),
-        })
+        .send(Printout::new(
+            2,
+            NET_PROCESS_ID.clone(),
+            content.to_string(),
+        ))
         .await;
 }
 

--- a/kinode/src/eth/subscription.rs
+++ b/kinode/src/eth/subscription.rs
@@ -1,3 +1,4 @@
+use lib::types::core::ETH_PROCESS_ID;
 use crate::eth::*;
 use alloy::pubsub::RawSubscription;
 use alloy::rpc::types::eth::pubsub::SubscriptionResult;
@@ -191,7 +192,7 @@ async fn build_subscription(
         return Err(EthError::PermissionDenied); // will never hit
     };
     if *kind == pubsub::SubscriptionKind::NewHeads {
-        Printout::new(0, format!("newHeads subscription requested by {target}!"))
+        Printout::new(0, ETH_PROCESS_ID.clone(), format!("newHeads subscription requested by {target}!"))
             .send(print_tx)
             .await;
     }

--- a/kinode/src/eth/subscription.rs
+++ b/kinode/src/eth/subscription.rs
@@ -1,8 +1,8 @@
-use lib::types::core::ETH_PROCESS_ID;
 use crate::eth::*;
 use alloy::pubsub::RawSubscription;
 use alloy::rpc::types::eth::pubsub::SubscriptionResult;
 use alloy::rpc::types::pubsub;
+use lib::types::core::ETH_PROCESS_ID;
 
 /// cleans itself up when the subscription is closed or fails.
 pub async fn create_new_subscription(
@@ -192,9 +192,13 @@ async fn build_subscription(
         return Err(EthError::PermissionDenied); // will never hit
     };
     if *kind == pubsub::SubscriptionKind::NewHeads {
-        Printout::new(0, ETH_PROCESS_ID.clone(), format!("newHeads subscription requested by {target}!"))
-            .send(print_tx)
-            .await;
+        Printout::new(
+            0,
+            ETH_PROCESS_ID.clone(),
+            format!("newHeads subscription requested by {target}!"),
+        )
+        .send(print_tx)
+        .await;
     }
     let mut urls = {
         // in code block to drop providers lock asap to avoid deadlock

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -145,10 +145,10 @@ pub async fn fd_manager(
                     &send_to_loop,
                 ).await {
                     Ok(Some(to_print)) => {
-                        Printout::new(2, to_print).send(&send_to_terminal).await;
+                        Printout::new(2, FD_MANAGER_PROCESS_ID.clone(), to_print).send(&send_to_terminal).await;
                     }
                     Err(e) => {
-                        Printout::new(1, &format!("handle_message error: {e:?}"))
+                        Printout::new(1, FD_MANAGER_PROCESS_ID.clone(), &format!("handle_message error: {e:?}"))
                             .send(&send_to_terminal)
                             .await;
                     }
@@ -163,7 +163,7 @@ pub async fn fd_manager(
                             state.update_all_fds_limits(our_node.as_str(), &send_to_loop).await;
                         }
                     }
-                    Err(e) => Printout::new(1, &format!("update_max_fds error: {e:?}"))
+                    Err(e) => Printout::new(1, FD_MANAGER_PROCESS_ID.clone(), &format!("update_max_fds error: {e:?}"))
                         .send(&send_to_terminal)
                         .await,
                 }
@@ -173,10 +173,10 @@ pub async fn fd_manager(
         if let Some(message) = recv_from_loop.recv().await {
             match handle_message(&our_node, message, &mut state, &send_to_loop).await {
                 Ok(Some(to_print)) => {
-                    Printout::new(2, to_print).send(&send_to_terminal).await;
+                    Printout::new(2, FD_MANAGER_PROCESS_ID.clone(), to_print).send(&send_to_terminal).await;
                 }
                 Err(e) => {
-                    Printout::new(1, &format!("handle_message error: {e:?}"))
+                    Printout::new(1, FD_MANAGER_PROCESS_ID.clone(), &format!("handle_message error: {e:?}"))
                         .send(&send_to_terminal)
                         .await;
                 }

--- a/kinode/src/fd_manager.rs
+++ b/kinode/src/fd_manager.rs
@@ -173,12 +173,18 @@ pub async fn fd_manager(
         if let Some(message) = recv_from_loop.recv().await {
             match handle_message(&our_node, message, &mut state, &send_to_loop).await {
                 Ok(Some(to_print)) => {
-                    Printout::new(2, FD_MANAGER_PROCESS_ID.clone(), to_print).send(&send_to_terminal).await;
-                }
-                Err(e) => {
-                    Printout::new(1, FD_MANAGER_PROCESS_ID.clone(), &format!("handle_message error: {e:?}"))
+                    Printout::new(2, FD_MANAGER_PROCESS_ID.clone(), to_print)
                         .send(&send_to_terminal)
                         .await;
+                }
+                Err(e) => {
+                    Printout::new(
+                        1,
+                        FD_MANAGER_PROCESS_ID.clone(),
+                        &format!("handle_message error: {e:?}"),
+                    )
+                    .send(&send_to_terminal)
+                    .await;
                 }
                 _ => {}
             }

--- a/kinode/src/http/client.rs
+++ b/kinode/src/http/client.rs
@@ -217,10 +217,11 @@ async fn connect_websocket(
         Ok((ws_stream, _)) => ws_stream,
         Err(e) => {
             let _ = print_tx
-                .send(Printout {
-                    verbosity: 1,
-                    content: format!("http-client: underlying lib connection error {e:?}"),
-                })
+                .send(Printout::new(
+                    1,
+                    HTTP_CLIENT_PROCESS_ID.clone(),
+                    format!("http-client: underlying lib connection error {e:?}"),
+                ))
                 .await;
 
             return Err(HttpClientError::WsOpenFailed {
@@ -404,10 +405,11 @@ async fn handle_http_request(
     };
 
     let _ = print_tx
-        .send(Printout {
-            verbosity: 2,
-            content: format!("http-client: {req_method} request to {}", url),
-        })
+        .send(Printout::new(
+            2,
+            HTTP_CLIENT_PROCESS_ID.clone(),
+            format!("http-client: {req_method} request to {}", url),
+        ))
         .await;
 
     // Build the request
@@ -498,10 +500,11 @@ async fn handle_http_request(
         }
         Err(e) => {
             let _ = print_tx
-                .send(Printout {
-                    verbosity: 2,
-                    content: "http-client: executed request but got error".to_string(),
-                })
+                .send(Printout::new(
+                    2,
+                    HTTP_CLIENT_PROCESS_ID.clone(),
+                    "http-client: executed request but got error".to_string(),
+                ))
                 .await;
             // Forward the error to the target process
             http_error_message(

--- a/kinode/src/http/server.rs
+++ b/kinode/src/http/server.rs
@@ -255,9 +255,13 @@ async fn serve(
     send_to_loop: MessageSender,
     print_tx: PrintSender,
 ) {
-    Printout::new(0, HTTP_SERVER_PROCESS_ID.clone(), format!("http-server: running on port {our_port}"))
-        .send(&print_tx)
-        .await;
+    Printout::new(
+        0,
+        HTTP_SERVER_PROCESS_ID.clone(),
+        format!("http-server: running on port {our_port}"),
+    )
+    .send(&print_tx)
+    .await;
 
     // filter to receive websockets
     let cloned_our = our.clone();
@@ -449,9 +453,13 @@ async fn ws_handler(
     print_tx: PrintSender,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let original_path = utils::normalize_path(path.as_str());
-    Printout::new(2, HTTP_SERVER_PROCESS_ID.clone(), format!("http-server: ws request for {original_path}"))
-        .send(&print_tx)
-        .await;
+    Printout::new(
+        2,
+        HTTP_SERVER_PROCESS_ID.clone(),
+        format!("http-server: ws request for {original_path}"),
+    )
+    .send(&print_tx)
+    .await;
 
     if ws_senders.len() >= WS_SELF_IMPOSED_MAX_CONNECTIONS as usize {
         Printout::new(
@@ -560,9 +568,13 @@ async fn http_handler(
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let original_path = utils::normalize_path(path.as_str());
     let base_path = original_path.split('/').skip(1).next().unwrap_or("");
-    Printout::new(2, HTTP_SERVER_PROCESS_ID.clone(), format!("http-server: request for {original_path}"))
-        .send(&print_tx)
-        .await;
+    Printout::new(
+        2,
+        HTTP_SERVER_PROCESS_ID.clone(),
+        format!("http-server: request for {original_path}"),
+    )
+    .send(&print_tx)
+    .await;
 
     let id: u64 = rand::random();
     let serialized_headers = utils::serialize_headers(&headers);

--- a/kinode/src/http/server.rs
+++ b/kinode/src/http/server.rs
@@ -255,7 +255,7 @@ async fn serve(
     send_to_loop: MessageSender,
     print_tx: PrintSender,
 ) {
-    Printout::new(0, format!("http-server: running on port {our_port}"))
+    Printout::new(0, HTTP_SERVER_PROCESS_ID.clone(), format!("http-server: running on port {our_port}"))
         .send(&print_tx)
         .await;
 
@@ -449,13 +449,14 @@ async fn ws_handler(
     print_tx: PrintSender,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let original_path = utils::normalize_path(path.as_str());
-    Printout::new(2, format!("http-server: ws request for {original_path}"))
+    Printout::new(2, HTTP_SERVER_PROCESS_ID.clone(), format!("http-server: ws request for {original_path}"))
         .send(&print_tx)
         .await;
 
     if ws_senders.len() >= WS_SELF_IMPOSED_MAX_CONNECTIONS as usize {
         Printout::new(
             0,
+            HTTP_SERVER_PROCESS_ID.clone(),
             format!(
                 "http-server: too many open websockets ({})! rejecting incoming",
                 ws_senders.len()
@@ -559,7 +560,7 @@ async fn http_handler(
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let original_path = utils::normalize_path(path.as_str());
     let base_path = original_path.split('/').skip(1).next().unwrap_or("");
-    Printout::new(2, format!("http-server: request for {original_path}"))
+    Printout::new(2, HTTP_SERVER_PROCESS_ID.clone(), format!("http-server: request for {original_path}"))
         .send(&print_tx)
         .await;
 
@@ -577,6 +578,7 @@ async fn http_handler(
     } else {
         Printout::new(
             2,
+            HTTP_SERVER_PROCESS_ID.clone(),
             format!("http-server: no route found for {original_path}"),
         )
         .send(&print_tx)
@@ -816,6 +818,7 @@ async fn handle_rpc_message(
 
     Printout::new(
         2,
+        HTTP_SERVER_PROCESS_ID.clone(),
         format!("http-server: passing on RPC message to {target_process}"),
     )
     .send(&print_tx)
@@ -989,6 +992,7 @@ async fn maintain_websocket(
 
     Printout::new(
         2,
+        HTTP_SERVER_PROCESS_ID.clone(),
         format!("http-server: new websocket connection to {app} with id {channel_id}"),
     )
     .send(&print_tx)
@@ -1063,6 +1067,7 @@ async fn maintain_websocket(
     }
     Printout::new(
         2,
+        HTTP_SERVER_PROCESS_ID.clone(),
         format!("http-server: websocket connection {channel_id} closed"),
     )
     .send(&print_tx)
@@ -1198,6 +1203,7 @@ async fn handle_app_message(
                     let mut path_bindings = path_bindings.write().await;
                     Printout::new(
                         2,
+                        HTTP_SERVER_PROCESS_ID.clone(),
                         format!(
                             "http: binding {path}, {}, {}, {}",
                             if authenticated {
@@ -1269,6 +1275,7 @@ async fn handle_app_message(
                     let mut path_bindings = path_bindings.write().await;
                     Printout::new(
                         2,
+                        HTTP_SERVER_PROCESS_ID.clone(),
                         format!(
                             "http: binding subdomain {subdomain} with path {path}, {}",
                             if cache { "cached" } else { "dynamic" },

--- a/kinode/src/kernel/mod.rs
+++ b/kinode/src/kernel/mod.rs
@@ -105,9 +105,13 @@ async fn handle_kernel_request(
     };
     let command: t::KernelCommand = match serde_json::from_slice(&request.body) {
         Err(e) => {
-            t::Printout::new(0, KERNEL_PROCESS_ID.clone(), format!("kernel: couldn't parse command: {e:?}"))
-                .send(send_to_terminal)
-                .await;
+            t::Printout::new(
+                0,
+                KERNEL_PROCESS_ID.clone(),
+                format!("kernel: couldn't parse command: {e:?}"),
+            )
+            .send(send_to_terminal)
+            .await;
             return None;
         }
         Ok(c) => c,
@@ -159,9 +163,13 @@ async fn handle_kernel_request(
             public,
         } => {
             let Some(blob) = km.lazy_load_blob else {
-                t::Printout::new(0, KERNEL_PROCESS_ID.clone(), "kernel: process startup requires bytes")
-                    .send(send_to_terminal)
-                    .await;
+                t::Printout::new(
+                    0,
+                    KERNEL_PROCESS_ID.clone(),
+                    "kernel: process startup requires bytes",
+                )
+                .send(send_to_terminal)
+                .await;
                 // fire an error back
                 t::KernelMessage::builder()
                     .id(km.id)
@@ -302,9 +310,13 @@ async fn handle_kernel_request(
                     t::KernelResponse::InitializedProcess
                 }
                 Err(e) => {
-                    t::Printout::new(0, KERNEL_PROCESS_ID.clone(), format!("kernel: error initializing process: {e:?}"))
-                        .send(send_to_terminal)
-                        .await;
+                    t::Printout::new(
+                        0,
+                        KERNEL_PROCESS_ID.clone(),
+                        format!("kernel: error initializing process: {e:?}"),
+                    )
+                    .send(send_to_terminal)
+                    .await;
                     t::KernelResponse::InitializeProcessError
                 }
             };
@@ -382,9 +394,13 @@ async fn handle_kernel_request(
                         t::KernelResponse::RunProcessError
                     }
                 } else {
-                    t::Printout::new(0, KERNEL_PROCESS_ID.clone(), format!("kernel: no such process {process_id} to run"))
-                        .send(send_to_terminal)
-                        .await;
+                    t::Printout::new(
+                        0,
+                        KERNEL_PROCESS_ID.clone(),
+                        format!("kernel: no such process {process_id} to run"),
+                    )
+                    .send(send_to_terminal)
+                    .await;
                     t::KernelResponse::RunProcessError
                 };
             t::KernelMessage::builder()
@@ -417,9 +433,13 @@ async fn handle_kernel_request(
             let process_handle = match process_handles.remove(&process_id) {
                 Some(ph) => ph,
                 None => {
-                    t::Printout::new(2, KERNEL_PROCESS_ID.clone(), format!("kernel: no such process {process_id} to kill"))
-                        .send(send_to_terminal)
-                        .await;
+                    t::Printout::new(
+                        2,
+                        KERNEL_PROCESS_ID.clone(),
+                        format!("kernel: no such process {process_id} to kill"),
+                    )
+                    .send(send_to_terminal)
+                    .await;
                     return None;
                 }
             };
@@ -436,14 +456,22 @@ async fn handle_kernel_request(
                     .expect("event loop: fatal: sender died");
             }
             if request.expects_response.is_none() {
-                t::Printout::new(2, KERNEL_PROCESS_ID.clone(), format!("kernel: killing process {process_id}"))
-                    .send(send_to_terminal)
-                    .await;
-                return None;
-            }
-            t::Printout::new(0, KERNEL_PROCESS_ID.clone(), format!("kernel: killing process {process_id}"))
+                t::Printout::new(
+                    2,
+                    KERNEL_PROCESS_ID.clone(),
+                    format!("kernel: killing process {process_id}"),
+                )
                 .send(send_to_terminal)
                 .await;
+                return None;
+            }
+            t::Printout::new(
+                0,
+                KERNEL_PROCESS_ID.clone(),
+                format!("kernel: killing process {process_id}"),
+            )
+            .send(send_to_terminal)
+            .await;
             t::KernelMessage::builder()
                 .id(km.id)
                 .source(("our", KERNEL_PROCESS_ID.clone()))
@@ -719,9 +747,13 @@ pub async fn kernel(
         {
             Ok(()) => {}
             Err(e) => {
-                t::Printout::new(0, KERNEL_PROCESS_ID.clone(), format!("kernel: couldn't reboot process: {e}"))
-                    .send(&send_to_terminal)
-                    .await;
+                t::Printout::new(
+                    0,
+                    KERNEL_PROCESS_ID.clone(),
+                    format!("kernel: couldn't reboot process: {e}"),
+                )
+                .send(&send_to_terminal)
+                .await;
                 non_rebooted_processes.insert(process_id.clone());
             }
         }

--- a/kinode/src/kernel/process.rs
+++ b/kinode/src/kernel/process.rs
@@ -296,9 +296,13 @@ pub async fn make_process_loop(
             // the process will run until it returns from init() or crashes
             match bindings.call_init(&mut store, &our.to_string()).await {
                 Ok(()) => {
-                    t::Printout::new(1, t::KERNEL_PROCESS_ID.clone(), format!("process {our} returned without error"))
-                        .send(&send_to_terminal)
-                        .await;
+                    t::Printout::new(
+                        1,
+                        t::KERNEL_PROCESS_ID.clone(),
+                        format!("process {our} returned without error"),
+                    )
+                    .send(&send_to_terminal)
+                    .await;
                 }
                 Err(e) => {
                     let stderr = wasi_stderr.contents().into();
@@ -330,9 +334,13 @@ pub async fn make_process_loop(
             // the process will run until it returns from init() or crashes
             match bindings.call_init(&mut store, &our.to_string()).await {
                 Ok(()) => {
-                    t::Printout::new(1, t::KERNEL_PROCESS_ID.clone(), format!("process {our} returned without error"))
-                        .send(&send_to_terminal)
-                        .await;
+                    t::Printout::new(
+                        1,
+                        t::KERNEL_PROCESS_ID.clone(),
+                        format!("process {our} returned without error"),
+                    )
+                    .send(&send_to_terminal)
+                    .await;
                 }
                 Err(e) => {
                     let stderr = wasi_stderr.contents().into();

--- a/kinode/src/kernel/process.rs
+++ b/kinode/src/kernel/process.rs
@@ -166,6 +166,7 @@ async fn make_component(
             Err(e) => {
                 t::Printout::new(
                     0,
+                    t::KERNEL_PROCESS_ID.clone(),
                     format!("kernel: process {our_process_id} failed to instantiate: {e:?}"),
                 )
                 .send(&send_to_terminal)
@@ -209,6 +210,7 @@ async fn make_component_v0(
             Err(e) => {
                 t::Printout::new(
                     0,
+                    t::KERNEL_PROCESS_ID.clone(),
                     format!("kernel: process {our_process_id} failed to instantiate: {e:?}"),
                 )
                 .send(&send_to_terminal)
@@ -294,7 +296,7 @@ pub async fn make_process_loop(
             // the process will run until it returns from init() or crashes
             match bindings.call_init(&mut store, &our.to_string()).await {
                 Ok(()) => {
-                    t::Printout::new(1, format!("process {our} returned without error"))
+                    t::Printout::new(1, t::KERNEL_PROCESS_ID.clone(), format!("process {our} returned without error"))
                         .send(&send_to_terminal)
                         .await;
                 }
@@ -308,6 +310,7 @@ pub async fn make_process_loop(
                     };
                     t::Printout::new(
                         0,
+                        t::KERNEL_PROCESS_ID.clone(),
                         format!("\x1b[38;5;196mprocess {our} ended with error:\x1b[0m\n{output}"),
                     )
                     .send(&send_to_terminal)
@@ -327,7 +330,7 @@ pub async fn make_process_loop(
             // the process will run until it returns from init() or crashes
             match bindings.call_init(&mut store, &our.to_string()).await {
                 Ok(()) => {
-                    t::Printout::new(1, format!("process {our} returned without error"))
+                    t::Printout::new(1, t::KERNEL_PROCESS_ID.clone(), format!("process {our} returned without error"))
                         .send(&send_to_terminal)
                         .await;
                 }
@@ -341,6 +344,7 @@ pub async fn make_process_loop(
                     };
                     t::Printout::new(
                         0,
+                        t::KERNEL_PROCESS_ID.clone(),
                         format!("\x1b[38;5;196mprocess {our} ended with error:\x1b[0m\n{output}"),
                     )
                     .send(&send_to_terminal)
@@ -359,6 +363,7 @@ pub async fn make_process_loop(
 
     t::Printout::new(
         1,
+        t::KERNEL_PROCESS_ID.clone(),
         format!(
             "process {} has OnExit behavior {}",
             metadata.our.process, metadata.on_exit

--- a/kinode/src/kernel/standard_host.rs
+++ b/kinode/src/kernel/standard_host.rs
@@ -6,9 +6,18 @@ use lib::wit::Host as StandardHost;
 use ring::signature::{self, KeyPair};
 
 async fn print_debug(proc: &process::ProcessState, content: &str) {
-    t::Printout::new(2, format!("{}: {}", proc.metadata.our.process, content))
-        .send(&proc.send_to_terminal)
-        .await;
+    t::Printout::new(
+        2,
+        &proc.metadata.our.process,
+        format!(
+            "{}:{}: {}",
+            proc.metadata.our.process.package(),
+            proc.metadata.our.process.publisher(),
+            content
+        ),
+    )
+    .send(&proc.send_to_terminal)
+    .await;
 }
 
 impl process::ProcessState {
@@ -339,6 +348,7 @@ impl process::ProcessState {
         let Some(ref prompting_message) = self.prompting_message else {
             t::Printout::new(
                 0,
+                KERNEL_PROCESS_ID.clone(),
                 format!("kernel: need non-None prompting_message to handle Response {response:?}"),
             )
             .send(&self.send_to_terminal)
@@ -449,15 +459,16 @@ impl StandardHost for process::ProcessWasi {
     async fn print_to_terminal(&mut self, verbosity: u8, content: String) -> Result<()> {
         self.process
             .send_to_terminal
-            .send(t::Printout {
+            .send(t::Printout::new(
                 verbosity,
-                content: format!(
+                &self.process.metadata.our.process,
+                format!(
                     "{}:{}: {}",
                     self.process.metadata.our.process.package(),
                     self.process.metadata.our.process.publisher(),
                     content
                 ),
-            })
+            ))
             .await
             .map_err(|e| anyhow::anyhow!("fatal: couldn't send to terminal: {e:?}"))
     }

--- a/kinode/src/kernel/standard_host_v0.rs
+++ b/kinode/src/kernel/standard_host_v0.rs
@@ -6,13 +6,18 @@ use lib::v0::wit::Host as StandardHost;
 use ring::signature::{self, KeyPair};
 
 async fn print_debug(proc: &process::ProcessState, content: &str) {
-    let _ = proc
-        .send_to_terminal
-        .send(t::Printout {
-            verbosity: 2,
-            content: format!("{}: {}", proc.metadata.our.process, content),
-        })
-        .await;
+    t::Printout::new(
+        2,
+        &proc.metadata.our.process,
+        format!(
+            "{}:{}: {}",
+            proc.metadata.our.process.package(),
+            proc.metadata.our.process.publisher(),
+            content
+        ),
+    )
+    .send(&proc.send_to_terminal)
+    .await;
 }
 
 impl process::ProcessState {
@@ -342,6 +347,7 @@ impl process::ProcessState {
         let Some(ref prompting_message) = self.prompting_message else {
             t::Printout::new(
                 0,
+                KERNEL_PROCESS_ID.clone(),
                 format!("kernel: need non-None prompting_message to handle Response {response:?}"),
             )
             .send(&self.send_to_terminal)
@@ -457,15 +463,16 @@ impl StandardHost for process::ProcessWasiV0 {
     async fn print_to_terminal(&mut self, verbosity: u8, content: String) -> Result<()> {
         self.process
             .send_to_terminal
-            .send(t::Printout {
+            .send(t::Printout::new(
                 verbosity,
-                content: format!(
+                &self.process.metadata.our.process,
+                format!(
                     "{}:{}: {}",
                     self.process.metadata.our.process.package(),
                     self.process.metadata.our.process.publisher(),
                     content
                 ),
-            })
+            ))
             .await
             .map_err(|e| anyhow::anyhow!("fatal: couldn't send to terminal: {e:?}"))
     }

--- a/kinode/src/kv.rs
+++ b/kinode/src/kv.rs
@@ -124,6 +124,7 @@ pub async fn kv(
         if state.our.node != km.source.node {
             Printout::new(
                 1,
+                KV_PROCESS_ID.clone(),
                 format!(
                     "kv: got request from {}, but requests must come from our node {}",
                     km.source.node, state.our.node,
@@ -138,6 +139,7 @@ pub async fn kv(
             if let Err(e) = handle_fd_request(km, &mut state).await {
                 Printout::new(
                     1,
+                    KV_PROCESS_ID.clone(),
                     format!("kv: got request from fd-manager that errored: {e:?}"),
                 )
                 .send(&state.send_to_terminal)
@@ -167,7 +169,7 @@ pub async fn kv(
                     (km.id.clone(), km.rsvp.clone().unwrap_or(km.source.clone()));
 
                 if let Err(e) = handle_request(km, &mut state, &send_to_caps_oracle).await {
-                    Printout::new(1, format!("kv: {e}"))
+                    Printout::new(1, KV_PROCESS_ID.clone(), format!("kv: {e}"))
                         .send(&state.send_to_terminal)
                         .await;
                     KernelMessage::builder()

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -3,7 +3,7 @@ use clap::{arg, value_parser, Command};
 use lib::types::core::{
     CapMessageReceiver, CapMessageSender, DebugReceiver, DebugSender, Identity, KernelCommand,
     KernelMessage, Keyfile, Message, MessageReceiver, MessageSender, NetworkErrorReceiver,
-    NetworkErrorSender, NodeRouting, PrintReceiver, PrintSender, ProcessId, Request,
+    NetworkErrorSender, NodeRouting, PrintReceiver, PrintSender, ProcessId, ProcessVerbosity, Request,
     KERNEL_PROCESS_ID,
 };
 #[cfg(feature = "simulation-mode")]
@@ -108,7 +108,7 @@ async fn main() {
     let detached = *matches.get_one::<bool>("detached").unwrap();
 
     let process_verbosity = matches.get_one::<String>("process-verbosity").unwrap();
-    let process_verbosity: HashMap<ProcessId, u8> = if process_verbosity.is_empty() {
+    let process_verbosity: ProcessVerbosity = if process_verbosity.is_empty() {
         HashMap::new()
     } else {
         serde_json::from_str(&process_verbosity)

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -8,6 +8,7 @@ use lib::types::core::{
 };
 #[cfg(feature = "simulation-mode")]
 use ring::{rand::SystemRandom, signature, signature::KeyPair};
+use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::sync::Arc;
@@ -105,6 +106,10 @@ async fn main() {
 
     // detached determines whether terminal is interactive
     let detached = *matches.get_one::<bool>("detached").unwrap();
+
+    let process_verbosity = matches.get_one::<String>("process-verbosity").unwrap();
+    let process_verbosity: HashMap<ProcessId, u8> = serde_json::from_str(&process_verbosity)
+        .expect("failed to parse given --process-verbosity to HashMap<ProcessId, u8>");
 
     #[cfg(feature = "simulation-mode")]
     let (fake_node_name, fakechain_port) = (
@@ -477,6 +482,7 @@ async fn main() {
             is_logging,
             max_log_size.copied(),
             number_log_files.copied(),
+            process_verbosity,
         ) => {
             match quit {
                 Ok(()) => {
@@ -726,6 +732,10 @@ fn build_command() -> Command {
         .arg(
             arg!(--"soft-ulimit" <SOFT_ULIMIT> "Enforce a static maximum number of file descriptors (default fetched from system)")
                 .value_parser(value_parser!(u64)),
+        )
+        .arg(
+            arg!(--"process-verbosity" <JSON_STRING> "ProcessId: verbosity JSON object")
+                .default_value("")
         );
 
     #[cfg(feature = "simulation-mode")]

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -108,8 +108,12 @@ async fn main() {
     let detached = *matches.get_one::<bool>("detached").unwrap();
 
     let process_verbosity = matches.get_one::<String>("process-verbosity").unwrap();
-    let process_verbosity: HashMap<ProcessId, u8> = serde_json::from_str(&process_verbosity)
-        .expect("failed to parse given --process-verbosity to HashMap<ProcessId, u8>");
+    let process_verbosity: HashMap<ProcessId, u8> = if process_verbosity.is_empty() {
+        HashMap::new()
+    } else {
+        serde_json::from_str(&process_verbosity)
+            .expect("failed to parse given --process-verbosity to HashMap<ProcessId, u8>")
+    };
 
     #[cfg(feature = "simulation-mode")]
     let (fake_node_name, fakechain_port) = (

--- a/kinode/src/main.rs
+++ b/kinode/src/main.rs
@@ -3,8 +3,8 @@ use clap::{arg, value_parser, Command};
 use lib::types::core::{
     CapMessageReceiver, CapMessageSender, DebugReceiver, DebugSender, Identity, KernelCommand,
     KernelMessage, Keyfile, Message, MessageReceiver, MessageSender, NetworkErrorReceiver,
-    NetworkErrorSender, NodeRouting, PrintReceiver, PrintSender, ProcessId, ProcessVerbosity, Request,
-    KERNEL_PROCESS_ID,
+    NetworkErrorSender, NodeRouting, PrintReceiver, PrintSender, ProcessId, ProcessVerbosity,
+    Request, KERNEL_PROCESS_ID,
 };
 #[cfg(feature = "simulation-mode")]
 use ring::{rand::SystemRandom, signature, signature::KeyPair};

--- a/kinode/src/net/utils.rs
+++ b/kinode/src/net/utils.rs
@@ -5,7 +5,7 @@ use crate::net::types::{
 use lib::types::core::{
     Identity, KernelMessage, KnsUpdate, Message, MessageSender, NetAction, NetworkErrorSender,
     NodeId, NodeRouting, PrintSender, Printout, Request, Response, SendError, SendErrorKind,
-    WrappedSendError,
+    WrappedSendError, NET_PROCESS_ID,
 };
 use {
     futures::{SinkExt, StreamExt},
@@ -429,12 +429,12 @@ pub async fn parse_hello_message(
 
 /// Create a terminal printout at verbosity level 0.
 pub async fn print_loud(print_tx: &PrintSender, content: &str) {
-    Printout::new(0, content).send(print_tx).await;
+    Printout::new(0, NET_PROCESS_ID.clone(), content).send(print_tx).await;
 }
 
 /// Create a terminal printout at verbosity level 2.
 pub async fn print_debug(print_tx: &PrintSender, content: &str) {
-    Printout::new(2, content).send(print_tx).await;
+    Printout::new(2, NET_PROCESS_ID.clone(), content).send(print_tx).await;
 }
 
 pub fn get_now() -> u64 {

--- a/kinode/src/net/utils.rs
+++ b/kinode/src/net/utils.rs
@@ -429,12 +429,16 @@ pub async fn parse_hello_message(
 
 /// Create a terminal printout at verbosity level 0.
 pub async fn print_loud(print_tx: &PrintSender, content: &str) {
-    Printout::new(0, NET_PROCESS_ID.clone(), content).send(print_tx).await;
+    Printout::new(0, NET_PROCESS_ID.clone(), content)
+        .send(print_tx)
+        .await;
 }
 
 /// Create a terminal printout at verbosity level 2.
 pub async fn print_debug(print_tx: &PrintSender, content: &str) {
-    Printout::new(2, NET_PROCESS_ID.clone(), content).send(print_tx).await;
+    Printout::new(2, NET_PROCESS_ID.clone(), content)
+        .send(print_tx)
+        .await;
 }
 
 pub fn get_now() -> u64 {

--- a/kinode/src/sqlite.rs
+++ b/kinode/src/sqlite.rs
@@ -135,6 +135,7 @@ pub async fn sqlite(
         if state.our.node != km.source.node {
             Printout::new(
                 1,
+                SQLITE_PROCESS_ID.clone(),
                 format!(
                     "sqlite: got request from {}, but requests must come from our node {}",
                     km.source.node, state.our.node
@@ -149,6 +150,7 @@ pub async fn sqlite(
             if let Err(e) = handle_fd_request(km, &mut state).await {
                 Printout::new(
                     1,
+                    SQLITE_PROCESS_ID.clone(),
                     format!("sqlite: got request from fd-manager that errored: {e:?}"),
                 )
                 .send(&state.send_to_terminal)
@@ -178,7 +180,7 @@ pub async fn sqlite(
                     (km.id.clone(), km.rsvp.clone().unwrap_or(km.source.clone()));
 
                 if let Err(e) = handle_request(km, &mut state, &send_to_caps_oracle).await {
-                    Printout::new(1, format!("sqlite: {e}"))
+                    Printout::new(1, SQLITE_PROCESS_ID.clone(), format!("sqlite: {e}"))
                         .send(&state.send_to_terminal)
                         .await;
                     KernelMessage::builder()

--- a/kinode/src/state.rs
+++ b/kinode/src/state.rs
@@ -110,6 +110,7 @@ pub async fn state_sender(
         if *our_node != km.source.node {
             Printout::new(
                 1,
+                STATE_PROCESS_ID.clone(),
                 format!(
                     "state: got request from {}, but requests must come from our node {our_node}",
                     km.source.node

--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -646,6 +646,9 @@ async fn handle_key_event(
             modifiers: KeyModifiers::CONTROL,
             ..
         } => {
+            if state.process_verbosity_mode {
+                return Ok(Some(false));
+            }
             // go from low to high, then reset to 0
             match verbose_mode {
                 0 => *verbose_mode = 1,
@@ -692,6 +695,9 @@ async fn handle_key_event(
             modifiers: KeyModifiers::CONTROL,
             ..
         } => {
+            if state.process_verbosity_mode {
+                return Ok(Some(false));
+            }
             let _ = debug_event_loop.send(DebugCommand::ToggleStepthrough).await;
             *in_step_through = !*in_step_through;
             Printout::new(
@@ -717,6 +723,9 @@ async fn handle_key_event(
             modifiers: KeyModifiers::CONTROL,
             ..
         } => {
+            if state.process_verbosity_mode {
+                return Ok(Some(false));
+            }
             let _ = debug_event_loop.send(DebugCommand::Step).await;
             return Ok(Some(false));
         }
@@ -728,6 +737,9 @@ async fn handle_key_event(
             modifiers: KeyModifiers::CONTROL,
             ..
         } => {
+            if state.process_verbosity_mode {
+                return Ok(Some(false));
+            }
             *logging_mode = !*logging_mode;
             Printout::new(
                 0,
@@ -749,7 +761,7 @@ async fn handle_key_event(
             modifiers: KeyModifiers::CONTROL,
             ..
         } => {
-            if state.search_mode {
+            if state.search_mode || state.process_verbosity_mode {
                 return Ok(Some(false));
             }
             // go up one command in history
@@ -781,7 +793,7 @@ async fn handle_key_event(
             modifiers: KeyModifiers::CONTROL,
             ..
         } => {
-            if state.search_mode {
+            if state.search_mode || state.process_verbosity_mode {
                 return Ok(Some(false));
             }
             // go down one command in history
@@ -841,6 +853,9 @@ async fn handle_key_event(
             modifiers: KeyModifiers::CONTROL,
             ..
         } => {
+            if state.process_verbosity_mode {
+                return Ok(Some(false));
+            }
             if state.search_mode {
                 *search_depth += 1;
             }
@@ -866,6 +881,9 @@ async fn handle_key_event(
             modifiers: KeyModifiers::CONTROL,
             ..
         } => {
+            if state.search_mode {
+                return Ok(Some(false));
+            }
             if state.process_verbosity_mode {
                 // Exit process verbosity mode
                 state.process_verbosity_mode = false;

--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -357,6 +357,7 @@ pub async fn terminal(
 
     let printout_queue = VecDeque::new();
     let max_printout_queue_len = MAX_PRINTOUT_QUEUE_LEN_DEFAULT.clone();
+    let printout_queue_number_dropped_printouts = 0;
 
     let mut state = State {
         stdout,
@@ -381,6 +382,7 @@ pub async fn terminal(
         saved_line,
         printout_queue,
         max_printout_queue_len,
+        printout_queue_number_dropped_printouts,
     };
 
     // use to trigger cleanup if receive signal to kill process

--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -536,6 +536,7 @@ async fn handle_key_event(
             }
             Printout::new(
                 0,
+                TERMINAL_PROCESS_ID.clone(),
                 format!(
                     "verbose mode: {}",
                     match verbose_mode {
@@ -563,6 +564,7 @@ async fn handle_key_event(
             *in_step_through = !*in_step_through;
             Printout::new(
                 0,
+                TERMINAL_PROCESS_ID.clone(),
                 format!(
                     "debug mode {}",
                     match in_step_through {
@@ -597,6 +599,7 @@ async fn handle_key_event(
             *logging_mode = !*logging_mode;
             Printout::new(
                 0,
+                TERMINAL_PROCESS_ID.clone(),
                 format!("logging mode: {}", if *logging_mode { "on" } else { "off" }),
             )
             .send(&print_tx)

--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -220,27 +220,6 @@ impl State {
 
         Some((process_id, verbosity))
     }
-
-    fn restore_screen(&mut self) -> Result<(), std::io::Error> {
-        // Clear everything
-        execute!(
-            self.stdout,
-            cursor::MoveTo(0, 0),
-            terminal::Clear(ClearType::All),
-        )?;
-
-        // Move cursor back to bottom and restore normal input line
-        execute!(
-            self.stdout,
-            cursor::MoveTo(0, self.win_rows),
-            Print(&self.current_line.prompt),
-            Print(&self.current_line.line),
-            cursor::MoveTo(
-                self.current_line.prompt_len as u16 + self.current_line.cursor_col,
-                self.win_rows
-            ),
-        )
-    }
 }
 
 struct CurrentLine {
@@ -315,6 +294,7 @@ pub async fn terminal(
     is_logging: bool,
     max_log_size: Option<u64>,
     number_log_files: Option<u64>,
+    process_verbosity: HashMap<ProcessId, u8>,
 ) -> anyhow::Result<()> {
     let (stdout, _maybe_raw_mode) = utils::splash(&our, version, is_detached)?;
 
@@ -349,7 +329,6 @@ pub async fn terminal(
     let log_dir_path = home_directory_path.join(".terminal_logs");
     let logger = utils::Logger::new(log_dir_path, max_log_size, number_log_files);
 
-    let process_verbosity = HashMap::new();
     let process_verbosity_mode = false;
     let saved_line = None;
 

--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -346,7 +346,8 @@ fn handle_printout(printout: Printout, state: &mut State) -> anyhow::Result<()> 
     }
     // skip writing print to terminal if it's of a greater
     // verbosity level than our current mode
-    let current_verbosity = state.process_verbosity
+    let current_verbosity = state
+        .process_verbosity
         .get(&printout.source)
         .unwrap_or_else(|| &state.verbose_mode);
     if &printout.verbosity > current_verbosity {

--- a/kinode/src/terminal/mod.rs
+++ b/kinode/src/terminal/mod.rs
@@ -125,7 +125,7 @@ impl State {
         execute!(
             self.stdout,
             terminal::EnterAlternateScreen,
-            cursor::Hide,  // Hide cursor while in alternate screen
+            cursor::Hide, // Hide cursor while in alternate screen
         )?;
 
         self.display_process_verbosity()?;
@@ -134,11 +134,7 @@ impl State {
 
     fn exit_process_verbosity_mode(&mut self) -> Result<(), std::io::Error> {
         // Leave alternate screen and restore cursor
-        execute!(
-            self.stdout,
-            cursor::Show,
-            terminal::LeaveAlternateScreen,
-        )?;
+        execute!(self.stdout, cursor::Show, terminal::LeaveAlternateScreen,)?;
         Ok(())
     }
 
@@ -157,24 +153,23 @@ impl State {
             style::SetForegroundColor(style::Color::Green),
             Print("=== Process Verbosity Mode ===\n\r"),
             style::SetForegroundColor(style::Color::Reset),
-            Print(format!("Overall verbosity: {}\n\r", match self.verbose_mode {
-                0 => "off",
-                1 => "debug",
-                2 => "super-debug",
-                3 => "full event loop",
-                _ => "unknown",
-            })),
+            Print(format!(
+                "Overall verbosity: {}\n\r",
+                match self.verbose_mode {
+                    0 => "off",
+                    1 => "debug",
+                    2 => "super-debug",
+                    3 => "full event loop",
+                    _ => "unknown",
+                }
+            )),
             Print("\n\rProcess-specific verbosity levels:\n\r"),
         )?;
 
         // Display current process verbosities
         let mut row = 4;
         if self.process_verbosity.is_empty() {
-            execute!(
-                self.stdout,
-                cursor::MoveTo(0, row),
-                Print("(none set)\n\r"),
-            )?;
+            execute!(self.stdout, cursor::MoveTo(0, row), Print("(none set)\n\r"),)?;
             row += 1;
         } else {
             for (process_id, verbosity) in &self.process_verbosity {
@@ -1002,7 +997,9 @@ async fn handle_key_event(
                 KeyCode::Enter => {
                     // if we were in process verbosity mode, update state
                     if state.process_verbosity_mode {
-                        if let Some((process_id, verbosity)) = State::parse_process_verbosity(&current_line.line) {
+                        if let Some((process_id, verbosity)) =
+                            State::parse_process_verbosity(&current_line.line)
+                        {
                             state.process_verbosity.insert(process_id, verbosity);
                             current_line.line.clear();
                             current_line.line_col = 0;

--- a/kinode/src/timer.rs
+++ b/kinode/src/timer.rs
@@ -59,14 +59,14 @@ pub async fn timer_service(
                 // we only handle Requests
                 let Message::Request(req) = km.message else { continue };
                 let Ok(timer_action) = serde_json::from_slice::<TimerAction>(&req.body) else {
-                    Printout::new(1, "timer service received a request with an invalid body").send(&print_tx).await;
+                    Printout::new(1, TIMER_PROCESS_ID.clone(), "timer service received a request with an invalid body").send(&print_tx).await;
                     continue
                 };
                 match timer_action {
                     TimerAction::Debug => {
-                        Printout::new(0, format!("timer service active timers ({}):", timer_map.timers.len())).send(&print_tx).await;
+                        Printout::new(0, TIMER_PROCESS_ID.clone(), format!("timer service active timers ({}):", timer_map.timers.len())).send(&print_tx).await;
                         for (k, v) in timer_map.timers.iter() {
-                            Printout::new(0, format!("{k}: {v:?}")).send(&print_tx).await;
+                            Printout::new(0, TIMER_PROCESS_ID.clone(), format!("{k}: {v:?}")).send(&print_tx).await;
                         }
                         continue
                     }
@@ -98,7 +98,7 @@ pub async fn timer_service(
                                 .send(&kernel_message_sender).await;
                             continue
                         }
-                        Printout::new(3, format!("set timer to pop in {timer_millis}ms")).send(&print_tx).await;
+                        Printout::new(3, TIMER_PROCESS_ID.clone(), format!("set timer to pop in {timer_millis}ms")).send(&print_tx).await;
                         if !timer_map.contains(pop_time) {
                             timer_tasks.spawn(async move {
                                 tokio::time::sleep(std::time::Duration::from_millis(timer_millis - 1)).await;

--- a/kinode/src/vfs.rs
+++ b/kinode/src/vfs.rs
@@ -63,6 +63,7 @@ pub async fn vfs(
         if *our_node != km.source.node {
             Printout::new(
                 1,
+                VFS_PROCESS_ID.clone(),
                 format!(
                     "vfs: got request from {}, but requests must come from our node {our_node}",
                     km.source.node
@@ -77,6 +78,7 @@ pub async fn vfs(
             if let Err(e) = handle_fd_request(km, &mut files).await {
                 Printout::new(
                     1,
+                    VFS_PROCESS_ID.clone(),
                     format!("vfs: got request from fd-manager that errored: {e:?}"),
                 )
                 .send(&send_to_terminal)

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -1365,6 +1365,7 @@ pub enum DebugCommand {
     ToggleStepthrough,
     Step,
     ToggleEventLoop,
+    ToggleEventLoopForProcess(ProcessId),
 }
 
 /// IPC format for requests sent to kernel runtime module

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -1332,16 +1332,19 @@ pub struct WrappedSendError {
 /// - `3`: very verbose: shows every event in event loop
 pub struct Printout {
     pub verbosity: u8,
+    pub source: ProcessId,
     pub content: String,
 }
 
 impl Printout {
-    pub fn new<T>(verbosity: u8, content: T) -> Self
+    pub fn new<T, U>(verbosity: u8, source: T, content: U) -> Self
     where
-        T: Into<String>,
+        T: Into<ProcessId>,
+        U: Into<String>,
     {
         Self {
             verbosity,
+            source: source.into(),
             content: content.into(),
         }
     }

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -1355,6 +1355,55 @@ impl Printout {
     }
 }
 
+#[derive(Error, Debug)]
+pub enum ProcessVerbosityValError {
+    #[error("Parse failed; must be `m` `mute` or `muted` (-> `Muted`) OR a u8")]
+    ParseFailed,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub enum ProcessVerbosityVal {
+    U8(u8),
+    Muted,
+}
+
+impl ProcessVerbosityVal {
+    pub fn get_verbosity(&self) -> Option<&u8> {
+        match self {
+            ProcessVerbosityVal::U8(v) => Some(v),
+            ProcessVerbosityVal::Muted => None,
+        }
+    }
+}
+
+impl std::str::FromStr for ProcessVerbosityVal {
+    type Err = ProcessVerbosityValError;
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if input == "m" || input == "mute" || input == "muted" {
+            return Ok(Self::Muted);
+        }
+        let Ok(u) = input.parse::<u8>() else {
+            return Err(ProcessVerbosityValError::ParseFailed);
+        };
+        Ok(Self::U8(u))
+    }
+}
+
+impl std::fmt::Display for ProcessVerbosityVal {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                ProcessVerbosityVal::U8(verbosity) => format!("{verbosity}"),
+                ProcessVerbosityVal::Muted => "muted".to_string(),
+            },
+        )
+    }
+}
+
+pub type ProcessVerbosity = HashMap<ProcessId, ProcessVerbosityVal>;
+
 /// kernel sets in case, e.g.,
 ///  A requests response from B does not request response from C
 ///  -> kernel sets `Some(A) = Rsvp` for B's request to C


### PR DESCRIPTION
## Problem

It'd be nice to be able to control not just the overall verbosity of the Kinode terminal, but also the verbosity of individual processes.

## Solution

- [x] Add a `source: ProcessId` field to `Printout` (4271525)
- [x] Add `terminal` state of per-process-verbosity: `HashMap<ProcessId, u8>` (70a2d68)
- [x] Use that state to decide whether to print or not (70a2d68)
- [ ] ~~Add scripts to manipulate that state (e.g. `process-verbosity <ProcessId> <u8>` and perhaps `package-verbosity <PackageId> <u8>`)~~
- [x] Add "process verbosity mode" to allow setting per-process verbosity (aca7cdb)
- [x] Add runtime argument to set pre-process verbosities at boot (b5dae0c)

## Testing

TODO

## Docs Update

TODO

## Notes

[Context](https://discord.com/channels/1186394868336038080/1186684706700410962/1307097791864111124)