### PR TITLE
Dr/eth interface generic

### DIFF
--- a/kinode/src/eth/mod.rs
+++ b/kinode/src/eth/mod.rs
@@ -769,7 +769,7 @@ async fn fulfill_request(
                 }
             }
         };
-        match pubsub.raw_request(method.into(), params.clone()).await {
+        match pubsub.raw_request(method.into(), params).await {
             Ok(value) => {
                 let mut is_replacement_successful = true;
                 providers.entry(chain_id.clone()).and_modify(|aps| {
@@ -793,7 +793,7 @@ async fn fulfill_request(
                     )
                     .await;
                 }
-                let response = EthResponse::Response { value };
+                let response = EthResponse::Response(value);
                 let mut request_cache = request_cache.lock().await;
                 if request_cache.len() >= MAX_REQUEST_CACHE_LEN {
                     // drop 10% oldest cache entries
@@ -813,7 +813,9 @@ async fn fulfill_request(
                 .await;
                 // if rpc_error is of type ErrResponse, return to user!
                 if let RpcError::ErrorResp(err) = rpc_error {
-                    return EthResponse::Err(EthError::RpcError(err));
+                    let err_value =
+                        serde_json::to_value(err).unwrap_or_else(|_| serde_json::Value::Null);
+                    return EthResponse::Err(EthError::RpcError(err_value));
                 }
                 // this provider failed and needs to be reset
                 let mut is_reset_successful = true;

--- a/lib/src/eth.rs
+++ b/lib/src/eth.rs
@@ -42,7 +42,7 @@ pub enum SubscriptionKind {
 /// The Action and Request type that can be made to eth:distro:sys. Any process with messaging
 /// capabilities can send this action to the eth provider.
 ///
-/// Will be serialized and deserialized using `serde_json::to_vec` and `serde_json::from_slice`.
+/// Will be serialized and deserialized using [`serde_json::to_vec`] and [`serde_json::from_slice`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum EthAction {
     /// Subscribe to logs with a custom filter. ID is to be used to unsubscribe.

--- a/lib/src/eth.rs
+++ b/lib/src/eth.rs
@@ -70,7 +70,7 @@ pub enum EthAction {
 pub type EthSubResult = Result<EthSub, EthSubError>;
 
 /// Incoming type for successful subscription updates.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EthSub {
     pub id: u64,
     /// can be parsed to [`alloy::rpc::types::eth::pubsub::SubscriptionResult`]
@@ -78,15 +78,15 @@ pub struct EthSub {
 }
 
 /// If your subscription is closed unexpectedly, you will receive this.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EthSubError {
     pub id: u64,
     pub error: String,
 }
 
-/// The Response type which a process will get from requesting with an [`EthAction`] will be
-/// of this type, serialized and deserialized using `serde_json::to_vec`
-/// and `serde_json::from_slice`.
+/// The Response body type which a process will get from requesting
+/// with an [`EthAction`] will be of this type, serialized and deserialized
+/// using [`serde_json::to_vec`] and [`serde_json::from_slice`].
 ///
 /// In the case of an [`EthAction::SubscribeLogs`] request, the response will indicate if
 /// the subscription was successfully created or not.
@@ -97,7 +97,7 @@ pub enum EthResponse {
     Err(EthError),
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum EthError {
     /// RPC provider returned an error.
     /// Can be parsed to [`alloy::rpc::json_rpc::ErrorPayload`]
@@ -122,7 +122,7 @@ pub enum EthError {
 
 /// The action type used for configuring eth:distro:sys. Only processes which have the "root"
 /// capability from eth:distro:sys can successfully send this action.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum EthConfigAction {
     /// Add a new provider to the list of providers.
     AddProvider(ProviderConfig),
@@ -153,7 +153,7 @@ pub enum EthConfigAction {
 }
 
 /// Response type from an [`EthConfigAction`] request.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum EthConfigResponse {
     Ok,
     /// Response from a GetProviders request.

--- a/lib/src/eth.rs
+++ b/lib/src/eth.rs
@@ -1,7 +1,43 @@
-use alloy::rpc::json_rpc::ErrorPayload;
-use alloy::rpc::types::eth::pubsub::{Params, SubscriptionKind, SubscriptionResult};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+
+/// Subscription kind. Pulled directly from alloy (https://github.com/alloy-rs/alloy).
+/// Why? Because alloy is not yet 1.0 and the types in this interface must be stable.
+/// If alloy SubscriptionKind changes, we can implement a transition function in runtime
+/// for this type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub enum SubscriptionKind {
+    /// New block headers subscription.
+    ///
+    /// Fires a notification each time a new header is appended to the chain, including chain
+    /// reorganizations. In case of a chain reorganization the subscription will emit all new
+    /// headers for the new chain. Therefore the subscription can emit multiple headers on the same
+    /// height.
+    NewHeads,
+    /// Logs subscription.
+    ///
+    /// Returns logs that are included in new imported blocks and match the given filter criteria.
+    /// In case of a chain reorganization previous sent logs that are on the old chain will be
+    /// resent with the removed property set to true. Logs from transactions that ended up in the
+    /// new chain are emitted. Therefore, a subscription can emit logs for the same transaction
+    /// multiple times.
+    Logs,
+    /// New Pending Transactions subscription.
+    ///
+    /// Returns the hash or full tx for all transactions that are added to the pending state and
+    /// are signed with a key that is available in the node. When a transaction that was
+    /// previously part of the canonical chain isn't part of the new canonical chain after a
+    /// reorganization its again emitted.
+    NewPendingTransactions,
+    /// Node syncing status subscription.
+    ///
+    /// Indicates when the node starts or stops synchronizing. The result can either be a boolean
+    /// indicating that the synchronization has started (true), finished (false) or an object with
+    /// various progress indicators.
+    Syncing,
+}
 
 /// The Action and Request type that can be made to eth:distro:sys. Any process with messaging
 /// capabilities can send this action to the eth provider.
@@ -10,12 +46,12 @@ use std::collections::{HashMap, HashSet};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum EthAction {
     /// Subscribe to logs with a custom filter. ID is to be used to unsubscribe.
-    /// Logs come in as alloy_rpc_types::pubsub::SubscriptionResults
+    /// Logs come in as JSON value which can be parsed to [`alloy::rpc::types::eth::pubsub::SubscriptionResult`]
     SubscribeLogs {
         sub_id: u64,
         chain_id: u64,
         kind: SubscriptionKind,
-        params: Params,
+        params: serde_json::Value,
     },
     /// Kill a SubscribeLogs subscription of a given ID, to stop getting updates.
     UnsubscribeLogs(u64),
@@ -37,7 +73,8 @@ pub type EthSubResult = Result<EthSub, EthSubError>;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EthSub {
     pub id: u64,
-    pub result: SubscriptionResult,
+    /// can be parsed to [`alloy::rpc::types::eth::pubsub::SubscriptionResult`]
+    pub result: serde_json::Value,
 }
 
 /// If your subscription is closed unexpectedly, you will receive this.
@@ -56,14 +93,15 @@ pub struct EthSubError {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum EthResponse {
     Ok,
-    Response { value: serde_json::Value },
+    Response(serde_json::Value),
     Err(EthError),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum EthError {
-    /// RPC provider returned an error
-    RpcError(ErrorPayload),
+    /// RPC provider returned an error.
+    /// Can be parsed to [`alloy::rpc::json_rpc::ErrorPayload`]
+    RpcError(serde_json::Value),
     /// provider module cannot parse message
     MalformedRequest,
     /// No RPC provider for the chain

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,3 @@
-//#![feature(let_chains)]
-
 pub mod core;
 pub mod eth;
 mod http;


### PR DESCRIPTION
## Problem

Current OS interface, specifically the eth module aspect, uses types from alloy. We need to achieve permanent backwards compatibility, so we can't use these types which are in a beta crate still being actively developed.

Linked to https://github.com/kinode-dao/process_lib/pull/118 in process_lib

## Solution

This PR replaces all alloy types with JSON values. This works perfectly since the crate is a wrapper over a JSON RPC standard anyways. We now do less munging, actually.


## Docs Update

https://github.com/kinode-dao/kinode-book/pull/261