### PR TITLE
update default providers/routers for 1.0

### DIFF
--- a/kinode/src/eth/default_providers_mainnet.json
+++ b/kinode/src/eth/default_providers_mainnet.json
@@ -6,7 +6,7 @@
             "Node": {
                 "use_as_provider": true,
                 "kns_update": {
-                    "name": "providerfren.os",
+                    "name": "eth-provider.kino",
                     "owner": "",
                     "node": "",
                     "public_key": "0x54f5a8a4c625d5925e63ed3f0203b63e007e3f822d7858bd98b1fd9704c99451",
@@ -28,7 +28,29 @@
             "Node": {
                 "use_as_provider": true,
                 "kns_update": {
-                    "name": "providerfren.os",
+                    "name": "optimism-provider.kino",
+                    "owner": "",
+                    "node": "",
+                    "public_key": "0x54f5a8a4c625d5925e63ed3f0203b63e007e3f822d7858bd98b1fd9704c99451",
+                    "ips": [
+                        "147.135.114.167"
+                    ],
+                    "ports": {
+                        "ws": 9999
+                    },
+                    "routers": []
+                }
+            }
+        }
+    },
+    {
+        "chain_id": 8453,
+        "trusted": false,
+        "provider": {
+            "Node": {
+                "use_as_provider": true,
+                "kns_update": {
+                    "name": "base-provider.kino",
                     "owner": "",
                     "node": "",
                     "public_key": "0x54f5a8a4c625d5925e63ed3f0203b63e007e3f822d7858bd98b1fd9704c99451",
@@ -50,7 +72,7 @@
             "Node": {
                 "use_as_provider": true,
                 "kns_update": {
-                    "name": "providerfren.os",
+                    "name": "sepolia-provider.kino",
                     "owner": "",
                     "node": "",
                     "public_key": "0x54f5a8a4c625d5925e63ed3f0203b63e007e3f822d7858bd98b1fd9704c99451",

--- a/kinode/src/register.rs
+++ b/kinode/src/register.rs
@@ -74,11 +74,17 @@ pub async fn register(
         routing: NodeRouting::Both {
             ip: ip.clone(),
             ports: ports_map,
-            routers: vec![
-                "default-router-1.os".into(),
-                "default-router-2.os".into(),
-                "default-router-3.os".into(),
-            ],
+            routers: {
+                // select 3 random routers from this list
+                use rand::prelude::SliceRandom;
+                let routers = (1..=12)
+                    .map(|i| format!("default-router-{}.kino", i))
+                    .collect::<Vec<_>>()
+                    .choose_multiple(&mut rand::thread_rng(), 3)
+                    .cloned()
+                    .collect::<Vec<_>>();
+                routers
+            },
         },
     });
 


### PR DESCRIPTION
before merging:
- [ ] deploy kimap mainnet
- [ ] mint `default-router-n.kino` for n=[1..=12]
- [ ] mint `eth-provider.kino`, `optimism-provider.kino`, `base-provider.kino`, `sepolia-provider.kino`
- [ ] key providers with RPCs for associated chains