### PR TITLE
app-store: remove hi

### DIFF
--- a/kinode/packages/app-store/api/app-store:sys-v1.wit
+++ b/kinode/packages/app-store/api/app-store:sys-v1.wit
@@ -10,11 +10,13 @@ interface main {
     /// Represents various requests that can be made to the main App Store interface
     variant request {
         local(local-request),
+        remote(remote-request),
     }
 
     /// Represents various responses from the main App Store interface
     variant response {
         local(local-response),
+        remote(remote-response),
         chain-error(chain-error),
         download-error(download-error),
         handling-error(string),
@@ -58,6 +60,18 @@ interface main {
         apis-response(apis-response),
         /// lazy-load-blob: on success; the WIT API that was requested.
         get-api-response(get-api-response),
+    }
+
+    /// Remote requests that can be made to the App Store
+    variant remote-request {
+        /// lazy-load-blob: none.
+        ping,
+    }
+
+    /// Remote responses from the App Store
+    variant remote-response {
+        /// lazy-load-blob: none.
+        ping,
     }
 
     /// Request to add a new package
@@ -135,7 +149,7 @@ interface chain {
         /// lazy-load-blob: none.
         stop-auto-update(package-id),
         /// Reset app-store db
-        /// 
+        ///
         /// lazy-load-blob: none.
         reset,
     }

--- a/kinode/packages/app-store/api/app-store:sys-v1.wit
+++ b/kinode/packages/app-store/api/app-store:sys-v1.wit
@@ -114,7 +114,7 @@ interface chain {
     use standard.{package-id};
 
     /// Requests that can be made to the chain component
-    variant chain-requests {
+    variant chain-request {
         /// Get information about a specific app
         ///
         /// lazy-load-blob: none.
@@ -142,7 +142,7 @@ interface chain {
     }
 
     /// Responses from the chain component
-    variant chain-responses {
+    variant chain-response {
         /// lazy-load-blob: none.
         get-app(option<onchain-app>),
         /// lazy-load-blob: none.
@@ -208,7 +208,7 @@ interface downloads {
     use chain.{onchain-metadata};
 
     /// Requests that can be made to the downloads component
-    variant download-requests {
+    variant download-request {
         /// Check if a a node is mirroring a given package.
         /// returns a success response if the node is mirroring the package,
         /// otherwise an error response of type err(not-mirroring).
@@ -270,7 +270,7 @@ interface downloads {
     }
 
     /// Responses from the downloads component
-    variant download-responses {
+    variant download-response {
         /// catch-all success response
         /// lazy-load-blob: none.
         success,

--- a/kinode/packages/app-store/api/app-store:sys-v1.wit
+++ b/kinode/packages/app-store/api/app-store:sys-v1.wit
@@ -10,16 +10,14 @@ interface main {
     /// Represents various requests that can be made to the main App Store interface
     variant request {
         local(local-request),
-        remote(remote-request),
+        /// remote requests possible in future--currently all handled by downloads process
     }
 
     /// Represents various responses from the main App Store interface
     variant response {
         local(local-response),
-        remote(remote-response),
         chain-error(chain-error),
         download-error(download-error),
-        handling-error(string),
     }
 
     /// Local requests that can be made to the App Store
@@ -62,18 +60,6 @@ interface main {
         get-api-response(get-api-response),
     }
 
-    /// Remote requests that can be made to the App Store
-    variant remote-request {
-        /// lazy-load-blob: none.
-        ping,
-    }
-
-    /// Remote responses from the App Store
-    variant remote-response {
-        /// lazy-load-blob: none.
-        ping,
-    }
-
     /// Request to add a new package
     record new-package-request {
         package-id: package-id,
@@ -83,7 +69,8 @@ interface main {
     /// Request to install a package
     record install-package-request {
         package-id: package-id,
-        metadata: option<onchain-metadata>, // if None, local sideloaded package.
+        /// if None, local sideloaded package.
+        metadata: option<onchain-metadata>,
         version-hash: string,
     }
 
@@ -222,6 +209,12 @@ interface downloads {
 
     /// Requests that can be made to the downloads component
     variant download-requests {
+        /// Check if a a node is mirroring a given package.
+        /// returns a success response if the node is mirroring the package,
+        /// otherwise an error response of type err(not-mirroring).
+        ///
+        /// lazy-load-blob: none.
+        mirror-check(package-id),
         /// Request a remote download
         ///
         /// lazy-load-blob: none.
@@ -278,12 +271,14 @@ interface downloads {
 
     /// Responses from the downloads component
     variant download-responses {
+        /// catch-all success response
         /// lazy-load-blob: none.
         success,
         /// lazy-load-blob: none.
-        err(download-error),
-        /// lazy-load-blob: none.
         get-files(list<entry>),
+        /// catch-all error response
+        /// lazy-load-blob: none.
+        err(download-error),
     }
 
     /// Request for a local download
@@ -316,7 +311,6 @@ interface downloads {
         http-client-error,
         blob-not-found,
         vfs-error,
-        handling-error(string),
         timeout,
         invalid-manifest,
         offline,
@@ -346,7 +340,8 @@ interface downloads {
     record auto-download-error {
         package-id: package-id,
         version-hash: string,
-        tries: list<tuple<string, download-error>>, // (mirror, error)
+        /// list is of (mirror, error)
+        tries: list<tuple<string, download-error>>,
     }
 
     /// Represents a hash mismatch error

--- a/kinode/packages/app-store/app-store/src/http_api.rs
+++ b/kinode/packages/app-store/app-store/src/http_api.rs
@@ -4,9 +4,9 @@
 //!
 use crate::{
     kinode::process::{
-        chain::{ChainRequests, ChainResponses},
+        chain::{ChainRequest, ChainResponse},
         downloads::{
-            DownloadRequests, DownloadResponses, Entry, LocalDownloadRequest, RemoveFileRequest,
+            DownloadRequest, DownloadResponse, Entry, LocalDownloadRequest, RemoveFileRequest,
         },
     },
     state::{MirrorCheck, PackageState, State, Updates},
@@ -272,11 +272,11 @@ fn serve_paths(
         // GET all apps
         "/apps" | "/apps-public" => {
             let resp = Request::to(("our", "chain", "app-store", "sys"))
-                .body(serde_json::to_vec(&ChainRequests::GetApps)?)
+                .body(serde_json::to_vec(&ChainRequest::GetApps)?)
                 .send_and_await_response(5)??;
-            let msg = serde_json::from_slice::<ChainResponses>(resp.body())?;
+            let msg = serde_json::from_slice::<ChainResponse>(resp.body())?;
             match msg {
-                ChainResponses::GetApps(apps) => {
+                ChainResponse::GetApps(apps) => {
                     Ok((StatusCode::OK, None, serde_json::to_vec(&apps)?))
                 }
                 _ => Err(anyhow::anyhow!("Invalid response from chain: {:?}", msg)),
@@ -298,11 +298,11 @@ fn serve_paths(
                     let package_id =
                         crate::kinode::process::main::PackageId::from_process_lib(package_id);
                     let resp = Request::to(("our", "chain", "app-store", "sys"))
-                        .body(serde_json::to_vec(&ChainRequests::GetApp(package_id))?)
+                        .body(serde_json::to_vec(&ChainRequest::GetApp(package_id))?)
                         .send_and_await_response(5)??;
-                    let msg = serde_json::from_slice::<ChainResponses>(resp.body())?;
+                    let msg = serde_json::from_slice::<ChainResponse>(resp.body())?;
                     match msg {
-                        ChainResponses::GetApp(app) => {
+                        ChainResponse::GetApp(app) => {
                             Ok((StatusCode::OK, None, serde_json::to_vec(&app)?))
                         }
                         _ => Err(anyhow::anyhow!("Invalid response from chain: {:?}", msg)),
@@ -328,15 +328,15 @@ fn serve_paths(
         "/downloads" => {
             // get all local downloads!
             let resp = Request::to(("our", "downloads", "app-store", "sys"))
-                .body(serde_json::to_vec(&DownloadRequests::GetFiles(None))?)
+                .body(serde_json::to_vec(&DownloadRequest::GetFiles(None))?)
                 .send_and_await_response(5)??;
 
-            let msg = serde_json::from_slice::<DownloadResponses>(resp.body())?;
+            let msg = serde_json::from_slice::<DownloadResponse>(resp.body())?;
             match msg {
-                DownloadResponses::GetFiles(files) => {
+                DownloadResponse::GetFiles(files) => {
                     Ok((StatusCode::OK, None, serde_json::to_vec(&files)?))
                 }
-                DownloadResponses::Err(e) => Err(anyhow::anyhow!("Error from downloads: {:?}", e)),
+                DownloadResponse::Err(e) => Err(anyhow::anyhow!("Error from downloads: {:?}", e)),
                 _ => Err(anyhow::anyhow!(
                     "Invalid response from downloads: {:?}",
                     msg
@@ -354,17 +354,17 @@ fn serve_paths(
             };
             let package_id = crate::kinode::process::main::PackageId::from_process_lib(package_id);
             let resp = Request::to(("our", "downloads", "app-store", "sys"))
-                .body(serde_json::to_vec(&DownloadRequests::GetFiles(Some(
+                .body(serde_json::to_vec(&DownloadRequest::GetFiles(Some(
                     package_id,
                 )))?)
                 .send_and_await_response(5)??;
 
-            let msg = serde_json::from_slice::<DownloadResponses>(resp.body())?;
+            let msg = serde_json::from_slice::<DownloadResponse>(resp.body())?;
             match msg {
-                DownloadResponses::GetFiles(files) => {
+                DownloadResponse::GetFiles(files) => {
                     Ok((StatusCode::OK, None, serde_json::to_vec(&files)?))
                 }
-                DownloadResponses::Err(e) => Err(anyhow::anyhow!("Error from downloads: {:?}", e)),
+                DownloadResponse::Err(e) => Err(anyhow::anyhow!("Error from downloads: {:?}", e)),
                 _ => Err(anyhow::anyhow!(
                     "Invalid response from downloads: {:?}",
                     msg
@@ -393,14 +393,14 @@ fn serve_paths(
 
             // get the file corresponding to the version hash, extract manifest and return.
             let resp = Request::to(("our", "downloads", "app-store", "sys"))
-                .body(serde_json::to_vec(&DownloadRequests::GetFiles(Some(
+                .body(serde_json::to_vec(&DownloadRequest::GetFiles(Some(
                     package_id.clone(),
                 )))?)
                 .send_and_await_response(5)??;
 
-            let msg = serde_json::from_slice::<DownloadResponses>(resp.body())?;
+            let msg = serde_json::from_slice::<DownloadResponse>(resp.body())?;
             match msg {
-                DownloadResponses::GetFiles(files) => {
+                DownloadResponse::GetFiles(files) => {
                     let file_name = format!("{version_hash}.zip");
                     let file_entry = files.into_iter().find(|entry| match entry {
                         Entry::File(file) => file.name == file_name,
@@ -426,7 +426,7 @@ fn serve_paths(
                         }
                     }
                 }
-                DownloadResponses::Err(e) => Ok((
+                DownloadResponse::Err(e) => Ok((
                     StatusCode::NOT_FOUND,
                     None,
                     format!("Error from downloads: {:?}", e).into_bytes(),
@@ -472,11 +472,11 @@ fn serve_paths(
         }
         "/ourapps" => {
             let resp = Request::to(("our", "chain", "app-store", "sys"))
-                .body(serde_json::to_vec(&ChainRequests::GetOurApps)?)
+                .body(serde_json::to_vec(&ChainRequest::GetOurApps)?)
                 .send_and_await_response(5)??;
-            let msg = serde_json::from_slice::<ChainResponses>(resp.body())?;
+            let msg = serde_json::from_slice::<ChainResponse>(resp.body())?;
             match msg {
-                ChainResponses::GetOurApps(apps) => {
+                ChainResponse::GetOurApps(apps) => {
                     Ok((StatusCode::OK, None, serde_json::to_vec(&apps)?))
                 }
                 _ => Err(anyhow::anyhow!("Invalid response from chain: {:?}", msg)),
@@ -508,7 +508,7 @@ fn serve_paths(
                 .map(|s| s.to_string())
                 .ok_or_else(|| anyhow::anyhow!("No version_hash specified!"))?;
 
-            let download_request = DownloadRequests::LocalDownload(LocalDownloadRequest {
+            let download_request = DownloadRequest::LocalDownload(LocalDownloadRequest {
                 package_id: crate::kinode::process::main::PackageId::from_process_lib(package_id),
                 download_from: download_from.clone(),
                 desired_version_hash: version_hash,
@@ -520,7 +520,7 @@ fn serve_paths(
             Ok((
                 StatusCode::OK,
                 None,
-                serde_json::to_vec(&DownloadResponses::Success)?,
+                serde_json::to_vec(&DownloadResponse::Success)?,
             ))
         }
         // POST /apps/:id/install
@@ -585,14 +585,14 @@ fn serve_paths(
                 Method::PUT => {
                     let resp = Request::new()
                         .target(downloads)
-                        .body(serde_json::to_vec(&DownloadRequests::StartMirroring(
+                        .body(serde_json::to_vec(&DownloadRequest::StartMirroring(
                             crate::kinode::process::main::PackageId::from_process_lib(package_id),
                         ))?)
                         .send_and_await_response(5)??;
-                    let msg = serde_json::from_slice::<DownloadResponses>(resp.body())?;
+                    let msg = serde_json::from_slice::<DownloadResponse>(resp.body())?;
                     match msg {
-                        DownloadResponses::Success => Ok((StatusCode::OK, None, vec![])),
-                        DownloadResponses::Err(e) => {
+                        DownloadResponse::Success => Ok((StatusCode::OK, None, vec![])),
+                        DownloadResponse::Err(e) => {
                             Err(anyhow::anyhow!("Error starting mirroring: {:?}", e))
                         }
                         _ => Err(anyhow::anyhow!(
@@ -605,14 +605,14 @@ fn serve_paths(
                 Method::DELETE => {
                     let resp = Request::new()
                         .target(downloads)
-                        .body(serde_json::to_vec(&DownloadRequests::StopMirroring(
+                        .body(serde_json::to_vec(&DownloadRequest::StopMirroring(
                             crate::kinode::process::main::PackageId::from_process_lib(package_id),
                         ))?)
                         .send_and_await_response(5)??;
-                    let msg = serde_json::from_slice::<DownloadResponses>(resp.body())?;
+                    let msg = serde_json::from_slice::<DownloadResponse>(resp.body())?;
                     match msg {
-                        DownloadResponses::Success => Ok((StatusCode::OK, None, vec![])),
-                        DownloadResponses::Err(e) => {
+                        DownloadResponse::Success => Ok((StatusCode::OK, None, vec![])),
+                        DownloadResponse::Err(e) => {
                             Err(anyhow::anyhow!("Error stopping mirroring: {:?}", e))
                         }
                         _ => Err(anyhow::anyhow!(
@@ -646,7 +646,7 @@ fn serve_paths(
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string())
                 .ok_or_else(|| anyhow::anyhow!("No version_hash specified!"))?;
-            let download_request = DownloadRequests::RemoveFile(RemoveFileRequest {
+            let download_request = DownloadRequest::RemoveFile(RemoveFileRequest {
                 package_id: crate::kinode::process::main::PackageId::from_process_lib(package_id),
                 version_hash: version_hash,
             });
@@ -654,10 +654,10 @@ fn serve_paths(
             let resp = Request::to(("our", "downloads", "app-store", "sys"))
                 .body(serde_json::to_vec(&download_request)?)
                 .send_and_await_response(5)??;
-            let msg = serde_json::from_slice::<DownloadResponses>(resp.body())?;
+            let msg = serde_json::from_slice::<DownloadResponse>(resp.body())?;
             match msg {
-                DownloadResponses::Success => Ok((StatusCode::OK, None, vec![])),
-                DownloadResponses::Err(e) => Err(anyhow::anyhow!("Error removing file: {:?}", e)),
+                DownloadResponse::Success => Ok((StatusCode::OK, None, vec![])),
+                DownloadResponse::Err(e) => Err(anyhow::anyhow!("Error removing file: {:?}", e)),
                 _ => Err(anyhow::anyhow!(
                     "Invalid response from downloads: {:?}",
                     msg
@@ -670,10 +670,10 @@ fn serve_paths(
             let package_id = get_package_id(url_params)?;
 
             let chain_request = match method {
-                Method::PUT => ChainRequests::StartAutoUpdate(
+                Method::PUT => ChainRequest::StartAutoUpdate(
                     crate::kinode::process::main::PackageId::from_process_lib(package_id),
                 ),
-                Method::DELETE => ChainRequests::StopAutoUpdate(
+                Method::DELETE => ChainRequest::StopAutoUpdate(
                     crate::kinode::process::main::PackageId::from_process_lib(package_id),
                 ),
                 _ => {
@@ -689,11 +689,11 @@ fn serve_paths(
                 .body(serde_json::to_vec(&chain_request)?)
                 .send_and_await_response(5)??;
 
-            let msg = serde_json::from_slice::<ChainResponses>(resp.body())?;
+            let msg = serde_json::from_slice::<ChainResponse>(resp.body())?;
             match msg {
-                ChainResponses::AutoUpdateStarted
-                | ChainResponses::AutoUpdateStopped
-                | ChainResponses::Err(_) => Ok((StatusCode::OK, None, serde_json::to_vec(&msg)?)),
+                ChainResponse::AutoUpdateStarted
+                | ChainResponse::AutoUpdateStopped
+                | ChainResponse::Err(_) => Ok((StatusCode::OK, None, serde_json::to_vec(&msg)?)),
                 _ => Ok((
                     StatusCode::INTERNAL_SERVER_ERROR,
                     None,
@@ -739,10 +739,10 @@ fn serve_paths(
 
             let resp = Request::new()
                 .target(chain)
-                .body(&ChainRequests::Reset)
+                .body(&ChainRequest::Reset)
                 .send_and_await_response(5)??;
-            let msg = serde_json::from_slice::<ChainResponses>(resp.body())?;
-            if let ChainResponses::ResetOk = msg {
+            let msg = serde_json::from_slice::<ChainResponse>(resp.body())?;
+            if let ChainResponse::ResetOk = msg {
                 Ok((StatusCode::OK, None, vec![]))
             } else {
                 Ok((StatusCode::INTERNAL_SERVER_ERROR, None, vec![]))
@@ -780,7 +780,7 @@ fn serve_paths(
             };
             if let Err(SendError { kind, .. }) =
                 Request::to((node, "downloads", "app-store", "sys"))
-                    .body(DownloadRequests::MirrorCheck(
+                    .body(DownloadRequest::MirrorCheck(
                         crate::kinode::process::main::PackageId::from_process_lib(
                             package_id_parsed,
                         ),

--- a/kinode/packages/app-store/app-store/src/http_api.rs
+++ b/kinode/packages/app-store/app-store/src/http_api.rs
@@ -8,6 +8,7 @@ use crate::{
         downloads::{
             DownloadRequests, DownloadResponses, Entry, LocalDownloadRequest, RemoveFileRequest,
         },
+        main::RemoteRequest,
     },
     state::{MirrorCheck, PackageState, State, Updates},
 };
@@ -764,8 +765,8 @@ fn serve_paths(
                     format!("Missing node").into_bytes(),
                 ));
             };
-            if let Err(SendError { kind, .. }) = Request::to((node, "net", "distro", "sys"))
-                .body(b"checking your mirror status...")
+            if let Err(SendError { kind, .. }) = Request::to((node, "main", "app-store", "sys"))
+                .body(RemoteRequest::Ping)
                 .send_and_await_response(3)
                 .unwrap()
             {

--- a/kinode/packages/app-store/app-store/src/lib.rs
+++ b/kinode/packages/app-store/app-store/src/lib.rs
@@ -30,7 +30,7 @@
 //! It delegates these responsibilities to the downloads and chain processes respectively.
 //!
 use crate::kinode::process::downloads::{
-    AutoDownloadCompleteRequest, DownloadCompleteRequest, DownloadResponses, ProgressUpdate,
+    AutoDownloadCompleteRequest, DownloadCompleteRequest, DownloadResponse, ProgressUpdate,
 };
 use crate::kinode::process::main::{
     ApisResponse, GetApiResponse, InstallPackageRequest, InstallResponse, LocalRequest,
@@ -72,7 +72,7 @@ pub enum Req {
 #[serde(untagged)] // untagged as a meta-type for all incoming responses
 pub enum Resp {
     LocalResponse(LocalResponse),
-    Download(DownloadResponses),
+    Download(DownloadResponse),
 }
 
 call_init!(init);

--- a/kinode/packages/app-store/app-store/src/lib.rs
+++ b/kinode/packages/app-store/app-store/src/lib.rs
@@ -34,8 +34,8 @@ use crate::kinode::process::downloads::{
 };
 use crate::kinode::process::main::{
     ApisResponse, GetApiResponse, InstallPackageRequest, InstallResponse, LocalRequest,
-    LocalResponse, NewPackageRequest, NewPackageResponse, RemoteRequest, RemoteResponse, Response as AppStoreResponse,
-    UninstallResponse,
+    LocalResponse, NewPackageRequest, NewPackageResponse, RemoteRequest, RemoteResponse,
+    Response as AppStoreResponse, UninstallResponse,
 };
 use kinode_process_lib::{
     await_message, call_init, get_blob, http, print_to_terminal, println, vfs, Address,
@@ -132,13 +132,11 @@ fn handle_message(
                     response.send()?;
                 }
             }
-            Req::RemoteRequest(remote_request) => {
-                match remote_request {
-                    RemoteRequest::Ping => {
-                        Response::new().body(RemoteResponse::Ping).send()?;
-                    }
+            Req::RemoteRequest(remote_request) => match remote_request {
+                RemoteRequest::Ping => {
+                    Response::new().body(RemoteResponse::Ping).send()?;
                 }
-            }
+            },
             Req::Http(server_request) => {
                 if !message.is_local(&our) || message.source().process != "http-server:distro:sys" {
                     return Err(anyhow::anyhow!("http-server from non-local node"));

--- a/kinode/packages/app-store/app-store/src/lib.rs
+++ b/kinode/packages/app-store/app-store/src/lib.rs
@@ -34,7 +34,7 @@ use crate::kinode::process::downloads::{
 };
 use crate::kinode::process::main::{
     ApisResponse, GetApiResponse, InstallPackageRequest, InstallResponse, LocalRequest,
-    LocalResponse, NewPackageRequest, NewPackageResponse, Response as AppStoreResponse,
+    LocalResponse, NewPackageRequest, NewPackageResponse, RemoteRequest, RemoteResponse, Response as AppStoreResponse,
     UninstallResponse,
 };
 use kinode_process_lib::{
@@ -63,6 +63,7 @@ const VFS_TIMEOUT: u64 = 10;
 #[serde(untagged)] // untagged as a meta-type for all incoming requests
 pub enum Req {
     LocalRequest(LocalRequest),
+    RemoteRequest(RemoteRequest),
     Progress(ProgressUpdate),
     DownloadComplete(DownloadCompleteRequest),
     AutoDownloadComplete(AutoDownloadCompleteRequest),
@@ -129,6 +130,13 @@ fn handle_message(
                     response.blob(blob).send()?;
                 } else {
                     response.send()?;
+                }
+            }
+            Req::RemoteRequest(remote_request) => {
+                match remote_request {
+                    RemoteRequest::Ping => {
+                        Response::new().body(RemoteResponse::Ping).send()?;
+                    }
                 }
             }
             Req::Http(server_request) => {

--- a/kinode/packages/app-store/download/src/lib.rs
+++ b/kinode/packages/app-store/download/src/lib.rs
@@ -12,7 +12,7 @@
 //! Example:
 //!     download:app-store:sys my-friend.os app:publisher.os f5d374ab50e66888a7c2332b22d0f909f2e3115040725cfab98dcae488916990
 //!
-use crate::kinode::process::downloads::{DownloadRequests, LocalDownloadRequest};
+use crate::kinode::process::downloads::{DownloadRequest, LocalDownloadRequest};
 use kinode_process_lib::{
     await_next_message_body, call_init, println, Address, PackageId, Request,
 };
@@ -51,7 +51,7 @@ fn init(our: Address) {
     let version_hash: String = arg3.to_string();
 
     let Ok(_) = Request::to((our.node(), ("downloads", "app-store", "sys")))
-        .body(DownloadRequests::LocalDownload(LocalDownloadRequest {
+        .body(DownloadRequest::LocalDownload(LocalDownloadRequest {
             package_id: crate::kinode::process::main::PackageId {
                 package_name: package_id.package_name.clone(),
                 publisher_node: package_id.publisher_node.clone(),

--- a/kinode/packages/app-store/downloads/src/lib.rs
+++ b/kinode/packages/app-store/downloads/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 use crate::kinode::process::downloads::{
     AutoDownloadCompleteRequest, AutoDownloadError, AutoUpdateRequest, DirEntry,
-    DownloadCompleteRequest, DownloadError, DownloadRequests, DownloadResponses, Entry, FileEntry,
+    DownloadCompleteRequest, DownloadError, DownloadRequest, DownloadResponse, Entry, FileEntry,
     HashMismatch, LocalDownloadRequest, RemoteDownloadRequest, RemoveFileRequest,
 };
 use ft_worker_lib::{spawn_receive_transfer, spawn_send_transfer};
@@ -77,7 +77,7 @@ pub const VFS_TIMEOUT: u64 = 5; // 5s
 #[derive(Debug, Serialize, Deserialize, process_macros::SerdeJsonInto)]
 #[serde(untagged)] // untagged as a meta-type for all incoming responses
 pub enum Resp {
-    Download(DownloadResponses),
+    Download(DownloadResponse),
     HttpClient(Result<client::HttpClientResponse, client::HttpClientError>),
 }
 
@@ -186,7 +186,7 @@ fn handle_message(
 ) -> anyhow::Result<()> {
     if message.is_request() {
         match message.body().try_into()? {
-            DownloadRequests::LocalDownload(download_request) => {
+            DownloadRequest::LocalDownload(download_request) => {
                 // we want to download a package.
                 if !message.is_local(our) {
                     return Err(anyhow::anyhow!("not local"));
@@ -232,7 +232,7 @@ fn handle_message(
                 )?;
 
                 Request::to((&download_from, "downloads", "app-store", "sys"))
-                    .body(DownloadRequests::RemoteDownload(RemoteDownloadRequest {
+                    .body(DownloadRequest::RemoteDownload(RemoteDownloadRequest {
                         package_id,
                         desired_version_hash,
                         worker_address: our_worker.to_string(),
@@ -241,7 +241,7 @@ fn handle_message(
                     .context(&download_request)
                     .send()?;
             }
-            DownloadRequests::RemoteDownload(download_request) => {
+            DownloadRequest::RemoteDownload(download_request) => {
                 let RemoteDownloadRequest {
                     package_id,
                     desired_version_hash,
@@ -252,13 +252,13 @@ fn handle_message(
 
                 // check if we are mirroring, if not send back an error.
                 if !state.mirroring.contains(&process_lib_package_id) {
-                    let resp = DownloadResponses::Err(DownloadError::NotMirroring);
+                    let resp = DownloadResponse::Err(DownloadError::NotMirroring);
                     Response::new().body(&resp).send()?;
                     return Ok(()); // return here, todo unify remote and local responses?
                 }
 
                 if !download_zip_exists(&process_lib_package_id, &desired_version_hash) {
-                    let resp = DownloadResponses::Err(DownloadError::FileNotFound);
+                    let resp = DownloadResponse::Err(DownloadError::FileNotFound);
                     Response::new().body(&resp).send()?;
                     return Ok(()); // return here, todo unify remote and local responses?
                 }
@@ -266,17 +266,17 @@ fn handle_message(
                 let target_worker = Address::from_str(&worker_address)?;
                 let _ =
                     spawn_send_transfer(our, &package_id, &desired_version_hash, &target_worker)?;
-                let resp = DownloadResponses::Success;
+                let resp = DownloadResponse::Success;
                 Response::new().body(&resp).send()?;
             }
-            DownloadRequests::Progress(ref progress) => {
+            DownloadRequest::Progress(ref progress) => {
                 // forward progress to main:app-store:sys,
                 // pushed to UI via websockets
                 let _ = Request::to(("our", "main", "app-store", "sys"))
                     .body(progress)
                     .send();
             }
-            DownloadRequests::DownloadComplete(req) => {
+            DownloadRequest::DownloadComplete(req) => {
                 if !message.is_local(our) {
                     return Err(anyhow::anyhow!("got non local download complete"));
                 }
@@ -306,7 +306,7 @@ fn handle_message(
                     }
                 }
             }
-            DownloadRequests::GetFiles(maybe_id) => {
+            DownloadRequest::GetFiles(maybe_id) => {
                 // if not local, throw to the boonies.
                 // note, can also implement a discovery protocol here in the future
                 if !message.is_local(our) {
@@ -326,11 +326,11 @@ fn handle_message(
                     }
                 };
 
-                let resp = DownloadResponses::GetFiles(files);
+                let resp = DownloadResponse::GetFiles(files);
 
                 Response::new().body(&resp).send()?;
             }
-            DownloadRequests::RemoveFile(remove_req) => {
+            DownloadRequest::RemoveFile(remove_req) => {
                 if !message.is_local(our) {
                     return Err(anyhow::anyhow!("not local"));
                 }
@@ -348,10 +348,10 @@ fn handle_message(
                 let manifest_path = format!("{}/{}.json", package_dir, version_hash);
                 let _ = vfs::remove_file(&manifest_path, None);
                 Response::new()
-                    .body(Resp::Download(DownloadResponses::Success))
+                    .body(Resp::Download(DownloadResponse::Success))
                     .send()?;
             }
-            DownloadRequests::AddDownload(add_req) => {
+            DownloadRequest::AddDownload(add_req) => {
                 if !message.is_local(our) {
                     return Err(anyhow::anyhow!("not local"));
                 }
@@ -383,26 +383,26 @@ fn handle_message(
                 }
 
                 Response::new()
-                    .body(Resp::Download(DownloadResponses::Success))
+                    .body(Resp::Download(DownloadResponse::Success))
                     .send()?;
             }
-            DownloadRequests::StartMirroring(package_id) => {
+            DownloadRequest::StartMirroring(package_id) => {
                 let package_id = package_id.to_process_lib();
                 state.mirroring.insert(package_id);
                 set_state(&serde_json::to_vec(&state)?);
                 Response::new()
-                    .body(Resp::Download(DownloadResponses::Success))
+                    .body(Resp::Download(DownloadResponse::Success))
                     .send()?;
             }
-            DownloadRequests::StopMirroring(package_id) => {
+            DownloadRequest::StopMirroring(package_id) => {
                 let package_id = package_id.to_process_lib();
                 state.mirroring.remove(&package_id);
                 set_state(&serde_json::to_vec(&state)?);
                 Response::new()
-                    .body(Resp::Download(DownloadResponses::Success))
+                    .body(Resp::Download(DownloadResponse::Success))
                     .send()?;
             }
-            DownloadRequests::AutoUpdate(auto_update_request) => {
+            DownloadRequest::AutoUpdate(auto_update_request) => {
                 if !message.is_local(&our)
                     && message.source().process != ProcessId::new(Some("chain"), "app-store", "sys")
                 {
@@ -470,7 +470,7 @@ fn handle_message(
 
                 // kick off local download to ourselves
                 Request::to(("our", "downloads", "app-store", "sys"))
-                    .body(DownloadRequests::LocalDownload(download_request))
+                    .body(DownloadRequest::LocalDownload(download_request))
                     .send()?;
             }
             _ => {}
@@ -485,7 +485,7 @@ fn handle_message(
                 if let Some(context) = message.context() {
                     let download_request = serde_json::from_slice::<LocalDownloadRequest>(context)?;
                     match download_response {
-                        DownloadResponses::Err(e) => {
+                        DownloadResponse::Err(e) => {
                             print_to_terminal(1, &format!("downloads: got error response: {e:?}"));
                             let key = (
                                 download_request.package_id.clone().to_process_lib(),
@@ -505,7 +505,7 @@ fn handle_message(
                                     .send()?;
                             }
                         }
-                        DownloadResponses::Success => {
+                        DownloadResponse::Success => {
                             // todo: maybe we do something here.
                             print_to_terminal(
                                 1,
@@ -626,7 +626,7 @@ fn try_next_mirror(
             auto_updates.insert(key, metadata);
             Request::to(("our", "downloads", "app-store", "sys"))
                 .body(
-                    serde_json::to_vec(&DownloadRequests::LocalDownload(LocalDownloadRequest {
+                    serde_json::to_vec(&DownloadRequest::LocalDownload(LocalDownloadRequest {
                         package_id: crate::kinode::process::main::PackageId::from_process_lib(
                             package_id,
                         ),

--- a/kinode/packages/app-store/ft-worker/src/ft_worker_lib.rs
+++ b/kinode/packages/app-store/ft-worker/src/ft_worker_lib.rs
@@ -3,7 +3,7 @@
 //! for file transfers in the App Store system
 //!
 use crate::kinode::process::downloads::{
-    DownloadRequests, LocalDownloadRequest, PackageId, RemoteDownloadRequest,
+    DownloadRequest, LocalDownloadRequest, PackageId, RemoteDownloadRequest,
 };
 
 use kinode_process_lib::*;
@@ -33,7 +33,7 @@ pub fn spawn_send_transfer(
     };
 
     let req = Request::new().target((&our.node, worker_process_id)).body(
-        serde_json::to_vec(&DownloadRequests::RemoteDownload(RemoteDownloadRequest {
+        serde_json::to_vec(&DownloadRequest::RemoteDownload(RemoteDownloadRequest {
             package_id: package_id.clone(),
             desired_version_hash: version_hash.to_string(),
             worker_address: to_addr.to_string(),
@@ -71,7 +71,7 @@ pub fn spawn_receive_transfer(
     let req = Request::new()
         .target((&our.node, worker_process_id.clone()))
         .body(
-            serde_json::to_vec(&DownloadRequests::LocalDownload(LocalDownloadRequest {
+            serde_json::to_vec(&DownloadRequest::LocalDownload(LocalDownloadRequest {
                 package_id: package_id.clone(),
                 desired_version_hash: version_hash.to_string(),
                 download_from: from_node.to_string(),

--- a/kinode/packages/app-store/ft-worker/src/lib.rs
+++ b/kinode/packages/app-store/ft-worker/src/lib.rs
@@ -102,21 +102,19 @@ fn init(our: Address) {
                 Ok(_) => print_to_terminal(
                     1,
                     &format!(
-                        "ft_worker: receive downloaded package in {}ms",
+                        "ft_worker: received downloaded package in {}ms",
                         start.elapsed().as_millis()
                     ),
                 ),
                 Err(e) => {
                     print_to_terminal(1, &format!("ft_worker: receive error: {}", e));
-                    // bubble up to parent.
-                    // TODO: doublecheck this.
-                    // if this fires on a basic timeout, that's bad.
+                    // fallback bubble up to parent.
                     Request::new()
                         .body(DownloadRequests::DownloadComplete(
                             DownloadCompleteRequest {
                                 package_id: package_id.clone().into(),
                                 version_hash: desired_version_hash.to_string(),
-                                err: Some(DownloadError::HandlingError(e.to_string())),
+                                err: Some(DownloadError::WorkerSpawnFailed),
                             },
                         ))
                         .target(parent_process)

--- a/kinode/packages/app-store/ft-worker/src/lib.rs
+++ b/kinode/packages/app-store/ft-worker/src/lib.rs
@@ -34,13 +34,13 @@
 //! ## Integration with App Store:
 //!
 //! This worker process is spawned by the main downloads process of the App Store system.
-//! It uses the `DownloadRequests` and related types from the app store's API to communicate
+//! It uses the `DownloadRequest` and related types from the app store's API to communicate
 //! with other components of the system.
 //!
 //! Note: This implementation uses a fixed chunk size of 256KB for file transfers.
 //!
 use crate::kinode::process::downloads::{
-    ChunkRequest, DownloadCompleteRequest, DownloadError, DownloadRequests, HashMismatch,
+    ChunkRequest, DownloadCompleteRequest, DownloadError, DownloadRequest, HashMismatch,
     LocalDownloadRequest, ProgressUpdate, RemoteDownloadRequest, SizeUpdate,
 };
 use kinode_process_lib::*;
@@ -88,7 +88,7 @@ fn init(our: Address) {
         .try_into()
         .expect("ft_worker: got unparseable init message")
     {
-        DownloadRequests::LocalDownload(local_request) => {
+        DownloadRequest::LocalDownload(local_request) => {
             let LocalDownloadRequest {
                 package_id,
                 desired_version_hash,
@@ -110,20 +110,18 @@ fn init(our: Address) {
                     print_to_terminal(1, &format!("ft_worker: receive error: {}", e));
                     // fallback bubble up to parent.
                     Request::new()
-                        .body(DownloadRequests::DownloadComplete(
-                            DownloadCompleteRequest {
-                                package_id: package_id.clone().into(),
-                                version_hash: desired_version_hash.to_string(),
-                                err: Some(DownloadError::WorkerSpawnFailed),
-                            },
-                        ))
+                        .body(DownloadRequest::DownloadComplete(DownloadCompleteRequest {
+                            package_id: package_id.clone().into(),
+                            version_hash: desired_version_hash.to_string(),
+                            err: Some(DownloadError::WorkerSpawnFailed),
+                        }))
                         .target(parent_process)
                         .send()
                         .unwrap();
                 }
             }
         }
-        DownloadRequests::RemoteDownload(remote_request) => {
+        DownloadRequest::RemoteDownload(remote_request) => {
             let RemoteDownloadRequest {
                 package_id,
                 desired_version_hash,
@@ -163,7 +161,7 @@ fn handle_sender(worker: &str, package_id: &PackageId, version_hash: &str) -> an
     let num_chunks = (size as f64 / CHUNK_SIZE as f64).ceil() as u64;
 
     Request::new()
-        .body(DownloadRequests::Size(SizeUpdate {
+        .body(DownloadRequest::Size(SizeUpdate {
             package_id: package_id.clone().into(),
             size,
         }))
@@ -204,13 +202,11 @@ fn handle_receiver(
         if *message.source() == timer_address {
             // send error message to downloads process
             Request::new()
-                .body(DownloadRequests::DownloadComplete(
-                    DownloadCompleteRequest {
-                        package_id: package_id.clone().into(),
-                        version_hash: version_hash.to_string(),
-                        err: Some(DownloadError::Timeout),
-                    },
-                ))
+                .body(DownloadRequest::DownloadComplete(DownloadCompleteRequest {
+                    package_id: package_id.clone().into(),
+                    version_hash: version_hash.to_string(),
+                    err: Some(DownloadError::Timeout),
+                }))
                 .target(parent_process.clone())
                 .send()?;
             return Ok(());
@@ -220,7 +216,7 @@ fn handle_receiver(
         }
 
         match message.body().try_into()? {
-            DownloadRequests::Chunk(chunk) => {
+            DownloadRequest::Chunk(chunk) => {
                 let bytes = if let Some(blob) = get_blob() {
                     blob.bytes
                 } else {
@@ -266,7 +262,7 @@ fn handle_receiver(
                                 })),
                             };
                             Request::new()
-                                .body(DownloadRequests::DownloadComplete(req))
+                                .body(DownloadRequest::DownloadComplete(req))
                                 .target(parent_process.clone())
                                 .send()?;
                         }
@@ -278,20 +274,18 @@ fn handle_receiver(
                         extract_and_write_manifest(&contents, &manifest_filename)?;
 
                         Request::new()
-                            .body(DownloadRequests::DownloadComplete(
-                                DownloadCompleteRequest {
-                                    package_id: package_id.clone().into(),
-                                    version_hash: version_hash.to_string(),
-                                    err: None,
-                                },
-                            ))
+                            .body(DownloadRequest::DownloadComplete(DownloadCompleteRequest {
+                                package_id: package_id.clone().into(),
+                                version_hash: version_hash.to_string(),
+                                err: None,
+                            }))
                             .target(parent_process.clone())
                             .send()?;
                         return Ok(());
                     }
                 }
             }
-            DownloadRequests::Size(update) => {
+            DownloadRequest::Size(update) => {
                 size = Some(update.size);
             }
             _ => println!("ft_worker: got unexpected message"),
@@ -316,7 +310,7 @@ fn send_chunk(
     file.read_at(&mut buffer)?;
 
     Request::new()
-        .body(DownloadRequests::Chunk(ChunkRequest {
+        .body(DownloadRequest::Chunk(ChunkRequest {
             package_id: package_id.clone().into(),
             version_hash: version_hash.to_string(),
             offset,
@@ -343,7 +337,7 @@ fn handle_chunk(
         // let progress = ((chunk.offset + chunk.length) as f64 / *total_size as f64 * 100.0) as u64;
 
         Request::new()
-            .body(DownloadRequests::Progress(ProgressUpdate {
+            .body(DownloadRequest::Progress(ProgressUpdate {
                 package_id: chunk.package_id.clone(),
                 downloaded: chunk.offset + chunk.length,
                 total: *total_size,

--- a/kinode/packages/app-store/pkg/manifest.json
+++ b/kinode/packages/app-store/pkg/manifest.json
@@ -73,7 +73,6 @@
                 "process": "homepage:homepage:sys",
                 "params": "RemoveOther"
             },
-            "net:distro:sys",
             "downloads:app-store:sys",
             "chain:app-store:sys",
             "vfs:distro:sys",
@@ -98,7 +97,6 @@
         ],
         "grant_capabilities": [
             "eth:distro:sys",
-            "net:distro:sys",
             "http-client:distro:sys",
             "http-server:distro:sys",
             "kns-indexer:kns-indexer:sys",

--- a/kinode/packages/app-store/ui/src/components/MirrorSelector.tsx
+++ b/kinode/packages/app-store/ui/src/components/MirrorSelector.tsx
@@ -47,7 +47,7 @@ const MirrorSelector: React.FC<MirrorSelectorProps> = ({ packageId, onMirrorSele
 
     const checkMirrorStatus = useCallback(async (mirror: string) => {
         try {
-            const status = await checkMirror(mirror);
+            const status = await checkMirror(packageId, mirror);
             setMirrorStatuses(prev => ({ ...prev, [mirror]: status?.is_online ?? false }));
             return status?.is_online ?? false;
         } catch {

--- a/kinode/packages/app-store/ui/src/pages/MyAppsPage.tsx
+++ b/kinode/packages/app-store/ui/src/pages/MyAppsPage.tsx
@@ -88,8 +88,6 @@ export default function MyAppsPage() {
             return error;
         } else if ('HashMismatch' in error) {
             return `Hash mismatch (expected ${error.HashMismatch.desired.slice(0, 8)}, got ${error.HashMismatch.actual.slice(0, 8)})`;
-        } else if ('HandlingError' in error) {
-            return error.HandlingError;
         } else if ('Timeout' in error) {
             return 'Connection timed out';
         }

--- a/kinode/packages/app-store/ui/src/store/index.ts
+++ b/kinode/packages/app-store/ui/src/store/index.ts
@@ -208,9 +208,9 @@ const useAppsStore = create<AppsStore>()((set, get) => ({
     return null;
   },
 
-  checkMirror: async (node: string) => {
+  checkMirror: async (id: string, node: string) => {
     try {
-      const res = await fetch(`${BASE_URL}/mirrorcheck/${node}`);
+      const res = await fetch(`${BASE_URL}/mirrorcheck/${id}/${node}`);
       if (res.status === HTTP_STATUS.OK) {
         return await res.json() as MirrorCheckFile;
       }
@@ -416,7 +416,7 @@ const useAppsStore = create<AppsStore>()((set, get) => ({
       const response = await fetch(`${BASE_URL}/reset`, {
         method: 'POST',
       });
-      
+
       if (!response.ok) {
         throw new Error('Reset failed');
       }

--- a/kinode/packages/app-store/ui/src/types/Apps.ts
+++ b/kinode/packages/app-store/ui/src/types/Apps.ts
@@ -108,7 +108,6 @@ export type DownloadError =
     | "HttpClientError"
     | "BlobNotFound"
     | "VfsError"
-    | { HandlingError: string }
     | "Timeout"
     | "InvalidManifest"
     | "Offline";

--- a/kinode/packages/kns-indexer/kns-indexer/src/lib.rs
+++ b/kinode/packages/kns-indexer/kns-indexer/src/lib.rs
@@ -170,7 +170,7 @@ fn init(our: Address) {
 
 fn main(our: &Address, state: &mut State) -> anyhow::Result<()> {
     #[cfg(feature = "simulation-mode")]
-    add_temp_hardcoded_tlzs(&mut state);
+    add_temp_hardcoded_tlzs(state);
 
     // loop through checkpointed values and send to net
     if let Err(e) = state.send_nodes() {


### PR DESCRIPTION
## Problem

We use `net:distro:sys` hi to test for node connectivity. This is bad practice because it requires `net` caps, which are very sensitive.

## Solution

Use a `Ping` variant.

## Testing

I wasn't able to test this out in the time I had today. Testing would look like:
1. Publish app on `foo.os`
2. Try to download the app on `bar.os` with event loop on for `main:app-store:sys`
3. Note the outgoing/incoming `Ping`s

## Docs Update

None

## Notes

None