### PR TITLE
kernel: fix v1 get_state: if no state, properly return None

### DIFF
--- a/kinode/src/kernel/standard_host_v1.rs
+++ b/kinode/src/kernel/standard_host_v1.rs
@@ -569,9 +569,13 @@ impl StandardHost for process::ProcessWasiV1 {
         {
             Ok(Ok(_resp)) => {
                 // basically assuming filesystem responding properly here
-                match &self.process.last_blob {
-                    None => Ok(None),
-                    Some(blob) => Ok(Some(blob.bytes.clone())),
+                if self.process.last_message_blobbed {
+                    match &self.process.last_blob {
+                        None => Ok(None),
+                        Some(blob) => Ok(Some(blob.bytes.clone())),
+                    }
+                } else {
+                    Ok(None)
                 }
             }
             _ => Ok(None),


### PR DESCRIPTION
## Problem

We changed blob behavior, but that breaks the `get_state()` host function when there is no state. This is because if the process has a blob from a previous message but no state, `get_state()` will return the most-recent-non-`None` blob, not `None` as expected.

## Solution

Properly handle the case: return `None` if there is no state, even if have previously received a blob.

## Testing

Run [test_get_state](https://gist.github.com/nick1udwig/7e5050fb012c9736fcf1a27b73e20745) against v0.10.0 and here.

Against v0.10.0:
```
Mon 06:30 chat:template.os: state: None
Mon 06:30 chat:template.os: state: Some(<elided>)
```

Here:
```
Mon 06:38 chat:template.os: state: None
Mon 06:38 chat:template.os: state: None
```

Specifically instructions to run tests look like:
```bash
# Test v0.10.0
kit f

## In another terminal
kit n test_get_state

## Replace test_get_state/test_get_state/src/lib.rs with https://gist.github.com/nick1udwig/7e5050fb012c9736fcf1a27b73e20745 and then:
kit bs test_get_state

# Test v0.10.1
## Get this branch in your local Kinode repo
## Say Kinode repo lives at KINODE_REPO
kit f -r ${KINODE_REPO}

## In another terminal
kit n test_get_state

## Replace test_get_state/test_get_state/src/lib.rs with https://gist.github.com/nick1udwig/7e5050fb012c9736fcf1a27b73e20745 and then:
kit bs test_get_state
```

## Docs Update

None

## Notes

[h/t](https://github.com/kinode-dao/kinode/blob/5c377d1a170beee5174e589b259b616ff7b5dcd4/kinode/src/kernel/standard_host_v1.rs#L114) @jaxs-ribs 