### PR TITLE
app_store: fix launch button

### DIFF
--- a/kinode/packages/app-store/app-store/src/http_api.rs
+++ b/kinode/packages/app-store/app-store/src/http_api.rs
@@ -31,6 +31,7 @@ pub fn init_frontend(our: &Address, http_server: &mut server::HttpServer) {
         "/installed",     // all installed apps
         "/ourapps",       // all apps we've published
         "/updates",       // all auto_updates
+        "/homepageapps",  // all apps on homepage
         "/apps/:id",      // detail about an on-chain app
         "/downloads/:id", // local downloads for an app
         "/installed/:id", // detail about an installed app
@@ -481,6 +482,14 @@ fn serve_paths(
                 }
                 _ => Err(anyhow::anyhow!("Invalid response from chain: {:?}", msg)),
             }
+        }
+        "/homepageapps" => {
+            let resp = Request::to(("our", "homepage", "homepage", "sys"))
+                .body(serde_json::to_vec(&"GetApps")?)
+                .send_and_await_response(5)??;
+
+            // todo: import homepage with and parse into proper response type?
+            Ok((StatusCode::OK, None, resp.body().to_vec()))
         }
         // POST /apps/:id/download
         // download a listed app from a mirror

--- a/kinode/packages/app-store/pkg/manifest.json
+++ b/kinode/packages/app-store/pkg/manifest.json
@@ -92,6 +92,7 @@
             "http-server:distro:sys",
             "kns-indexer:kns-indexer:sys",
             "terminal:terminal:sys",
+            "homepage:homepage:sys",
             "vfs:distro:sys"
         ],
         "public": false

--- a/kinode/packages/app-store/ui/src/pages/AppPage.tsx
+++ b/kinode/packages/app-store/ui/src/pages/AppPage.tsx
@@ -174,13 +174,11 @@ export default function AppPage() {
       <div className="app-actions">
         {installedApp && (
           <>
-            <button
-              onClick={handleLaunch}
-              className="primary"
-              disabled={!canLaunch}
-            >
-              <FaPlay /> {canLaunch ? 'Launch' : 'No UI found for app'}
-            </button>
+            {canLaunch && (
+              <button onClick={handleLaunch} className="primary">
+                <FaPlay /> Launch
+              </button>
+            )}
             <button onClick={handleUninstall} className="secondary" disabled={isUninstalling}>
               {isUninstalling ? <FaSpinner className="fa-spin" /> : <FaTrash />} Uninstall
             </button>

--- a/kinode/packages/app-store/ui/src/store/index.ts
+++ b/kinode/packages/app-store/ui/src/store/index.ts
@@ -190,22 +190,21 @@ const useAppsStore = create<AppsStore>()((set, get) => ({
 
   fetchHomepageApps: async () => {
     try {
-      const res = await fetch('/apps');
+      const res = await fetch(`${BASE_URL}/homepageapps`);
       if (res.status === HTTP_STATUS.OK) {
-        const data: HomepageApp[] = await res.json();
-        set({ homepageApps: data });
+        const data = await res.json();
+        const apps = data.GetApps || [];
+        set({ homepageApps: apps });
       }
     } catch (error) {
       console.error("Error fetching homepage apps:", error);
+      set({ homepageApps: [] });
     }
   },
 
   getLaunchUrl: (id: string) => {
-    const app = get().homepageApps.find(app => `${app.package}:${app.publisher}` === id);
-    if (app && app.path) {
-      return app.path;
-    }
-    return null;
+    const app = get().homepageApps?.find(app => `${app.package_name}:${app.publisher}` === id);
+    return app?.path || null;
   },
 
   checkMirror: async (id: string, node: string) => {

--- a/kinode/packages/app-store/ui/src/types/Apps.ts
+++ b/kinode/packages/app-store/ui/src/types/Apps.ts
@@ -84,7 +84,7 @@ export interface ManifestResponse {
 export interface HomepageApp {
     id: string;
     process: string;
-    package: string;
+    package_name: string;
     publisher: string;
     path?: string;
     label: string;

--- a/kinode/packages/homepage/api/homepage:sys-v1.wit
+++ b/kinode/packages/homepage/api/homepage:sys-v1.wit
@@ -29,6 +29,15 @@ interface homepage {
         ///
         /// lazy-load-blob: none.
         set-stylesheet(string),
+        /// Get the list of apps on the homepage
+        ///
+        /// lazy-load-blob: none.
+        get-apps,
+    }
+
+    /// The response format to get  from the homepage.
+    variant response {
+        get-apps(list<app>),
     }
 
     record add-request {
@@ -36,6 +45,19 @@ interface homepage {
         icon: option<string>,
         path: option<string>,
         widget: option<string>,
+    }
+
+    record app {
+        id: string,
+        process: string,
+        package-name: string,
+        publisher: string,
+        path: option<string>,
+        label: string,
+        base64-icon: option<string>,
+        widget: option<string>,
+        order: u32,
+        favorite: bool,
     }
 }
 

--- a/kinode/packages/homepage/api/homepage:sys-v1.wit
+++ b/kinode/packages/homepage/api/homepage:sys-v1.wit
@@ -29,13 +29,13 @@ interface homepage {
         ///
         /// lazy-load-blob: none.
         set-stylesheet(string),
-        /// Get the list of apps on the homepage
+        /// get the list of apps currently on the homepage
         ///
         /// lazy-load-blob: none.
         get-apps,
     }
 
-    /// The response format to get  from the homepage.
+    /// The response format to get from the homepage. Serialized using serde_json.
     variant response {
         get-apps(list<app>),
     }


### PR DESCRIPTION
## Problem

"app has no UI" displayed even when app had registered itself with homepage. 

/apps served by root homepage not accessable from subdomain.

## Solution

Add getApps to homepage wit types, add /homepageapps to app_store http, which then awaits data from homepage.

## Notes

Instead displaying "No UI for app" now just doesn't render any button at all. 

Also, download page to be refactored into a simpler modal