### PR TITLE
app-store publish: use upgradable tba

### DIFF
--- a/kinode/packages/app-store/ui/src/abis/helpers.ts
+++ b/kinode/packages/app-store/ui/src/abis/helpers.ts
@@ -52,7 +52,7 @@ export function encodeIntoMintCall(multicalls: `0x${string}`, our_address: `0x${
             our_address,
             encodePacked(["bytes"], [stringToHex(app_name)]),
             initCall,
-            KINO_ACCOUNT_IMPL,
+            KINO_ACCOUNT_UPGRADABLE_IMPL,
         ]
     })
     return mintCall;

--- a/kinode/packages/app-store/ui/src/abis/index.ts
+++ b/kinode/packages/app-store/ui/src/abis/index.ts
@@ -4,7 +4,8 @@ export { encodeMulticalls, encodeIntoMintCall } from "./helpers";
 
 export const KIMAP: `0x${string}` = "0x000000000033e5CCbC52Ec7BDa87dB768f9aA93F";
 export const MULTICALL: `0x${string}` = "0xcA11bde05977b3631167028862bE2a173976CA11";
-export const KINO_ACCOUNT_IMPL: `0x${string}` = "0x83119a31628f2c19f578b0cac9a43eaba8d8512b";
+export const KINO_ACCOUNT_IMPL: `0x${string}` = "0x000000000012d439e33aAD99149d52A5c6f980Dc";
+export const KINO_ACCOUNT_UPGRADABLE_IMPL: `0x${string}` = "0x83119a31628f2c19f578b0cac9a43eaba8d8512b";
 
 
 export const multicallAbi = parseAbi([

--- a/kinode/packages/app-store/ui/src/abis/index.ts
+++ b/kinode/packages/app-store/ui/src/abis/index.ts
@@ -4,7 +4,7 @@ export { encodeMulticalls, encodeIntoMintCall } from "./helpers";
 
 export const KIMAP: `0x${string}` = "0x000000000033e5CCbC52Ec7BDa87dB768f9aA93F";
 export const MULTICALL: `0x${string}` = "0xcA11bde05977b3631167028862bE2a173976CA11";
-export const KINO_ACCOUNT_IMPL: `0x${string}` = "0x000000000012d439e33aAD99149d52A5c6f980Dc";
+export const KINO_ACCOUNT_IMPL: `0x${string}` = "0x83119a31628f2c19f578b0cac9a43eaba8d8512b";
 
 
 export const multicallAbi = parseAbi([


### PR DESCRIPTION
## Problem

We want to allow, e.g., reviews for App Store.

## Solution

1. [Deploy an upgradable TBA](https://basescan.org/address/0x83119a31628f2c19f578b0cac9a43eaba8d8512b)
2. Use upgradable TBA when publishing apps (this PR)

## Testing

TODO

## Docs Update

None

## Notes

None