### PR TITLE
fix fake chain and short node name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive_lib"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "lib",
 ]
@@ -3751,7 +3751,7 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "lib"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyperdrive_lib"
 authors = ["Sybil Technologies AG"]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "A general-purpose sovereign cloud computing platform"
 homepage = "https://hyperware.ai"

--- a/hyperdrive/Cargo.toml
+++ b/hyperdrive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyperdrive"
 authors = ["Sybil Technologies AG"]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "A general-purpose sovereign cloud computing platform"
 homepage = "https://hyperware.ai"

--- a/hyperdrive/src/fakenet.rs
+++ b/hyperdrive/src/fakenet.rs
@@ -45,7 +45,10 @@ pub async fn mint_local(
         Some(&"dev") => dotdev,
         _ => dotdev,
     };
-    println!("mint_local name, tlz, addy: {name}, {:?}, {minter}", parts.get(1));
+    println!(
+        "mint_local name, tlz, addy: {name}, {:?}, {minter}",
+        parts.get(1)
+    );
 
     let endpoint = format!("ws://localhost:{}", fakechain_port);
     let ws = WsConnect::new(endpoint);
@@ -110,7 +113,10 @@ pub async fn mint_local(
     ];
 
     let is_reset = tba != Address::default();
-    println!("is_reset, tba, owner, bytes: {}, {:?}, {:?}, {:?}", is_reset, tba, _owner, bytes);
+    println!(
+        "is_reset, tba, owner, bytes: {}, {:?}, {:?}, {:?}",
+        is_reset, tba, _owner, bytes
+    );
 
     let multicall = aggregateCall { calls: multicalls }.abi_encode();
 

--- a/hyperdrive/src/fakenet.rs
+++ b/hyperdrive/src/fakenet.rs
@@ -13,8 +13,8 @@ use std::str::FromStr;
 use crate::{keygen, sol::*, HYPERMAP_ADDRESS, HYPER_ACCOUNT_IMPL, MULTICALL_ADDRESS};
 
 const FAKE_DOTDEV_TBA: &str = "0xcc3A576b8cE5340f5CE23d0DDAf133C0822C3B6d";
-const FAKE_DOTOS_TBA: &str = "0xbE46837617f8304Aa5E6d0aE62B74340251f48Bf";
-const _FAKE_ZEROTH_TBA: &str = "0x4bb0778bb92564bf8e82d0b3271b7512443fb060";
+const FAKE_DOTOS_TBA: &str = "0x9b3853358ede717fc7D4806cF75d7A4d4517A9C9";
+const _FAKE_ZEROTH_TBA: &str = "0x809A598d9883f2Fb6B77382eBfC9473Fd6A857c9";
 
 /// Attempts to connect to a local anvil fakechain,
 /// registering a name with its KiMap contract.
@@ -45,6 +45,7 @@ pub async fn mint_local(
         Some(&"dev") => dotdev,
         _ => dotdev,
     };
+    println!("mint_local name, tlz, addy: {name}, {:?}, {minter}", parts.get(1));
 
     let endpoint = format!("ws://localhost:{}", fakechain_port);
     let ws = WsConnect::new(endpoint);
@@ -64,7 +65,6 @@ pub async fn mint_local(
         .input(TransactionInput::new(get_call.into()));
 
     let exists = provider.call(&get_tx).await?;
-    println!("exists: {:?}", exists);
 
     let decoded = getCall::abi_decode_returns(&exists, false)?;
 
@@ -72,8 +72,6 @@ pub async fn mint_local(
     let _owner = decoded.owner;
     let bytes = decoded.data;
     // now set ip, port and pubkey
-
-    println!("tba, owner and bytes: {:?}, {:?}, {:?}", tba, _owner, bytes);
 
     let localhost = Ipv4Addr::new(127, 0, 0, 1);
     let ip = keygen::ip_to_bytes(localhost.into());
@@ -112,6 +110,7 @@ pub async fn mint_local(
     ];
 
     let is_reset = tba != Address::default();
+    println!("is_reset, tba, owner, bytes: {}, {:?}, {:?}, {:?}", is_reset, tba, _owner, bytes);
 
     let multicall = aggregateCall { calls: multicalls }.abi_encode();
 
@@ -160,6 +159,8 @@ pub async fn mint_local(
     // Send the raw transaction and retrieve the transaction receipt.
     let tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
     let _receipt = tx_hash.get_receipt().await?;
+
+    println!("mint receipt: {:?}", _receipt);
 
     // send a small amount of ETH to the zero address
     // this is a workaround to get anvil to mine a block after our registration tx

--- a/hyperdrive/src/fakenet.rs
+++ b/hyperdrive/src/fakenet.rs
@@ -12,7 +12,6 @@ use std::str::FromStr;
 
 use crate::{keygen, sol::*, HYPERMAP_ADDRESS, HYPER_ACCOUNT_IMPL, MULTICALL_ADDRESS};
 
-const FAKE_DOTDEV_TBA: &str = "0xcc3A576b8cE5340f5CE23d0DDAf133C0822C3B6d";
 const FAKE_DOTOS_TBA: &str = "0x9b3853358ede717fc7D4806cF75d7A4d4517A9C9";
 const _FAKE_ZEROTH_TBA: &str = "0x809A598d9883f2Fb6B77382eBfC9473Fd6A857c9";
 
@@ -35,18 +34,16 @@ pub async fn mint_local(
 
     let multicall_address = Address::from_str(MULTICALL_ADDRESS)?;
     let dotos = Address::from_str(FAKE_DOTOS_TBA)?;
-    let dotdev = Address::from_str(FAKE_DOTDEV_TBA)?;
     let hypermap = Address::from_str(HYPERMAP_ADDRESS)?;
 
     let parts: Vec<&str> = name.split('.').collect();
     let label = parts[0];
     let minter = match parts.get(1) {
         Some(&"os") => dotos,
-        Some(&"dev") => dotdev,
-        _ => dotdev,
+        _ => dotos,
     };
     println!(
-        "mint_local name, tlz, addy: {name}, {:?}, {minter}",
+        "mint_local name, tlz, tlz address: {name}, {:?}, {minter}",
         parts.get(1)
     );
 
@@ -113,10 +110,6 @@ pub async fn mint_local(
     ];
 
     let is_reset = tba != Address::default();
-    println!(
-        "is_reset, tba, owner, bytes: {}, {:?}, {:?}, {:?}",
-        is_reset, tba, _owner, bytes
-    );
 
     let multicall = aggregateCall { calls: multicalls }.abi_encode();
 
@@ -165,8 +158,6 @@ pub async fn mint_local(
     // Send the raw transaction and retrieve the transaction receipt.
     let tx_hash = provider.send_raw_transaction(&tx_encoded).await?;
     let _receipt = tx_hash.get_receipt().await?;
-
-    println!("mint receipt: {:?}", _receipt);
 
     // send a small amount of ETH to the zero address
     // this is a workaround to get anvil to mine a block after our registration tx

--- a/hyperdrive/src/http/login.html
+++ b/hyperdrive/src/http/login.html
@@ -158,9 +158,16 @@
       document.getElementById("loading").style.display = "flex";
 
       try {
+        // salt is either node name (if node name is longer than 8 characters)
+        //  or node name repeated enough times to be longer than 8 characters
+        const hnsName = `${node}`;
+        const minSaltL = 8;
+        const nameL = hnsName.length;
+        const salt = nameL >= minSaltL ? hnsName : hnsName.repeat(1 + Math.floor(minSaltL / nameL));
+
         const h = await argon2.hash({
           pass: password,
-          salt: '${node}',
+          salt: salt,
           hashLen: 32,
           time: 2,
           mem: 19456,
@@ -186,6 +193,7 @@
         throw new Error("Login failed");
 
       } catch (err) {
+        console.log(`login failed with err: ${JSON.stringify(err)}`);
         document.getElementById("login-form").style.display = "flex";
         document.getElementById("loading").style.display = "none";
         document.getElementById("password").value = "";

--- a/hyperdrive/src/http/server.rs
+++ b/hyperdrive/src/http/server.rs
@@ -341,6 +341,8 @@ async fn login_handler(
         subdomain: info.subdomain,
     };
 
+    println!("login_handler: got info {info:?}\r");
+
     match keygen::decode_keyfile(&encoded_keyfile, &info.password_hash) {
         Ok(keyfile) => {
             let token = match keygen::generate_jwt(

--- a/hyperdrive/src/main.rs
+++ b/hyperdrive/src/main.rs
@@ -654,7 +654,6 @@ pub async fn simulate_node(
         }
         Some(name) => {
             let password_hash = password.unwrap_or_else(|| "secret".to_string());
-            println!("main: password_hash: {password_hash}\r");
             let (pubkey, networking_keypair) = keygen::generate_networking_key();
             let seed = SystemRandom::new();
             let mut jwt_secret = [0u8; 32];

--- a/hyperdrive/src/register-ui/src/pages/ImportKeyfile.tsx
+++ b/hyperdrive/src/register-ui/src/pages/ImportKeyfile.tsx
@@ -55,7 +55,21 @@ function ImportKeyfile({
 
       try {
         if (keyErrs.length === 0 && localKey !== null) {
-          argon2.hash({ pass: pw, salt: hnsName, hashLen: 32, time: 2, mem: 19456, type: argon2.ArgonType.Argon2id }).then(async h => {
+          // salt is either node name (if node name is longer than 8 characters)
+          //  or node name repeated enough times to be longer than 8 characters
+          const minSaltL = 8;
+          const nodeL = hnsName.length;
+          const salt = nodeL >= minSaltL ? hnsName : hnsName.repeat(1 + Math.floor(minSaltL / nodeL));
+          console.log(salt);
+
+          argon2.hash({
+            pass: pw,
+            salt: salt,
+            hashLen: 32,
+            time: 2,
+            mem: 19456,
+            type: argon2.ArgonType.Argon2id
+          }).then(async h => {
             const hashed_password_hex = `0x${h.hashHex}`;
 
             const result = await fetch("/import-keyfile", {

--- a/hyperdrive/src/register-ui/src/pages/Login.tsx
+++ b/hyperdrive/src/register-ui/src/pages/Login.tsx
@@ -45,9 +45,17 @@ function Login({
 
         try {
           // Try argon2 hash first
+
+          // salt is either node name (if node name is longer than 8 characters)
+          //  or node name repeated enough times to be longer than 8 characters
+          const minSaltL = 8;
+          const nodeL = hnsName.length;
+          const salt = nodeL >= minSaltL ? hnsName : hnsName.repeat(1 + Math.floor(minSaltL / nodeL));
+          console.log(salt);
+
           const h = await argon2.hash({
             pass: pw,
-            salt: hnsName,
+            salt: salt,
             hashLen: 32,
             time: 2,
             mem: 19456,

--- a/hyperdrive/src/register-ui/src/pages/SetPassword.tsx
+++ b/hyperdrive/src/register-ui/src/pages/SetPassword.tsx
@@ -50,7 +50,22 @@ function SetPassword({
 
       setTimeout(async () => {
         setLoading(true);
-        argon2.hash({ pass: pw, salt: hnsName, hashLen: 32, time: 2, mem: 19456, type: argon2.ArgonType.Argon2id }).then(async h => {
+
+        // salt is either node name (if node name is longer than 8 characters)
+        //  or node name repeated enough times to be longer than 8 characters
+        const minSaltL = 8;
+        const nodeL = hnsName.length;
+        const salt = nodeL >= minSaltL ? hnsName : hnsName.repeat(1 + Math.floor(minSaltL / nodeL));
+        console.log(salt);
+
+        argon2.hash({
+          pass: pw,
+          salt: salt,
+          hashLen: 32,
+          time: 2,
+          mem: 19456,
+          type: argon2.ArgonType.Argon2id
+        }).then(async h => {
           const hashed_password_hex = `0x${h.hashHex}` as `0x${string}`;
           let owner = address;
           let timestamp = Date.now();

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lib"
 authors = ["Sybil Technologies AG"]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 description = "A general-purpose sovereign cloud computing platform"
 homepage = "https://hyperware.ai"


### PR DESCRIPTION
## Problem

* short node name: we use node name for salt but minimum argon2 salt length is 8
* fake chain doesn't work due to contract changes

## Solution

* add logic to create salt from concatenation of node name when node name is too short by itself
* update contracts. sister PR: https://github.com/hyperware-ai/kit/pull/299

## Testing

- [x] fake nodes functional
- [x] can login to fake node with short name

## Docs Update

TODO

## Notes

TODOs
- [x] remove debugging prints
- [x] decide whether to deploy os exactly as on live network (and if so, deploy a fake namespace like `.f`) [EDIT: decided: no]