### PR TITLE
fix connect wallet to mobile coinbase wallet

### DIFF
--- a/hyperdrive/packages/app-store/ui/src/main.tsx
+++ b/hyperdrive/packages/app-store/ui/src/main.tsx
@@ -35,7 +35,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider showRecentTransactions={true}>
+        <RainbowKitProvider initialChain={8453} modalSize="compact" showRecentTransactions={true}>
           <App />
         </RainbowKitProvider>
       </QueryClientProvider>

--- a/hyperdrive/packages/settings/ui/src/main.tsx
+++ b/hyperdrive/packages/settings/ui/src/main.tsx
@@ -33,7 +33,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider showRecentTransactions={true}>
+        <RainbowKitProvider initialChain={8453} modalSize="compact" showRecentTransactions={true}>
           <App />
         </RainbowKitProvider>
       </QueryClientProvider>

--- a/hyperdrive/src/register-ui/src/index.tsx
+++ b/hyperdrive/src/register-ui/src/index.tsx
@@ -42,7 +42,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider modalSize="compact" showRecentTransactions={true}>
+        <RainbowKitProvider initialChain={8453} modalSize="compact" showRecentTransactions={true}>
           <App />
         </RainbowKitProvider>
       </QueryClientProvider>


### PR DESCRIPTION
## Problem

Can't use Connect Wallet to connect to mobile coinbase wallet -- which prevents, e.g., use with Hyperdrive Desktop.

## Solution

Tell RainbowKit to connect to Base (instead of default: 1).

## Testing

Try it (works on mobile coinbase wallet).

## Docs Update

None

## Notes

None