### PR TITLE
app-store: fix default icons

### DIFF
--- a/hyperdrive/packages/app-store/ui/src/pages/AppPage.tsx
+++ b/hyperdrive/packages/app-store/ui/src/pages/AppPage.tsx
@@ -124,13 +124,13 @@ export default function AppPage() {
   const handleMirrorSelect = useCallback((mirror: string, status: boolean | null | 'http') => {
     setSelectedMirror(mirror);
     setIsMirrorOnline(status === 'http' ? true : status);
-    setMirrorError(null);  
+    setMirrorError(null);
   }, []);
 
   const handleMirrorError = useCallback((error: string) => {
     setMirrorError(error);
     setIsMirrorOnline(false);
-    setAttemptedDownload(false); 
+    setAttemptedDownload(false);
   }, []);
 
   const handleInstallFlow = useCallback(async (isDownloadNeeded: boolean = false) => {
@@ -322,7 +322,7 @@ export default function AppPage() {
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '1rem' }}>
           <div style={{ width: '128px', height: '128px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <img
-              src={app.metadata?.image || '/bird-orange.svg'}
+              src={app.metadata?.image || '/h-green.svg'}
               alt={app.metadata?.name || app.package_id.package_name}
               className="app-icon"
               style={{ maxWidth: '100%', maxHeight: '100%' }}
@@ -465,9 +465,9 @@ export default function AppPage() {
               <div className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium mb-1">Mirror Selection</label>
-                  <MirrorSelector 
-                    packageId={id} 
-                    onMirrorSelect={handleMirrorSelect} 
+                  <MirrorSelector
+                    packageId={id}
+                    onMirrorSelect={handleMirrorSelect}
                     onError={handleMirrorError}
                   />
                   {mirrorError && (

--- a/hyperdrive/packages/app-store/ui/src/pages/StorePage.tsx
+++ b/hyperdrive/packages/app-store/ui/src/pages/StorePage.tsx
@@ -64,7 +64,7 @@ const AppCard: React.FC<{ app: AppListing }> = ({ app }) => {
     >
       <div className="app-icon-wrapper">
         <img
-          src={app.metadata?.image || '/bird-orange.svg'}
+          src={app.metadata?.image || '/h-green.svg'}
           alt={`${app.metadata?.name || app.package_id.package_name} icon`}
           className="app-icon"
         />


### PR DESCRIPTION
## Problem

Broke default App Store app icon when switching away from Kinode branding.

![image](https://github.com/user-attachments/assets/c3868a58-8c58-4076-8dc8-447ed32d6fa7)

## Solution

Change to properly use new icons.

## Testing

![image](https://github.com/user-attachments/assets/cf904ed3-258f-42b7-a1bf-7c7f16470a9e)

## Docs Update

None

## Notes

None