### PR TITLE
secure subdomains: on non-localhost, dont require re-login to ssd

### DIFF
--- a/hyperdrive/src/http/server.rs
+++ b/hyperdrive/src/http/server.rs
@@ -353,7 +353,11 @@ async fn login_handler(
 
     println!("login_handler: got info {info:?}\r");
 
-    let is_localhost = host.as_ref().unwrap_or(&warp::host::Authority::from_static("localhost")).host().contains("localhost");
+    let is_localhost = host
+        .as_ref()
+        .unwrap_or(&warp::host::Authority::from_static("localhost"))
+        .host()
+        .contains("localhost");
 
     match keygen::decode_keyfile(&encoded_keyfile, &info.password_hash) {
         Ok(keyfile) => {
@@ -383,7 +387,10 @@ async fn login_handler(
             };
 
             let cookie = match info.subdomain.unwrap_or_default().as_str() {
-                "" => format!("hyperware-auth_{our}={token}; domain=.{};", host.as_ref().unwrap().host()),
+                "" => format!(
+                    "hyperware-auth_{our}={token}; domain=.{};",
+                    host.as_ref().unwrap().host()
+                ),
                 subdomain => {
                     // enforce that subdomain string only contains a-z, 0-9, ., :, and -
                     let subdomain = subdomain
@@ -494,7 +501,11 @@ async fn ws_handler(
         return Err(warp::reject::not_found());
     };
 
-    let is_localhost = host.as_ref().unwrap_or(&warp::host::Authority::from_static("localhost")).host().contains("localhost");
+    let is_localhost = host
+        .as_ref()
+        .unwrap_or(&warp::host::Authority::from_static("localhost"))
+        .host()
+        .contains("localhost");
 
     if bound_path.authenticated {
         let Some(auth_token) = serialized_headers.get("cookie") else {
@@ -510,7 +521,12 @@ async fn ws_handler(
             // parse out subdomain from host (there can only be one)
             let request_subdomain = host.host().split('.').next().unwrap_or("");
             if request_subdomain != subdomain
-                || !utils::auth_token_valid(&our, if is_localhost { Some(&app) } else { None }, auth_token, &jwt_secret_bytes)
+                || !utils::auth_token_valid(
+                    &our,
+                    if is_localhost { Some(&app) } else { None },
+                    auth_token,
+                    &jwt_secret_bytes,
+                )
             {
                 return Err(warp::reject::not_found());
             }


### PR DESCRIPTION
## Problem

UX of secure subdomains is confusing and bad

## Solution

On non-localhost, set a cookie on login that allows access to any subdomains. This doesn't compromise security!

(localhost is still stuck with same old flow because browsers do not allow "all subdomain" cookie setting like normal domains)

## Testing

See #755

## Docs Update

None

## Notes

None