### PR TITLE
lock rpc down

### DIFF
--- a/hyperdrive/src/http/server.rs
+++ b/hyperdrive/src/http/server.rs
@@ -546,7 +546,9 @@ async fn ws_handler(
         .map(|addr| addr.ip().is_loopback())
         .unwrap_or(false);
 
-    if bound_path.extension && !is_local {
+    let is_behind_reverse_proxy = utils::is_behind_reverse_proxy(&headers);
+
+    if bound_path.extension && (!is_local || is_behind_reverse_proxy) {
         return Err(warp::reject::reject());
     }
 
@@ -737,7 +739,9 @@ async fn http_handler(
         .map(|addr| addr.ip().is_loopback())
         .unwrap_or(false);
 
-    if bound_path.local_only && !is_local {
+    let is_behind_reverse_proxy = utils::is_behind_reverse_proxy(&headers);
+
+    if bound_path.local_only && (!is_local || is_behind_reverse_proxy) {
         return Ok(warp::reply::with_status(vec![], StatusCode::FORBIDDEN).into_response());
     }
 

--- a/hyperdrive/src/http/utils.rs
+++ b/hyperdrive/src/http/utils.rs
@@ -7,7 +7,12 @@ use std::collections::HashMap;
 use tokio::net::TcpListener;
 use warp::http::{header::HeaderName, header::HeaderValue, HeaderMap};
 
-const REVERSE_PROXY_HEADERS: &[&str; 4] = &["x-forwarded-for", "x-forwarded-proto", "x-forwarded-host", "x-real-ip"];
+const REVERSE_PROXY_HEADERS: &[&str; 4] = &[
+    "x-forwarded-for",
+    "x-forwarded-proto",
+    "x-forwarded-host",
+    "x-real-ip",
+];
 
 #[derive(Serialize, Deserialize)]
 pub struct RpcMessage {

--- a/hyperdrive/src/http/utils.rs
+++ b/hyperdrive/src/http/utils.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 use tokio::net::TcpListener;
 use warp::http::{header::HeaderName, header::HeaderValue, HeaderMap};
 
+const REVERSE_PROXY_HEADERS: &[&str; 4] = &["x-forwarded-for", "x-forwarded-proto", "x-forwarded-host", "x-real-ip"];
+
 #[derive(Serialize, Deserialize)]
 pub struct RpcMessage {
     pub node: Option<String>,
@@ -141,4 +143,13 @@ pub async fn is_port_available(bind_addr: &str) -> Option<TcpListener> {
 
 pub fn _binary_encoded_string_to_bytes(s: &str) -> Vec<u8> {
     s.chars().map(|c| c as u8).collect()
+}
+
+pub fn is_behind_reverse_proxy(headers: &warp::http::HeaderMap) -> bool {
+    for reverse_proxy_header in REVERSE_PROXY_HEADERS {
+        if headers.contains_key(*reverse_proxy_header) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/hyperdrive/src/main.rs
+++ b/hyperdrive/src/main.rs
@@ -106,6 +106,8 @@ async fn main() {
             .expect("failed to parse given --process-verbosity. Must be JSON Object with keys `ProcessId`s and values either `{\"U8\": <verbosity>}` or `\"Muted\"`")
     };
 
+    let expose_local = *matches.get_one::<bool>("expose-local").unwrap();
+
     #[cfg(feature = "simulation-mode")]
     let (fake_node_name, fakechain_port) = (
         matches.get_one::<String>("fake-node-name"),
@@ -458,6 +460,7 @@ async fn main() {
         http_server_receiver,
         kernel_message_sender.clone(),
         print_sender.clone(),
+        expose_local,
     ));
     tasks.spawn(http::client::http_client(
         our.name.clone(),
@@ -784,6 +787,10 @@ fn build_command() -> Command {
         .arg(
             arg!(--"process-verbosity" <JSON_STRING> "ProcessId: verbosity JSON object")
                 .default_value("")
+        )
+        .arg(
+            arg!(--"expose-local" <EXPOSE_LOCAL> "Expose local-only and RPC endpoints. WARNING: If behind a reverse proxy, ensure proxy is set to put `x-forwarded-for` headers or this will allow your node to be controlled remotely without authentication! (caddy adds these headers by default and so is strongly recommended)")
+                .action(clap::ArgAction::SetTrue),
         );
 
     #[cfg(feature = "simulation-mode")]


### PR DESCRIPTION
## Problem

`is_local` is not a robust way to determine that an http request is actually local. E.g., a node behind a reverse proxy will believe all http requests it receives are local.

## Solution

1. Turn off `is_local` handling by default. Enable it with the commandline flag `expose-local`
2. When `expose-local`d, check for `x-forwarded`-type headers that reverse proxies commonly put on requests. Caddy puts these headers by default; nginx does not; apache may or may not.

## Testing

1. no flag, local
2. yes flag local
3. no flag reverse proxy
4. yes flag reverse proxy

## Docs Update

TODO

## Notes

None