### PR TITLE
hypermap-cacher: fix bootstrap & add more bootstrappers

### DIFF
--- a/hyperdrive/packages/hns-indexer/hns-indexer/src/lib.rs
+++ b/hyperdrive/packages/hns-indexer/hns-indexer/src/lib.rs
@@ -31,6 +31,16 @@ const SUBSCRIPTION_TIMEOUT_S: u64 = 60;
 const DELAY_MS: u64 = 2_000;
 const CHECKPOINT_MS: u64 = 5 * 60 * 1_000; // 5 minutes
 
+#[cfg(not(feature = "simulation-mode"))]
+const DEFAULT_NODES: &[&str] = &[
+    "us-cacher-1.hypr",
+    "eu-cacher-1.hypr",
+    "nick.hypr",
+    "nick1udwig.os",
+];
+#[cfg(feature = "simulation-mode")]
+const DEFAULT_NODES: &[&str] = &["fake.os"];
+
 type PendingNotes = BTreeMap<u64, Vec<(String, String, eth::Bytes, u8)>>;
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -795,7 +805,7 @@ fn main(our: &Address, state: &mut StateV1) -> anyhow::Result<()> {
     // if block in state is < current_block, get logs from that part.
     info!("syncing old logs from block: {}", state.last_block);
 
-    let nodes: HashSet<String> = ["nick.hypr".to_string()].into_iter().collect();
+    let nodes: HashSet<String> = DEFAULT_NODES.iter().map(|s| s.to_string()).collect();
     state.fetch_and_process_logs(nodes);
 
     // set a timer tick so any pending logs will be processed

--- a/hyperdrive/packages/hypermap-cacher/hypermap-cacher/src/lib.rs
+++ b/hyperdrive/packages/hypermap-cacher/hypermap-cacher/src/lib.rs
@@ -789,22 +789,15 @@ impl State {
             self.last_cached_block + 1
         );
 
-        // Only run RPC bootstrap if we're behind the current chain head
-        let current_chain_head = hypermap.provider.get_block_number()?;
-        if self.last_cached_block < current_chain_head {
-            self.cache_logs_and_update_manifest(hypermap)?;
+        // Catch up remainder (or as fallback) using RPC
+        self.cache_logs_and_update_manifest(hypermap)?;
 
-            // run it twice for fresh boot case:
-            // - initial bootstrap takes much time
-            // - in that time, the block you are updating to is no longer the head of the chain
-            // - so run again to get to the head of the chain
-            self.cache_logs_and_update_manifest(hypermap)?;
-        } else {
-            info!(
-                "Already caught up to chain head ({}), no RPC bootstrap needed",
-                current_chain_head
-            );
-        }
+        // run it twice for fresh boot case:
+        // - initial bootstrap takes much time
+        // - in that time, the block you are updating to is no longer the head of the chain
+        // - so run again to get to the head of the chain
+        self.cache_logs_and_update_manifest(hypermap)?;
+
         Ok(())
     }
 
@@ -1189,10 +1182,13 @@ fn main_loop(
     info!("Last cached block: {}", state.last_cached_block);
 
     // Always bootstrap on start to get latest state from other nodes or RPC
-    if state.is_starting {
+    while state.is_starting {
         match state.bootstrap_state(hypermap) {
             Ok(_) => info!("Bootstrap process completed successfully."),
-            Err(e) => error!("Error during bootstrap process: {:?}", e),
+            Err(e) => {
+                error!("Error during bootstrap process: {:?}", e);
+                std::thread::sleep(std::time::Duration::from_secs(RETRY_DELAY_S));
+            }
         }
     }
 

--- a/hyperdrive/packages/hypermap-cacher/hypermap-cacher/src/lib.rs
+++ b/hyperdrive/packages/hypermap-cacher/hypermap-cacher/src/lib.rs
@@ -37,7 +37,12 @@ const RETRY_DELAY_S: u64 = 10;
 const LOG_ITERATION_DELAY_MS: u64 = 200;
 
 #[cfg(not(feature = "simulation-mode"))]
-const DEFAULT_NODES: &[&str] = &["nick.hypr", "nick1udwig.os"];
+const DEFAULT_NODES: &[&str] = &[
+    "us-cacher-1.hypr",
+    "eu-cacher-1.hypr",
+    "nick.hypr",
+    "nick1udwig.os",
+];
 #[cfg(feature = "simulation-mode")]
 const DEFAULT_NODES: &[&str] = &["fake.os"];
 


### PR DESCRIPTION
## Problem

Had neglected to have same DEFAULT_NODES in hns-indexer as in hypermap-cacher. For brand-new nodes this meant that only a subset of DEFAULT_NODES were accessible (i.e. the ones in both). Further, having only 2 (really 1) nodes led to fragility.

## Solution

1. Copy DEFAULT_NODES between the two (TODO: DRY)
2. Spin up some more infra nodes to increase number of cachers

## Testing

Can a freshly booted node bootstrap properly?

## Docs Update

None

## Notes

None