### PR TITLE
dont crash on web socket close

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,6 +3869,7 @@ version = "1.4.1"
 dependencies = [
  "alloy",
  "anyhow",
+ "dashmap 5.5.3",
  "lazy_static",
  "rand 0.8.5",
  "regex",
@@ -3880,6 +3881,7 @@ dependencies = [
  "sha2",
  "thiserror 1.0.69",
  "tokio",
+ "warp",
  "wasmtime",
 ]
 

--- a/hyperdrive/src/http/server.rs
+++ b/hyperdrive/src/http/server.rs
@@ -110,8 +110,14 @@ async fn send_push(
             }
         }
         WsMessageType::Close => {
-            return utils::handle_close_websocket(id, &source, send_to_loop, ws_senders, channel_id)
-                .await;
+            return utils::handle_close_websocket(
+                id,
+                &source,
+                send_to_loop,
+                ws_senders,
+                channel_id,
+            )
+            .await;
         }
     };
     // Send to the websocket if registered

--- a/hyperdrive/src/http/server.rs
+++ b/hyperdrive/src/http/server.rs
@@ -110,7 +110,7 @@ async fn send_push(
             }
         }
         WsMessageType::Close => {
-            return utils::handle_close_websocket(id, source, send_to_loop, ws_senders, channel_id)
+            return utils::handle_close_websocket(id, &source, send_to_loop, ws_senders, channel_id)
                 .await;
         }
     };
@@ -1537,9 +1537,9 @@ async fn handle_app_message(
                 }
                 HttpServerAction::WebSocketClose(channel_id) => {
                     let is_return = utils::handle_close_websocket(
-                        id,
-                        source,
-                        send_to_loop,
+                        km.id,
+                        &km.source,
+                        &send_to_loop,
                         ws_senders,
                         channel_id,
                     )

--- a/hyperdrive/src/http/server.rs
+++ b/hyperdrive/src/http/server.rs
@@ -1,6 +1,7 @@
 use crate::http::server_types::{
-    HttpResponse, HttpResponseSenders, HttpSender, HttpServerAction, HttpServerError, HttpServerRequest, IncomingHttpRequest,
-    MessageType, RpcResponseBody, WebSocketSender, WebSocketSenders, WsMessageType,
+    HttpResponse, HttpResponseSenders, HttpSender, HttpServerAction, HttpServerError,
+    HttpServerRequest, IncomingHttpRequest, MessageType, RpcResponseBody, WebSocketSender,
+    WebSocketSenders, WsMessageType,
 };
 use crate::http::utils::{self, send_action_response};
 use crate::keygen;
@@ -109,13 +110,8 @@ async fn send_push(
             }
         }
         WsMessageType::Close => {
-            return utils::handle_close_websocket(
-                id,
-                source,
-                send_to_loop,
-                ws_senders,
-                channel_id,
-            ).await;
+            return utils::handle_close_websocket(id, source, send_to_loop, ws_senders, channel_id)
+                .await;
         }
     };
     // Send to the websocket if registered
@@ -1546,7 +1542,8 @@ async fn handle_app_message(
                         send_to_loop,
                         ws_senders,
                         channel_id,
-                    ).await;
+                    )
+                    .await;
 
                     if is_return {
                         return;

--- a/hyperdrive/src/http/utils.rs
+++ b/hyperdrive/src/http/utils.rs
@@ -1,6 +1,7 @@
+use crate::http::server_types::{HttpServerError, WebSocketSenders};
 use hmac::{Hmac, Mac};
 use jwt::VerifyWithKey;
-use lib::{core::ProcessId, types::http_server};
+use lib::{types::{http_server, core::{Address, KernelMessage, Message, MessageSender, ProcessId, Response, HTTP_SERVER_PROCESS_ID}}};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::collections::HashMap;
@@ -157,4 +158,51 @@ pub fn is_behind_reverse_proxy(headers: &warp::http::HeaderMap) -> bool {
         }
     }
     return false;
+}
+
+pub async fn handle_close_websocket(id: u64, source: Address, send_to_loop: &MessageSender, ws_senders: WebSocketSenders, channel_id: u32) -> bool {
+    let Some(got) = ws_senders.get(&channel_id) else {
+        return;
+    };
+
+    if got.value().0 != source.process {
+        send_action_response(
+            id,
+            source,
+            send_to_loop,
+            Err(HttpServerError::WsChannelNotFound),
+        )
+        .await;
+        return true;
+    }
+
+    let _ = got.value().1.send(warp::ws::Message::close()).await;
+    ws_senders.remove(&channel_id);
+
+    return false;
+}
+
+pub async fn send_action_response(
+    id: u64,
+    target: Address,
+    send_to_loop: &MessageSender,
+    result: Result<(), HttpServerError>,
+) {
+    KernelMessage::builder()
+        .id(id)
+        .source(("our", HTTP_SERVER_PROCESS_ID.clone()))
+        .target(target)
+        .message(Message::Response((
+            Response {
+                inherit: false,
+                body: serde_json::to_vec(&result).unwrap(),
+                metadata: None,
+                capabilities: vec![],
+            },
+            None,
+        )))
+        .build()
+        .unwrap()
+        .send(send_to_loop)
+        .await;
 }

--- a/hyperdrive/src/http/utils.rs
+++ b/hyperdrive/src/http/utils.rs
@@ -167,19 +167,19 @@ pub fn is_behind_reverse_proxy(headers: &warp::http::HeaderMap) -> bool {
 
 pub async fn handle_close_websocket(
     id: u64,
-    source: Address,
+    source: &Address,
     send_to_loop: &MessageSender,
     ws_senders: WebSocketSenders,
     channel_id: u32,
 ) -> bool {
     let Some(got) = ws_senders.get(&channel_id) else {
-        return;
+        return false;
     };
 
     if got.value().0 != source.process {
         send_action_response(
             id,
-            source,
+            source.clone(),
             send_to_loop,
             Err(HttpServerError::WsChannelNotFound),
         )

--- a/hyperdrive/src/http/utils.rs
+++ b/hyperdrive/src/http/utils.rs
@@ -1,7 +1,12 @@
 use crate::http::server_types::{HttpServerError, WebSocketSenders};
 use hmac::{Hmac, Mac};
 use jwt::VerifyWithKey;
-use lib::{types::{http_server, core::{Address, KernelMessage, Message, MessageSender, ProcessId, Response, HTTP_SERVER_PROCESS_ID}}};
+use lib::types::{
+    core::{
+        Address, KernelMessage, Message, MessageSender, ProcessId, Response, HTTP_SERVER_PROCESS_ID,
+    },
+    http_server,
+};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::collections::HashMap;
@@ -160,7 +165,13 @@ pub fn is_behind_reverse_proxy(headers: &warp::http::HeaderMap) -> bool {
     return false;
 }
 
-pub async fn handle_close_websocket(id: u64, source: Address, send_to_loop: &MessageSender, ws_senders: WebSocketSenders, channel_id: u32) -> bool {
+pub async fn handle_close_websocket(
+    id: u64,
+    source: Address,
+    send_to_loop: &MessageSender,
+    ws_senders: WebSocketSenders,
+    channel_id: u32,
+) -> bool {
     let Some(got) = ws_senders.get(&channel_id) else {
         return;
     };

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -33,4 +33,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.28", features = ["sync"] }
+warp = "0.3.5"
 wasmtime = { version = "33.0.0", features = ["component-model"] }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,6 +23,7 @@ alloy = { version = "0.8.1", features = [
     "rpc-types",
     "rpc-types-eth",
 ] }
+dashmap = "5.5.3"
 lazy_static = "1.4.0"
 rand = "0.8.4"
 regex = "1.11.0"

--- a/lib/src/http/server_types.rs
+++ b/lib/src/http/server_types.rs
@@ -1,4 +1,4 @@
-use crate::core::LazyLoadBlob;
+use crate::core::{LazyLoadBlob, ProcessId};
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -213,5 +213,5 @@ pub type HttpSender = tokio::sync::oneshot::Sender<(HttpResponse, Vec<u8>)>;
 /// mapping from an open websocket connection to a channel that will ingest
 /// WebSocketPush messages from the app that handles the connection, and
 /// send them to the connection.
-type WebSocketSenders = Arc<DashMap<u32, (ProcessId, WebSocketSender)>>;
-type WebSocketSender = tokio::sync::mpsc::Sender<warp::ws::Message>;
+pub type WebSocketSenders = Arc<DashMap<u32, (ProcessId, WebSocketSender)>>;
+pub type WebSocketSender = tokio::sync::mpsc::Sender<warp::ws::Message>;


### PR DESCRIPTION
## Problem

If an app `WebSocketPush`es a `Close`, *hyperdrive* crashes

## Solution

Don't crash, instead do the proper thing: treat it the same as a WebSocketClose action.

## Testing

Used in the voice hyperapp.

## Docs Update

None

## Notes

None