### PR TITLE
Dw/rpc flag handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ hyperdrive/packages/settings/pkg/ui/*
 hyperdrive/src/register-ui/build/
 hyperdrive/src/register-ui/dist/
 hyperdrive/packages/docs/pkg/ui
+/.idea

--- a/hyperdrive/src/main.rs
+++ b/hyperdrive/src/main.rs
@@ -6,7 +6,6 @@ use lib::types::core::{
     NetworkErrorSender, NodeRouting, PrintReceiver, PrintSender, ProcessId, ProcessVerbosity,
     Request, KERNEL_PROCESS_ID,
 };
-use lib::types::eth::RpcUrlConfigInput;
 #[cfg(feature = "simulation-mode")]
 use ring::{rand::SystemRandom, signature, signature::KeyPair};
 use std::collections::HashMap;
@@ -88,6 +87,12 @@ async fn main() {
     let rpc_config = matches.get_one::<String>("rpc-config").map(|p| {
         std::fs::canonicalize(&p).expect(&format!("specified rpc-config path {p} not found"))
     });
+
+    // Prevent using both --rpc and --rpc-config flags simultaneously
+    if rpc.is_some() && rpc_config.is_some() {
+        panic!("Cannot use both --rpc and --rpc-config flags simultaneously. Please use either --rpc for a single RPC URL or --rpc-config for multiple URLs and/or advanced configs (e.g., auth), but not both.");
+    }
+
     let password = matches.get_one::<String>("password");
 
     // logging mode is toggled at runtime by CTRL+L
@@ -129,38 +134,100 @@ async fn main() {
         is_eth_provider_config_updated = true;
         serde_json::from_str(DEFAULT_ETH_PROVIDERS).unwrap()
     };
+
+    // TODO: Remove debug logging before merging - before modification
+    eprintln!("[DEBUG-AUTH] eth_provider_config before --rpc/--rpc-config processing: {:#?}", eth_provider_config);
+
     if let Some(rpc) = rpc {
-        eth_provider_config.insert(
-            0,
-            lib::eth::ProviderConfig {
-                chain_id: CHAIN_ID,
-                trusted: true,
-                provider: lib::eth::NodeOrRpcUrl::RpcUrl {
-                    url: rpc.to_string(),
-                    auth: None,
-                },
+        // TODO: Remove debug logging before merging
+        eprintln!("[DEBUG-AUTH] Processing --rpc flag with URL: {}", rpc);
+
+        let new_provider = lib::eth::ProviderConfig {
+            chain_id: CHAIN_ID,
+            trusted: true,
+            provider: lib::eth::NodeOrRpcUrl::RpcUrl {
+                url: rpc.to_string(),
+                auth: None,
             },
-        );
+        };
+
+        add_provider_to_config(&mut eth_provider_config, new_provider);
         is_eth_provider_config_updated = true;
+
+        // TODO: Remove debug logging before merging
+        eprintln!("[DEBUG-AUTH] Added --rpc provider (with deduplication)");
     }
     if let Some(rpc_config) = rpc_config {
-        let rpc_config = tokio::fs::read_to_string(rpc_config)
-            .await
-            .expect("cant read rpc-config");
-        let rpc_config: Vec<RpcUrlConfigInput> =
-            serde_json::from_str(&rpc_config).expect("rpc-config had invalid format");
-        for RpcUrlConfigInput { url, auth } in rpc_config {
-            eth_provider_config.insert(
-                0,
-                lib::eth::ProviderConfig {
-                    chain_id: CHAIN_ID,
-                    trusted: true,
-                    provider: lib::eth::NodeOrRpcUrl::RpcUrl { url, auth },
-                },
-            );
+        // TODO: Remove debug logging before merging
+        eprintln!("[DEBUG-AUTH] Processing --rpc-config flag with file: {}", rpc_config.display());
+
+        match std::fs::read_to_string(&rpc_config) {
+            Ok(contents) => {
+                match serde_json::from_str::<Vec<lib::eth::RpcUrlConfigInput>>(&contents) {
+                    Ok(rpc_configs) => {
+                        // TODO: Remove debug logging before merging
+                        eprintln!("[DEBUG-AUTH] Loaded {} providers from config file", rpc_configs.len());
+
+                        // Store the length before consuming the vector
+                        let total_configs = rpc_configs.len();
+
+                        // Process in reverse order so the first entry in the file becomes highest priority
+                        for (reverse_index, rpc_url_config) in rpc_configs.into_iter().rev().enumerate() {
+                            let original_index = total_configs - 1 - reverse_index;
+
+                            // TODO: Remove debug logging before merging
+                            eprintln!("[DEBUG-AUTH] Processing config provider {} (original position {}): {}",
+                                      reverse_index + 1, original_index + 1, rpc_url_config.url);
+                            if let Some(ref auth) = rpc_url_config.auth {
+                                match auth {
+                                    lib::eth::Authorization::Basic(creds) => {
+                                        eprintln!("[DEBUG-AUTH] Config provider has Basic auth (length: {})", creds.len());
+                                    },
+                                    lib::eth::Authorization::Bearer(token) => {
+                                        eprintln!("[DEBUG-AUTH] Config provider has Bearer auth (length: {})", token.len());
+                                    },
+                                    lib::eth::Authorization::Raw(raw) => {
+                                        eprintln!("[DEBUG-AUTH] Config provider has Raw auth (length: {})", raw.len());
+                                    },
+                                }
+                            } else {
+                                eprintln!("[DEBUG-AUTH] Config provider has no auth");
+                            }
+
+                            let new_provider = lib::eth::ProviderConfig {
+                                chain_id: CHAIN_ID,
+                                trusted: true,
+                                provider: lib::eth::NodeOrRpcUrl::RpcUrl {
+                                    url: rpc_url_config.url,
+                                    auth: rpc_url_config.auth,
+                                },
+                            };
+
+                            add_provider_to_config(&mut eth_provider_config, new_provider);
+                        }
+                        is_eth_provider_config_updated = true;
+
+                        // TODO: Remove debug logging before merging
+                        eprintln!("[DEBUG-AUTH] Added all --rpc-config providers (with deduplication, order preserved)");
+                    }
+                    Err(e) => {
+                        // TODO: Remove debug logging before merging
+                        eprintln!("[DEBUG-AUTH] Failed to parse RPC config file: {}", e);
+                        eprintln!("Failed to parse RPC config file: {e}");
+                    }
+                }
+            }
+            Err(e) => {
+                // TODO: Remove debug logging before merging
+                eprintln!("[DEBUG-AUTH] Failed to read RPC config file: {}", e);
+                eprintln!("Failed to read RPC config file: {e}");
+            }
         }
-        is_eth_provider_config_updated = true;
     }
+
+    // TODO: Remove debug logging before merging - after modification
+    eprintln!("[DEBUG-AUTH] eth_provider_config after --rpc/--rpc-config processing: {:#?}", eth_provider_config);
+
     if is_eth_provider_config_updated {
         // save the new provider config
         tokio::fs::write(
@@ -274,7 +341,7 @@ async fn main() {
                 (ws_tcp_handle, ws_flag_used),
                 (tcp_tcp_handle, tcp_flag_used),
                 http_server_port,
-                rpc.cloned(),
+                eth_provider_config.clone(),
                 detached,
             )
             .await
@@ -285,7 +352,7 @@ async fn main() {
                 our_ip.to_string(),
                 (ws_tcp_handle, ws_flag_used),
                 (tcp_tcp_handle, tcp_flag_used),
-                rpc.cloned(),
+                eth_provider_config.clone(),
                 password,
             )
             .await
@@ -842,7 +909,7 @@ async fn serve_register_fe(
     ws_networking: (Option<tokio::net::TcpListener>, bool),
     tcp_networking: (Option<tokio::net::TcpListener>, bool),
     http_server_port: u16,
-    maybe_rpc: Option<String>,
+    eth_provider_config: lib::eth::SavedConfigs,
     detached: bool,
 ) -> (Identity, Vec<u8>, Keyfile) {
     let (kill_tx, kill_rx) = tokio::sync::oneshot::channel::<bool>();
@@ -861,7 +928,7 @@ async fn serve_register_fe(
                 (tcp_networking.0.as_ref(), tcp_networking.1),
                 http_server_port,
                 disk_keyfile,
-                maybe_rpc,
+                eth_provider_config,
                 detached) => {
             panic!("registration failed")
         }
@@ -888,7 +955,7 @@ async fn login_with_password(
     our_ip: String,
     ws_networking: (Option<tokio::net::TcpListener>, bool),
     tcp_networking: (Option<tokio::net::TcpListener>, bool),
-    maybe_rpc: Option<String>,
+    eth_provider_config: lib::eth::SavedConfigs,
     password: &str,
 ) -> (Identity, Vec<u8>, Keyfile) {
     use argon2::Argon2;
@@ -962,7 +1029,7 @@ async fn login_with_password(
         },
     };
 
-    let provider = Arc::new(register::connect_to_provider(maybe_rpc).await);
+    let provider = Arc::new(register::connect_to_provider_from_config(&eth_provider_config).await);
 
     register::assign_routing(
         &mut our,
@@ -984,6 +1051,35 @@ async fn login_with_password(
         .unwrap();
 
     (our, disk_keyfile, k)
+}
+
+/// Add a provider config with deduplication logic (same as runtime system)
+fn add_provider_to_config(eth_provider_config: &mut lib::eth::SavedConfigs, new_provider: lib::eth::ProviderConfig) {
+    match &new_provider.provider {
+        lib::eth::NodeOrRpcUrl::RpcUrl { url, .. } => {
+            // Remove any existing provider with this URL
+            eth_provider_config.0.retain(|config| {
+                if let lib::eth::NodeOrRpcUrl::RpcUrl { url: existing_url, .. } = &config.provider {
+                    existing_url != url
+                } else {
+                    true
+                }
+            });
+        }
+        lib::eth::NodeOrRpcUrl::Node { hns_update, .. } => {
+            // Remove any existing provider with this node name
+            eth_provider_config.0.retain(|config| {
+                if let lib::eth::NodeOrRpcUrl::Node { hns_update: existing_update, .. } = &config.provider {
+                    existing_update.name != hns_update.name
+                } else {
+                    true
+                }
+            });
+        }
+    }
+
+    // Insert the new provider at the front (position 0)
+    eth_provider_config.0.insert(0, new_provider);
 }
 
 fn make_remote_link(url: &str, text: &str) -> String {

--- a/hyperdrive/src/main.rs
+++ b/hyperdrive/src/main.rs
@@ -136,7 +136,10 @@ async fn main() {
     };
 
     // TODO: Remove debug logging before merging - before modification
-    eprintln!("[DEBUG-AUTH] eth_provider_config before --rpc/--rpc-config processing: {:#?}", eth_provider_config);
+    eprintln!(
+        "[DEBUG-AUTH] eth_provider_config before --rpc/--rpc-config processing: {:#?}",
+        eth_provider_config
+    );
 
     if let Some(rpc) = rpc {
         // TODO: Remove debug logging before merging
@@ -159,20 +162,28 @@ async fn main() {
     }
     if let Some(rpc_config) = rpc_config {
         // TODO: Remove debug logging before merging
-        eprintln!("[DEBUG-AUTH] Processing --rpc-config flag with file: {}", rpc_config.display());
+        eprintln!(
+            "[DEBUG-AUTH] Processing --rpc-config flag with file: {}",
+            rpc_config.display()
+        );
 
         match std::fs::read_to_string(&rpc_config) {
             Ok(contents) => {
                 match serde_json::from_str::<Vec<lib::eth::RpcUrlConfigInput>>(&contents) {
                     Ok(rpc_configs) => {
                         // TODO: Remove debug logging before merging
-                        eprintln!("[DEBUG-AUTH] Loaded {} providers from config file", rpc_configs.len());
+                        eprintln!(
+                            "[DEBUG-AUTH] Loaded {} providers from config file",
+                            rpc_configs.len()
+                        );
 
                         // Store the length before consuming the vector
                         let total_configs = rpc_configs.len();
 
                         // Process in reverse order so the first entry in the file becomes highest priority
-                        for (reverse_index, rpc_url_config) in rpc_configs.into_iter().rev().enumerate() {
+                        for (reverse_index, rpc_url_config) in
+                            rpc_configs.into_iter().rev().enumerate()
+                        {
                             let original_index = total_configs - 1 - reverse_index;
 
                             // TODO: Remove debug logging before merging
@@ -182,13 +193,13 @@ async fn main() {
                                 match auth {
                                     lib::eth::Authorization::Basic(creds) => {
                                         eprintln!("[DEBUG-AUTH] Config provider has Basic auth (length: {})", creds.len());
-                                    },
+                                    }
                                     lib::eth::Authorization::Bearer(token) => {
                                         eprintln!("[DEBUG-AUTH] Config provider has Bearer auth (length: {})", token.len());
-                                    },
+                                    }
                                     lib::eth::Authorization::Raw(raw) => {
                                         eprintln!("[DEBUG-AUTH] Config provider has Raw auth (length: {})", raw.len());
-                                    },
+                                    }
                                 }
                             } else {
                                 eprintln!("[DEBUG-AUTH] Config provider has no auth");
@@ -226,7 +237,10 @@ async fn main() {
     }
 
     // TODO: Remove debug logging before merging - after modification
-    eprintln!("[DEBUG-AUTH] eth_provider_config after --rpc/--rpc-config processing: {:#?}", eth_provider_config);
+    eprintln!(
+        "[DEBUG-AUTH] eth_provider_config after --rpc/--rpc-config processing: {:#?}",
+        eth_provider_config
+    );
 
     if is_eth_provider_config_updated {
         // save the new provider config
@@ -1054,12 +1068,18 @@ async fn login_with_password(
 }
 
 /// Add a provider config with deduplication logic (same as runtime system)
-fn add_provider_to_config(eth_provider_config: &mut lib::eth::SavedConfigs, new_provider: lib::eth::ProviderConfig) {
+fn add_provider_to_config(
+    eth_provider_config: &mut lib::eth::SavedConfigs,
+    new_provider: lib::eth::ProviderConfig,
+) {
     match &new_provider.provider {
         lib::eth::NodeOrRpcUrl::RpcUrl { url, .. } => {
             // Remove any existing provider with this URL
             eth_provider_config.0.retain(|config| {
-                if let lib::eth::NodeOrRpcUrl::RpcUrl { url: existing_url, .. } = &config.provider {
+                if let lib::eth::NodeOrRpcUrl::RpcUrl {
+                    url: existing_url, ..
+                } = &config.provider
+                {
                     existing_url != url
                 } else {
                     true
@@ -1069,7 +1089,11 @@ fn add_provider_to_config(eth_provider_config: &mut lib::eth::SavedConfigs, new_
         lib::eth::NodeOrRpcUrl::Node { hns_update, .. } => {
             // Remove any existing provider with this node name
             eth_provider_config.0.retain(|config| {
-                if let lib::eth::NodeOrRpcUrl::Node { hns_update: existing_update, .. } = &config.provider {
+                if let lib::eth::NodeOrRpcUrl::Node {
+                    hns_update: existing_update,
+                    ..
+                } = &config.provider
+                {
                     existing_update.name != hns_update.name
                 } else {
                     true

--- a/hyperdrive/src/register.rs
+++ b/hyperdrive/src/register.rs
@@ -39,7 +39,7 @@ pub async fn register(
     tcp_networking: (Option<&tokio::net::TcpListener>, bool),
     http_port: u16,
     keyfile: Option<Vec<u8>>,
-    maybe_rpc: Option<String>,
+    eth_provider_config: lib::eth::SavedConfigs,
     detached: bool,
 ) {
     // Networking info is generated and passed to the UI, but not used until confirmed
@@ -88,7 +88,7 @@ pub async fn register(
         },
     });
 
-    let provider = Arc::new(connect_to_provider(maybe_rpc).await);
+    let provider = Arc::new(connect_to_provider_from_config(&eth_provider_config).await);
 
     let keyfile = warp::any().map(move || keyfile.clone());
     let our_temp_id = warp::any().map(move || our_temp_id.clone());
@@ -245,38 +245,107 @@ pub async fn register(
         .await;
 }
 
-/// Connect to given provider or one of two public RPC providers as fallbacks.
-/// TODO: add more fallbacks
-pub async fn connect_to_provider(maybe_rpc: Option<String>) -> RootProvider<PubSubFrontend> {
-    let url = if let Some(ref rpc_url) = maybe_rpc {
-        rpc_url
-    } else {
-        "wss://base-rpc.publicnode.com"
-    };
+/// Connect to provider using the saved configuration with fallbacks
+pub async fn connect_to_provider_from_config(
+    eth_provider_config: &lib::eth::SavedConfigs,
+) -> RootProvider<PubSubFrontend> {
 
-    let rpc_urls = [
-        url,
-        "wss://base.llamarpc.com",
-        "wss://base-rpc.publicnode.com",
-        //"wss://1rpc.io/base",
-        //"wss://base.blockpi.network/v1/rpc/public",
-    ];
+    let saved_configs = &eth_provider_config.0;
 
-    for rpc_url in rpc_urls {
-        if let Ok(client) = ProviderBuilder::new()
-            .on_ws(WsConnect::new(rpc_url.to_string()))
-            .await
-        {
-            println!("Connected to {rpc_url}\r");
-            return client;
+    // TODO: Remove debug logging before merging
+    eprintln!("[DEBUG-AUTH] Number of configured providers (including Node providers which will not be used): {}", saved_configs.len());
+
+    // Try each configured provider first
+    for (index, provider_config) in saved_configs.iter().enumerate() {
+        // TODO: Remove debug logging before merging
+        eprintln!("[DEBUG-AUTH] Trying configured provider {}/{}", index + 1, saved_configs.len());
+
+        match &provider_config.provider {
+            lib::eth::NodeOrRpcUrl::RpcUrl { url, auth } => {
+                // TODO: Remove debug logging before merging
+                eprintln!("[DEBUG-AUTH] RPC URL provider: {}", url);
+                eprintln!("[DEBUG-AUTH] Auth present: {}", auth.is_some());
+                if let Some(auth_ref) = auth {
+                    match auth_ref {
+                        lib::eth::Authorization::Basic(creds) => {
+                            eprintln!("[DEBUG-AUTH] Auth type: Basic (credentials length: {})", creds.len());
+                            eprintln!("[DEBUG-AUTH] Basic auth format valid (contains ':'): {}", creds.contains(':'));
+                        },
+                        lib::eth::Authorization::Bearer(token) => {
+                            eprintln!("[DEBUG-AUTH] Auth type: Bearer (token length: {})", token.len());
+                        },
+                        lib::eth::Authorization::Raw(raw) => {
+                            eprintln!("[DEBUG-AUTH] Auth type: Raw (value length: {})", raw.len());
+                        },
+                    }
+                }
+
+                let ws_connect = WsConnect {
+                    url: url.clone(),
+                    auth: auth.clone().map(|a| a.into()),
+                    config: None,
+                };
+
+                // TODO: Remove debug logging before merging
+                eprintln!("[DEBUG-AUTH] Attempting connection to provider: {}", url);
+
+                if let Ok(client) = ProviderBuilder::new().on_ws(ws_connect).await {
+                    // TODO: Remove debug logging before merging
+                    eprintln!("[DEBUG-AUTH] ✅ Successfully connected to configured provider: {}", url);
+                    println!("Connected to configured provider: {url}\r");
+                    return client;
+                } else {
+                    // TODO: Remove debug logging before merging
+                    eprintln!("[DEBUG-AUTH] ❌ Failed to connect to configured provider: {}", url);
+                    println!("Failed to connect to provider: {url}\r");
+                }
+            }
+            lib::eth::NodeOrRpcUrl::Node { hns_update, use_as_provider } => {
+                // TODO: Remove debug logging before merging
+                eprintln!("[DEBUG-AUTH] Node provider: {} (use_as_provider: {})", hns_update.name, use_as_provider);
+                eprintln!("[DEBUG-AUTH] Skipping node provider (need RPC URL)");
+                continue;
+            }
         }
     }
 
+    // TODO: Remove debug logging before merging
+    eprintln!("[DEBUG-AUTH] All configured providers failed, falling back to defaults");
+
+    // Fall back to default providers if configured ones fail
+    let default_rpc_urls = [
+        "wss://base.llamarpc.com",
+        "wss://base-rpc.publicnode.com",
+    ];
+
+    for (index, rpc_url) in default_rpc_urls.iter().enumerate() {
+        // TODO: Remove debug logging before merging
+        eprintln!("[DEBUG-AUTH] Trying fallback provider {}/{}: {}", index + 1, default_rpc_urls.len(), rpc_url);
+
+        let ws_connect = WsConnect {
+            url: rpc_url.to_string(),
+            auth: None,
+            config: None,
+        };
+
+        if let Ok(client) = ProviderBuilder::new().on_ws(ws_connect).await {
+            // TODO: Remove debug logging before merging
+            eprintln!("[DEBUG-AUTH] ✅ Successfully connected to fallback provider: {}", rpc_url);
+            println!("Connected to fallback provider: {rpc_url}\r");
+            return client;
+        } else {
+            // TODO: Remove debug logging before merging
+            eprintln!("[DEBUG-AUTH] ❌ Failed to connect to fallback provider: {}", rpc_url);
+        }
+    }
+
+    // TODO: Remove debug logging before merging
+    eprintln!("[DEBUG-AUTH] ❌ All providers (configured + fallback) failed!");
+
     panic!(
-        "Error: runtime could not connect to Base ETH RPCs {rpc_urls:?}\n\
+        "Error: runtime could not connect to any ETH RPC providers\n\
         This is necessary in order to verify node identity onchain.\n\
-        Please make sure you are using a valid WebSockets URL if using \
-        the --rpc flag, and you are connected to the internet."
+        Please check your configured providers and internet connection."
     );
 }
 

--- a/hyperdrive/src/register.rs
+++ b/hyperdrive/src/register.rs
@@ -249,7 +249,6 @@ pub async fn register(
 pub async fn connect_to_provider_from_config(
     eth_provider_config: &lib::eth::SavedConfigs,
 ) -> RootProvider<PubSubFrontend> {
-
     let saved_configs = &eth_provider_config.0;
 
     // TODO: Remove debug logging before merging
@@ -258,7 +257,11 @@ pub async fn connect_to_provider_from_config(
     // Try each configured provider first
     for (index, provider_config) in saved_configs.iter().enumerate() {
         // TODO: Remove debug logging before merging
-        eprintln!("[DEBUG-AUTH] Trying configured provider {}/{}", index + 1, saved_configs.len());
+        eprintln!(
+            "[DEBUG-AUTH] Trying configured provider {}/{}",
+            index + 1,
+            saved_configs.len()
+        );
 
         match &provider_config.provider {
             lib::eth::NodeOrRpcUrl::RpcUrl { url, auth } => {
@@ -268,15 +271,24 @@ pub async fn connect_to_provider_from_config(
                 if let Some(auth_ref) = auth {
                     match auth_ref {
                         lib::eth::Authorization::Basic(creds) => {
-                            eprintln!("[DEBUG-AUTH] Auth type: Basic (credentials length: {})", creds.len());
-                            eprintln!("[DEBUG-AUTH] Basic auth format valid (contains ':'): {}", creds.contains(':'));
-                        },
+                            eprintln!(
+                                "[DEBUG-AUTH] Auth type: Basic (credentials length: {})",
+                                creds.len()
+                            );
+                            eprintln!(
+                                "[DEBUG-AUTH] Basic auth format valid (contains ':'): {}",
+                                creds.contains(':')
+                            );
+                        }
                         lib::eth::Authorization::Bearer(token) => {
-                            eprintln!("[DEBUG-AUTH] Auth type: Bearer (token length: {})", token.len());
-                        },
+                            eprintln!(
+                                "[DEBUG-AUTH] Auth type: Bearer (token length: {})",
+                                token.len()
+                            );
+                        }
                         lib::eth::Authorization::Raw(raw) => {
                             eprintln!("[DEBUG-AUTH] Auth type: Raw (value length: {})", raw.len());
-                        },
+                        }
                     }
                 }
 
@@ -291,18 +303,30 @@ pub async fn connect_to_provider_from_config(
 
                 if let Ok(client) = ProviderBuilder::new().on_ws(ws_connect).await {
                     // TODO: Remove debug logging before merging
-                    eprintln!("[DEBUG-AUTH] ✅ Successfully connected to configured provider: {}", url);
+                    eprintln!(
+                        "[DEBUG-AUTH] ✅ Successfully connected to configured provider: {}",
+                        url
+                    );
                     println!("Connected to configured provider: {url}\r");
                     return client;
                 } else {
                     // TODO: Remove debug logging before merging
-                    eprintln!("[DEBUG-AUTH] ❌ Failed to connect to configured provider: {}", url);
+                    eprintln!(
+                        "[DEBUG-AUTH] ❌ Failed to connect to configured provider: {}",
+                        url
+                    );
                     println!("Failed to connect to provider: {url}\r");
                 }
             }
-            lib::eth::NodeOrRpcUrl::Node { hns_update, use_as_provider } => {
+            lib::eth::NodeOrRpcUrl::Node {
+                hns_update,
+                use_as_provider,
+            } => {
                 // TODO: Remove debug logging before merging
-                eprintln!("[DEBUG-AUTH] Node provider: {} (use_as_provider: {})", hns_update.name, use_as_provider);
+                eprintln!(
+                    "[DEBUG-AUTH] Node provider: {} (use_as_provider: {})",
+                    hns_update.name, use_as_provider
+                );
                 eprintln!("[DEBUG-AUTH] Skipping node provider (need RPC URL)");
                 continue;
             }
@@ -313,14 +337,16 @@ pub async fn connect_to_provider_from_config(
     eprintln!("[DEBUG-AUTH] All configured providers failed, falling back to defaults");
 
     // Fall back to default providers if configured ones fail
-    let default_rpc_urls = [
-        "wss://base.llamarpc.com",
-        "wss://base-rpc.publicnode.com",
-    ];
+    let default_rpc_urls = ["wss://base.llamarpc.com", "wss://base-rpc.publicnode.com"];
 
     for (index, rpc_url) in default_rpc_urls.iter().enumerate() {
         // TODO: Remove debug logging before merging
-        eprintln!("[DEBUG-AUTH] Trying fallback provider {}/{}: {}", index + 1, default_rpc_urls.len(), rpc_url);
+        eprintln!(
+            "[DEBUG-AUTH] Trying fallback provider {}/{}: {}",
+            index + 1,
+            default_rpc_urls.len(),
+            rpc_url
+        );
 
         let ws_connect = WsConnect {
             url: rpc_url.to_string(),
@@ -330,12 +356,18 @@ pub async fn connect_to_provider_from_config(
 
         if let Ok(client) = ProviderBuilder::new().on_ws(ws_connect).await {
             // TODO: Remove debug logging before merging
-            eprintln!("[DEBUG-AUTH] ✅ Successfully connected to fallback provider: {}", rpc_url);
+            eprintln!(
+                "[DEBUG-AUTH] ✅ Successfully connected to fallback provider: {}",
+                rpc_url
+            );
             println!("Connected to fallback provider: {rpc_url}\r");
             return client;
         } else {
             // TODO: Remove debug logging before merging
-            eprintln!("[DEBUG-AUTH] ❌ Failed to connect to fallback provider: {}", rpc_url);
+            eprintln!(
+                "[DEBUG-AUTH] ❌ Failed to connect to fallback provider: {}",
+                rpc_url
+            );
         }
     }
 


### PR DESCRIPTION
## Problem

inconsistent handling of --rpc vs --rpc-config flags

## Solution

The handling of these flags has now been rationalized (and also made consistent with runtime handling as well). We start by recognizing that --rpc is just a special case (one provider, no auth) of what can be specified in --rpc-config. So only one or the other should be specified (if any), not both.

eth_provider_config will be potentially modified by these flags, adding ProviderConfigs at the top of the vector (after deduplicating them if needed), and preserving the order if multiple ProviderConfigs are specified in the --rpc-config file.

The calls to serve_register_fe and login_with_password now accept this whole eth_provider_config, not merely an RPC URL string. This propagates as required, eventually calling the new function connect_to_provider_from_config, which replaces the previous connect_to_provider function. Now it is possible for an authenticated connection to serve register and login with password. It will also attempt to use all of the saved/configured RPC providers, only falling back to the default if no others succeed.

## Notes

I'll remove tagged debug logging before merging
