### PR TITLE
state: do not allow arbitrary processes to alter state

### DIFF
--- a/hyperdrive/src/state.rs
+++ b/hyperdrive/src/state.rs
@@ -118,6 +118,20 @@ pub async fn state_sender(
             continue;
         }
 
+        if (km.source.process.package() != "distro" && km.source.process.package() != "terminal") || km.source.process.publisher() != "sys" {
+            Printout::new(
+                1,
+                STATE_PROCESS_ID.clone(),
+                format!(
+                    "state: got request from {}, but requests must come from kernel or terminal",
+                    km.source.process
+                ),
+            )
+            .send(&send_to_terminal)
+            .await;
+            continue;
+        }
+
         let queue = process_queues
             .get(&km.source.process)
             .cloned()

--- a/hyperdrive/src/state.rs
+++ b/hyperdrive/src/state.rs
@@ -118,7 +118,9 @@ pub async fn state_sender(
             continue;
         }
 
-        if (km.source.process.package() != "distro" && km.source.process.package() != "terminal") || km.source.process.publisher() != "sys" {
+        if (km.source.process.package() != "distro" && km.source.process.package() != "terminal")
+            || km.source.process.publisher() != "sys"
+        {
             Printout::new(
                 1,
                 STATE_PROCESS_ID.clone(),


### PR DESCRIPTION
## Problem

Any local process can call any state method -- including altering that state of other processes!

## Solution

Only distro and terminal processes can alter state.
Note that `get_state()` etc all send as if from kernel, so this doesn't change functionality in any way, just plugs a security hole.

## Testing

Try `clear-state`.

## Docs Update

None

## Notes

None