### PR TITLE
fix #816

### DIFF
--- a/hyperdrive/packages/app-store/app-store/src/http_api.rs
+++ b/hyperdrive/packages/app-store/app-store/src/http_api.rs
@@ -196,10 +196,16 @@ fn make_widget() -> String {
                         data.forEach(app => {
                             if (app.metadata) {
                                 const a = document.createElement('a');
+                                a.addEventListener('click', (e) => {
+                                    if (!window.location.hostname.endsWith('.localhost')) {
+                                        e.preventDefault();
+                                    }
+                                    window.parent?.postMessage({
+                                        type: 'APP_LINK_CLICKED',
+                                        url: `app/${app.package_id.package_name}:${app.package_id.publisher_node}`,
+                                    }, '*');
+                                });
                                 a.className = 'app';
-                                a.href = `/main:app-store:sys/app/${app.package_id.package_name}:${app.package_id.publisher_node}`
-                                a.target = '_blank';
-                                a.rel = 'noopener noreferrer';
                                 const iconLetter = app.metadata_hash.replace('0x', '')[0].toUpperCase();
                                 a.innerHTML = `<div
                                     class="app-image"

--- a/hyperdrive/packages/app-store/ui/src/pages/StorePage.tsx
+++ b/hyperdrive/packages/app-store/ui/src/pages/StorePage.tsx
@@ -49,7 +49,7 @@ export default function StorePage() {
       // Check if app is installed by looking in the installed state
       const notInstalledApps = Object.values(listings).filter((app) => {
         const appId = `${app.package_id.package_name}:${app.package_id.publisher_node}`;
-        console.log({ appId, installed, listings });
+        // console.log({ appId, installed, listings });
         return !installed[appId];
       });
       console.log({ notInstalledApps, installedKeys: Object.keys(installed) });
@@ -124,7 +124,7 @@ export default function StorePage() {
                   const appId = `${app.package_id.package_name}:${app.package_id.publisher_node}`;
                   const hpaId = hpa.id;
                   const path = hpa.path || '';
-                  console.log({ appId, hpaId, path });
+                  // console.log({ appId, hpaId, path });
                   return hpaId.endsWith(appId) && path
                 })
                   ? <ActionChip

--- a/hyperdrive/packages/homepage/ui/src/components/Home/components/AppContainer.tsx
+++ b/hyperdrive/packages/homepage/ui/src/components/Home/components/AppContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import type { RunningApp } from '../../../types/app.types';
 
 interface AppContainerProps {

--- a/hyperdrive/packages/homepage/ui/src/components/Home/components/HomeScreen.tsx
+++ b/hyperdrive/packages/homepage/ui/src/components/Home/components/HomeScreen.tsx
@@ -39,7 +39,7 @@ export const HomeScreen: React.FC = () => {
   const [showOnboarding, setShowOnboarding] = React.useState(!doNotShowOnboardingAgain);
   const [showWidgetOnboarding, setShowWidgetOnboarding] = React.useState(!doNotShowOnboardingAgain);
 
-  // console.log({ appPositions })
+  // console.log({ widgetSettings, appPositions })
 
   useEffect(() => {
     console.log('isInitialized', isInitialized);
@@ -47,10 +47,14 @@ export const HomeScreen: React.FC = () => {
     // add appstore, contacts, and settings to the homepage on initial load
     setIsInitialized(true);
     // default widgets
-    // addToHomeScreen("main:app-store:sys");
-    // addToHomeScreen("contacts:contacts:sys");
-    // addToHomeScreen("settings:settings:sys");
+    addToHomeScreen("main:app-store:sys");
+    addToHomeScreen("contacts:contacts:sys");
+    addToHomeScreen("settings:settings:sys");
     addToHomeScreen("homepage:homepage:sys"); // actually the clock widget
+
+    // disable these widgets by default
+    toggleWidget("main:app-store:sys");
+    toggleWidget("settings:settings:sys");
 
     // default dock apps
     addToDock("settings:settings:sys", 0);
@@ -205,6 +209,7 @@ export const HomeScreen: React.FC = () => {
   }, [apps, homeScreenApps]);
 
   const widgetApps = useMemo(() => {
+    console.log({ homeApps });
     return homeApps.filter(app => app.widget);
   }, [homeApps]);
 
@@ -344,7 +349,7 @@ export const HomeScreen: React.FC = () => {
               totalWidgets={widgetApps.length}
               className={classNames({
                 // 'invisible pointer-events-none': searchQuery && !app.label.toLowerCase().includes(searchQuery.toLowerCase()) && !widgetSettings[app.id]?.hide
-                'invisible pointer-events-none': !widgetSettings[app.id]?.hide
+                'invisible pointer-events-none': widgetSettings?.[app.id]?.hide
               })}
             >
               {showWidgetOnboarding && index === 0 && <div

--- a/hyperdrive/packages/homepage/ui/src/components/Home/components/Widget.tsx
+++ b/hyperdrive/packages/homepage/ui/src/components/Home/components/Widget.tsx
@@ -21,7 +21,6 @@ export const Widget: React.FC<WidgetProps> = ({ app, index, totalWidgets, childr
   const resizeRef = useRef<HTMLDivElement>(null);
 
   const settings = widgetSettings[app.id] || {};
-  if (settings.hide) return null;
   const isMobile = window.innerWidth < 768; // Tailwind md breakpoint
   const padding = isMobile ? 5 : 10;
   const spacing = isMobile ? 5 : 10;

--- a/hyperdrive/packages/homepage/ui/src/components/Home/index.tsx
+++ b/hyperdrive/packages/homepage/ui/src/components/Home/index.tsx
@@ -12,6 +12,8 @@ import './styles/animations.css';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { IframeMessageType, isIframeMessage } from '../../types/messages';
+import { usePersistenceStore } from '../../stores/persistenceStore';
+import { HomepageApp } from '../../types/app.types';
 dayjs.extend(relativeTime);
 
 export default function Home() {
@@ -92,8 +94,8 @@ export default function Home() {
         allGood = false;
       }
 
-      if (event.data.type !== IframeMessageType.OPEN_APP) {
-        console.log('expected OPEN_APP, got:', event.data.type);
+      if (![IframeMessageType.OPEN_APP, IframeMessageType.APP_LINK_CLICKED].includes(event.data.type)) {
+        console.log('expected IframeMessageType, got:', event.data.type);
         allGood = false;
       }
 
@@ -120,6 +122,11 @@ export default function Home() {
         } else {
           console.error('App not found:', { id, apps });
         }
+      } else if (event.data.type === IframeMessageType.APP_LINK_CLICKED) {
+        console.log({ appLinkClicked: event });
+        const { url } = event.data;
+        console.log({ url, apps });
+        openApp(apps.find(app => app.id.endsWith('app-store:sys')) as HomepageApp, url)
       }
     };
     window.addEventListener('message', handleMessage);

--- a/hyperdrive/packages/homepage/ui/src/stores/navigationStore.ts
+++ b/hyperdrive/packages/homepage/ui/src/stores/navigationStore.ts
@@ -66,7 +66,7 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
   },
 
   openApp: async (app: HomepageApp, query?: string) => {
-    console.log('openApp called with:', { app });
+    console.log('openApp called with:', { app, query });
 
     // Don't open apps without a valid path
     if (!app.path || !app.process || !app.publisher) {
@@ -79,7 +79,9 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
     if (isLocalhost) {
       console.log('[homepage] opening app in new tab:', { app });
       // don't use secure subdomain for localhost
-      window.open(app.path.replace(/^(https?:\/\/)(.*)localhost/, '$1localhost'), '_blank');
+      const path = app.path.replace(/^(https?:\/\/)(.*)localhost/, '$1localhost') + (query || '');
+      console.log({ path })
+      window.open(path, '_blank');
       set({ isAppDrawerOpen: false, isRecentAppsOpen: false });
       return;
     }
@@ -111,7 +113,7 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
       set({
         runningApps: [...runningApps, {
           ...app,
-          path: `${app.path}${query ? `${query.startsWith('?') ? '' : '?'}${query}` : ''}`,
+          path: `${app.path}${query || ''}`,
           openedAt: Date.now()
         }],
         currentAppId: app.id,


### PR DESCRIPTION
## Problem

Clicking into the appstore widget resulted in a newtab on non-localhost 

## Solution

When possible, use the window messaging protocol to open an iframe instead. Localhost should still use a newtab, similar to #822 
