### PR TITLE
app protocol links + semihelpful refresh

### DIFF
--- a/hyperdrive/packages/app-store/app-store/src/http_api.rs
+++ b/hyperdrive/packages/app-store/app-store/src/http_api.rs
@@ -174,6 +174,83 @@ fn make_widget() -> String {
     <h3>Top Apps</h3>
     <div id="latest-apps"></div>
     <script>
+    
+class HWProtocolWatcher {
+    constructor() {
+        this.isListening = false;
+        this.handleClick = this.handleClick.bind(this);
+    }
+    start() {
+        if (this.isListening) {
+            return;
+        }
+        document.addEventListener('click', this.handleClick, true);
+        console.log('[hw-protocol-watcher] initialized');
+        this.isListening = true;
+    }
+    stop() {
+        if (!this.isListening) {
+            return;
+        }
+        document.removeEventListener('click', this.handleClick, true);
+        this.isListening = false;
+    }
+    handleClick(event) {
+        const target = event.target;
+        const anchor = target.closest('a');
+        if (!anchor || !anchor.href) {
+            return;
+        }
+        if (!anchor.href.startsWith('hw://')) {
+            return;
+        }
+        console.log('event occurred');
+        event.preventDefault();
+        event.stopPropagation();
+        // Check if we're in an iframe
+        if (window.parent === window) {
+            // Not in an iframe, do nothing
+            return;
+        }
+        // Extract the path from hw://some-app-name:some-publisher.os/optional-path/etcetc
+        const url = anchor.href.replace('hw://', '/');
+        const message = {
+            type: 'HW_LINK_CLICKED',
+            url: url
+        };
+        window.parent.postMessage(message, '*');
+    }
+}
+// Auto-start functionality
+let globalWatcher = null;
+function startWatching() {
+    if (!globalWatcher) {
+        globalWatcher = new HWProtocolWatcher();
+    }
+    globalWatcher.start();
+    return globalWatcher;
+}
+function stopWatching() {
+    if (globalWatcher) {
+        globalWatcher.stop();
+    }
+}
+// Auto-start when module is loaded (can be disabled by calling stopWatching)
+if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => startWatching());
+    }
+    else {
+        startWatching();
+    }
+}
+
+    
+
+
+    </script>
+
+    <script>
         document.addEventListener('DOMContentLoaded', function() {
             function fetchApps() {
                 fetch('/main:app-store:sys/apps-public', { credentials: 'include' })
@@ -196,15 +273,7 @@ fn make_widget() -> String {
                         data.forEach(app => {
                             if (app.metadata) {
                                 const a = document.createElement('a');
-                                a.addEventListener('click', (e) => {
-                                    if (!window.location.hostname.endsWith('.localhost')) {
-                                        e.preventDefault();
-                                    }
-                                    window.parent?.postMessage({
-                                        type: 'APP_LINK_CLICKED',
-                                        url: `app/${app.package_id.package_name}:${app.package_id.publisher_node}`,
-                                    }, '*');
-                                });
+                                a.href = `hw://app-store:sys/app/${app.package_id.package_name}:${app.package_id.publisher_node}`;
                                 a.className = 'app';
                                 const iconLetter = app.metadata_hash.replace('0x', '')[0].toUpperCase();
                                 a.innerHTML = `<div

--- a/hyperdrive/packages/app-store/ui/package-lock.json
+++ b/hyperdrive/packages/app-store/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hyperware-ai/client-api": "^0.1.4",
+        "@hyperware-ai/hw-protocol-watcher": "^1.0.1",
         "@metamask/jazzicon": "^2.0.0",
         "@rainbow-me/rainbowkit": "^2.1.2",
         "@szhsin/react-menu": "^4.1.0",
@@ -659,6 +660,12 @@
         "buffer": "^6.0.3",
         "node-forge": "^1.3.1"
       }
+    },
+    "node_modules/@hyperware-ai/hw-protocol-watcher": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@hyperware-ai/hw-protocol-watcher/-/hw-protocol-watcher-1.0.1.tgz",
+      "integrity": "sha512-eKfJctdYpAxhvF3W99C5UfsjbzeidP3jSm5KpksKXbqpzJkfgWhdJCurDWu1XURNEV8As7wQFel5ZgyJ3BMKrQ==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
@@ -4088,12 +4095,17 @@
       }
     },
     "node_modules/cipher-base": {
-      "version": "1.0.4",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/classnames": {
@@ -7928,14 +7940,23 @@
       "license": "MIT"
     },
     "node_modules/sha.js": {
-      "version": "2.4.11",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
       },
       "bin": {
         "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shebang-command": {
@@ -8363,7 +8384,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
       "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isarray": "^2.0.5",
@@ -8378,7 +8398,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -8528,7 +8547,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",

--- a/hyperdrive/packages/app-store/ui/package.json
+++ b/hyperdrive/packages/app-store/ui/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hyperware-ai/client-api": "^0.1.4",
+    "@hyperware-ai/hw-protocol-watcher": "^1.0.1",
     "@metamask/jazzicon": "^2.0.0",
     "@rainbow-me/rainbowkit": "^2.1.2",
     "@szhsin/react-menu": "^4.1.0",

--- a/hyperdrive/packages/app-store/ui/src/App.tsx
+++ b/hyperdrive/packages/app-store/ui/src/App.tsx
@@ -18,7 +18,6 @@ const BASE_URL = import.meta.env.BASE_URL;
 if (window.our) window.our.process = BASE_URL?.replace("/", "");
 
 function App() {
-
   return (
     <div className="bg-white dark:bg-stone grow self-stretch min-h-screen px-4 pb-32 md:pb-0 md:px-0 overflow-y-auto">
       <Router basename={BASE_URL}>

--- a/hyperdrive/packages/app-store/ui/src/main.tsx
+++ b/hyperdrive/packages/app-store/ui/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import '@rainbow-me/rainbowkit/styles.css';
+import '@hyperware-ai/hw-protocol-watcher';
 
 import {
   getDefaultConfig,

--- a/hyperdrive/packages/app-store/ui/src/pages/AppPage.tsx
+++ b/hyperdrive/packages/app-store/ui/src/pages/AppPage.tsx
@@ -163,11 +163,11 @@ export default function AppPage() {
           if (installedVersion) {
             setCurrentVersion(installedVersion[0]);
             setUpToDate(installedVersion[0] === latestVer);
+            setAwaitPresenceInHomepageApps(true);
           }
         }
       }
 
-      setAwaitPresenceInHomepageApps(true);
     } catch (err) {
       setError("Failed to load app details. Please try again.");
       console.error(err);
@@ -178,6 +178,7 @@ export default function AppPage() {
 
   const calculateCanLaunch = useCallback((appData: AppListing) => {
     const { foundApp, path } = getLaunchUrl(`${appData?.package_id.package_name}:${appData?.package_id.publisher_node}`);
+    //console.log({ foundApp, path });
     setCanLaunch(foundApp);
     setLaunchUrl(path);
     if (foundApp) {

--- a/hyperdrive/packages/app-store/ui/src/pages/AppPage.tsx
+++ b/hyperdrive/packages/app-store/ui/src/pages/AppPage.tsx
@@ -396,20 +396,25 @@ export default function AppPage() {
 
   // Handle intent parameter from URL
   useEffect(() => {
+    if (hasProcessedIntent) {
+      return;
+    }
+
+
     const searchParams = new URLSearchParams(location.search);
     const intent = searchParams.get('intent');
 
     console.log({ intent, app, id });
 
-    if (!intent || !app || !id) {
-      console.log('no intent or app or id; returning');
+    if (!intent) {
+      setHasProcessedIntent(true);
+    }
+
+    if (!app || !id) {
+      console.log('no app or id; returning');
       return;
     }
 
-    if (hasProcessedIntent) {
-      console.log('has processed intent; returning');
-      return;
-    }
 
     // For install intent, ensure all required data is loaded before proceeding
     if (intent === 'install' && !installedApp) {

--- a/hyperdrive/packages/app-store/ui/src/types/messages.ts
+++ b/hyperdrive/packages/app-store/ui/src/types/messages.ts
@@ -1,11 +1,13 @@
 export enum IframeMessageType {
     OPEN_APP = 'OPEN_APP',
-    APP_LINK_CLICKED = 'APP_LINK_CLICKED'
+    APP_LINK_CLICKED = 'APP_LINK_CLICKED',
+    HW_LINK_CLICKED = 'HW_LINK_CLICKED'
 }
 
 export type IframeMessage =
     | { type: IframeMessageType.OPEN_APP, id: string }
     | { type: IframeMessageType.APP_LINK_CLICKED, url: string }
+    | { type: IframeMessageType.HW_LINK_CLICKED, url: string }
 
 export function isIframeMessage(message: any): message is IframeMessage {
     return message.type in IframeMessageType;

--- a/hyperdrive/packages/homepage/ui/src/components/Home/components/AppContainer.tsx
+++ b/hyperdrive/packages/homepage/ui/src/components/Home/components/AppContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useMemo, useEffect, useRef, useState } from 'react';
 import type { RunningApp } from '../../../types/app.types';
 
 interface AppContainerProps {
@@ -12,7 +12,10 @@ export const AppContainer: React.FC<AppContainerProps> = ({ app, isVisible }) =>
   const [isLoading, setIsLoading] = useState(true);
 
   // Ensure we have a valid path
-  const appUrl = app.path || `/app:${app.process}:${app.publisher}.os/`;
+  const appUrl = useMemo(() => {
+    setIsLoading(true);
+    return app.path || `/app:${app.process}:${app.publisher}.os/`;
+  }, [app.path]);
 
   const handleError = () => {
     setHasError(true);

--- a/hyperdrive/packages/homepage/ui/src/components/Home/index.tsx
+++ b/hyperdrive/packages/homepage/ui/src/components/Home/index.tsx
@@ -37,7 +37,10 @@ export default function Home() {
   // try to automatically open it
   useEffect(() => {
     if (window?.location?.hash?.startsWith('#app-')) {
-      const appNameToOpen = window.location.hash.replace('#app-', '');
+      // could be a path on the hash, or a query. delete them
+      let appNameToOpen = window.location.hash.replace('#app-', '')
+          .replace(/\?.*/, '')
+          .replace(/\/.*/, '');
       const appToOpen = apps?.find(app => app?.id === appNameToOpen);
       console.log('found window hash. attempting open', { hash: window.location.hash, appNameToOpen, appToOpen });
       if (appToOpen) {
@@ -146,7 +149,7 @@ export default function Home() {
         console.log({ url, apps });
         const urlParts = url.split('/').filter(part => part !== '' && part !== null && part !== undefined);
         const appName = urlParts[0];
-        const path = urlParts.slice(1).join('/');
+        const path = urlParts.slice(1).join('/')
         console.log({ urlParts, appName, path });
         openApp(apps.find(app => app.id.endsWith(appName)) as HomepageApp, path || undefined)
       }

--- a/hyperdrive/packages/homepage/ui/src/stores/navigationStore.ts
+++ b/hyperdrive/packages/homepage/ui/src/stores/navigationStore.ts
@@ -115,6 +115,18 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
 
     if (existingApp) {
       set({
+        runningApps: runningApps.map(rApp => {
+            const path  = `${app.path}${query || ''}`;
+            console.log(path, rApp.id, app.id);
+            if (rApp.id === app.id) {
+                console.log('found rApp')
+                return {
+                    ...rApp,
+                    path
+                }
+            }
+            return rApp;
+        }),
         currentAppId: app.id,
         isAppDrawerOpen: false,
         isRecentAppsOpen: false

--- a/hyperdrive/packages/homepage/ui/src/stores/navigationStore.ts
+++ b/hyperdrive/packages/homepage/ui/src/stores/navigationStore.ts
@@ -70,7 +70,9 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
 
     // Don't open apps without a valid path
     if (!app.path || !app.process || !app.publisher) {
-      console.warn(`Cannot open app ${app.label}: No valid path`);
+      const e = `Cannot open app ${app.label}: No valid path`
+      console.warn(e);
+      alert(e);
       return;
     }
 

--- a/hyperdrive/packages/homepage/ui/src/stores/navigationStore.ts
+++ b/hyperdrive/packages/homepage/ui/src/stores/navigationStore.ts
@@ -98,11 +98,19 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
       return;
     }
 
+    let maybeSlash = '';
+
+    if (query && query[0] && query[0] !== '?' && query[0] !== '/') {
+        // autoprepend a slash for the window history when the query type is unknown
+        console.log('autoprepended / to unknown query format');
+        maybeSlash = '/'
+    }
+
     // Add to browser history for back button support
     window?.history?.pushState(
       { type: 'app', appId: app.id, previousAppId: currentAppId },
       '',
-      `#app-${app.id}${query || ''}`
+      `#app-${app.id}${maybeSlash}${query || ''}`
     );
 
     if (existingApp) {

--- a/hyperdrive/packages/homepage/ui/src/types/messages.ts
+++ b/hyperdrive/packages/homepage/ui/src/types/messages.ts
@@ -1,11 +1,13 @@
 export enum IframeMessageType {
     OPEN_APP = 'OPEN_APP',
-    APP_LINK_CLICKED = 'APP_LINK_CLICKED'
+    APP_LINK_CLICKED = 'APP_LINK_CLICKED',
+    HW_LINK_CLICKED = 'HW_LINK_CLICKED'
 }
 
 export type IframeMessage =
     | { type: IframeMessageType.OPEN_APP, id: string }
     | { type: IframeMessageType.APP_LINK_CLICKED, url: string }
+    | { type: IframeMessageType.HW_LINK_CLICKED, url: string }
 
 export function isIframeMessage(message: any): message is IframeMessage {
     return message.type in IframeMessageType;


### PR DESCRIPTION
## Problem

1. #811 
2. hitting Refresh on an open app closes the app

## Solution

1. implement #811
2. read the `#url-hash` if present to attempt to find an app to open on refresh

## Testing

### #811
- [ ] open the Appstore Widget. Click a listing - they use `hw://` links now. 
- [ ] Verify the app listing click opens the appstore page of the respective app.
- Without closing the appstore, proceed immediately to the next set of tests.

### Reloads
- [ ] Hit Refresh, CTRL+R or F5. 
- [ ] Verify that the appstore reopens **to the main appstore page** on the page reload. (sub-page nav is something i'd like to add later on if needed - it's possible for the appstore we have but it may not be desired in the fully general case of all webapps.)
