### PR TITLE
eth: handle unresponsive rpcs

### DIFF
--- a/hyperdrive/src/eth/mod.rs
+++ b/hyperdrive/src/eth/mod.rs
@@ -1015,8 +1015,7 @@ async fn fulfill_request(
 
                     // Spawn method retry task if this is a new failure
                     if should_spawn_retry && method != "eth_sendRawTransaction" {
-                        use crate::eth::utils::spawn_method_retry_for_url_provider;
-                        spawn_method_retry_for_url_provider(
+                        crate::eth::utils::spawn_method_retry_for_url_provider(
                             providers.clone(),
                             chain_id.clone(),
                             url_provider.url.clone(),

--- a/hyperdrive/src/eth/mod.rs
+++ b/hyperdrive/src/eth/mod.rs
@@ -48,6 +48,10 @@ struct UrlProvider {
     /// a list, in case we build multiple providers for the same url
     pub pubsub: Vec<RootProvider<PubSubFrontend>>,
     pub auth: Option<Authorization>,
+    /// whether this provider was online as of last check
+    pub online: bool,
+    /// last time we checked if offline provider is back online
+    pub last_health_check: Option<Instant>,
 }
 
 #[derive(Debug, Clone)]
@@ -60,6 +64,10 @@ struct NodeProvider {
     /// the HNS update that describes this node provider
     /// kept so we can re-serialize to SavedConfigs
     pub hns_update: HnsUpdate,
+    /// whether this provider was online as of last check
+    pub online: bool,
+    /// last time we checked if offline provider is back online
+    pub last_health_check: Option<Instant>,
 }
 
 impl ActiveProviders {
@@ -76,6 +84,8 @@ impl ActiveProviders {
                     url: url.clone(),
                     pubsub: vec![],
                     auth: auth.clone(),
+                    online: true, // Default to online
+                    last_health_check: None,
                 };
                 self.urls.insert(0, url_provider);
             }
@@ -90,6 +100,8 @@ impl ActiveProviders {
                     trusted: new.trusted,
                     usable: true, // Default to usable
                     hns_update: hns_update.clone(),
+                    online: true, // Default to online
+                    last_health_check: None,
                 };
                 self.nodes.insert(0, node_provider);
             }
@@ -646,6 +658,7 @@ async fn handle_eth_action(
                         &eth_action,
                         &providers,
                         &mut receiver,
+                        &response_channels,
                         &print_tx,
                         &mut request_cache,
                     ),
@@ -665,6 +678,7 @@ async fn handle_eth_action(
                                     &eth_action,
                                     &providers,
                                     &mut receiver,
+                                    &response_channels,
                                     &print_tx,
                                     &mut request_cache,
                                 ),
@@ -730,6 +744,7 @@ async fn fulfill_request(
     eth_action: &EthAction,
     providers: &Providers,
     remote_request_receiver: &mut ProcessMessageReceiver,
+    response_channels: &ResponseChannels,
     print_tx: &PrintSender,
     request_cache: &mut RequestCache,
 ) -> EthResponse {
@@ -767,8 +782,22 @@ async fn fulfill_request(
     // then if we have none or they all fail, go to node providers.
     // finally, if no provider works, return an error.
 
-    // bump the successful provider to the front of the list for future requests
+    // Track all errors for comprehensive error reporting if all fail
+    let mut all_errors = Vec::new();
+    // Keep track of the last valid RPC error response (e.g., rate limits)
+    let mut last_rpc_error: Option<serde_json::Value> = None;
+
+    // Try URL providers, respecting their order but skipping offline ones
     for mut url_provider in urls.into_iter() {
+        // Skip offline providers
+        if !url_provider.online {
+            verbose_print(
+                print_tx,
+                &format!("eth: skipping offline url provider {}", url_provider.url),
+            )
+            .await;
+            continue;
+        }
         let (pubsub, newly_activated) = match url_provider.pubsub.first() {
             Some(pubsub) => (pubsub, false),
             None => {
@@ -791,28 +820,17 @@ async fn fulfill_request(
         };
         match pubsub.raw_request(method.into(), params).await {
             Ok(value) => {
-                let mut is_replacement_successful = true;
-                providers.entry(chain_id.clone()).and_modify(|aps| {
-                    let Some(index) = find_index(
-                        &aps.urls.iter().map(|u| u.url.as_str()).collect(),
-                        &url_provider.url,
-                    ) else {
-                        is_replacement_successful = false;
-                        return ();
-                    };
-                    let mut old_provider = aps.urls.remove(index);
-                    if newly_activated {
-                        old_provider.pubsub.push(url_provider.pubsub.pop().unwrap());
-                    }
-                    aps.urls.insert(0, old_provider);
-                });
-                if !is_replacement_successful {
-                    verbose_print(
-                        print_tx,
-                        &format!("eth: unexpectedly couldn't find provider to be modified"),
-                    )
-                    .await;
+                // Provider succeeded - just update the pubsub if newly activated
+                // DO NOT change the order of providers
+                if newly_activated {
+                    providers.entry(chain_id.clone()).and_modify(|aps| {
+                        if let Some(provider) = aps.urls.iter_mut()
+                            .find(|p| p.url == url_provider.url) {
+                            provider.pubsub.push(url_provider.pubsub.pop().unwrap());
+                        }
+                    });
                 }
+
                 let response = EthResponse::Response(value);
                 let mut request_cache = request_cache.lock().await;
                 if request_cache.len() >= MAX_REQUEST_CACHE_LEN {
@@ -831,34 +849,53 @@ async fn fulfill_request(
                     ),
                 )
                 .await;
-                // if rpc_error is of type ErrResponse, return to user!
-                if let RpcError::ErrorResp(err) = rpc_error {
-                    let err_value =
-                        serde_json::to_value(err).unwrap_or_else(|_| serde_json::Value::Null);
-                    return EthResponse::Err(EthError::RpcError(err_value));
+
+                // Track the error
+                all_errors.push((url_provider.url.clone(), format!("{:?}", rpc_error)));
+
+                // Store RPC error responses for later if all providers fail
+                if let RpcError::ErrorResp(err) = &rpc_error {
+                    last_rpc_error = Some(serde_json::to_value(err).unwrap_or_else(|_| serde_json::Value::Null));
                 }
-                if !newly_activated {
-                    // this provider failed and needs to be reset
-                    let mut is_reset_successful = true;
-                    providers.entry(chain_id.clone()).and_modify(|aps| {
-                        let Some(index) = find_index(
-                            &aps.urls.iter().map(|u| u.url.as_str()).collect(),
-                            &url_provider.url,
-                        ) else {
-                            is_reset_successful = false;
-                            return ();
-                        };
-                        let mut url = aps.urls.remove(index);
-                        url.pubsub = vec![];
-                        aps.urls.insert(index, url);
-                    });
-                    if !is_reset_successful {
-                        verbose_print(
-                            print_tx,
-                            &format!("eth: unexpectedly couldn't find provider to be modified"),
-                        )
-                        .await;
+
+                // Mark the provider as offline and spawn health check
+                let mut spawn_health_check = false;
+                providers.entry(chain_id.clone()).and_modify(|aps| {
+                    let Some(index) = find_index(
+                        &aps.urls.iter().map(|u| u.url.as_str()).collect(),
+                        &url_provider.url,
+                    ) else {
+                        return ();
+                    };
+                    let mut url = aps.urls.remove(index);
+                    url.pubsub = vec![];
+                    url.online = false;
+                    url.last_health_check = Some(Instant::now());
+
+                    // Only spawn health check if not already running
+                    if url.last_health_check.is_none() ||
+                       url.last_health_check.unwrap().elapsed() > Duration::from_secs(30) {
+                        spawn_health_check = true;
                     }
+
+                    aps.urls.insert(index, url);
+                });
+
+                // Spawn health check task if needed
+                if spawn_health_check {
+                    use crate::eth::utils::spawn_health_check_for_url_provider;
+                    spawn_health_check_for_url_provider(
+                        providers.clone(),
+                        chain_id.clone(),
+                        url_provider.url.clone(),
+                        print_tx.clone(),
+                    );
+
+                    verbose_print(
+                        print_tx,
+                        &format!("eth: spawned health check for offline provider {}", url_provider.url),
+                    )
+                    .await;
                 }
             }
         }
@@ -872,6 +909,19 @@ async fn fulfill_request(
         aps.nodes.clone()
     };
     for node_provider in &nodes {
+        // Skip offline node providers
+        if !node_provider.online || !node_provider.usable {
+            verbose_print(
+                print_tx,
+                &format!(
+                    "eth: skipping offline/unusable node provider {}",
+                    node_provider.hns_update.name
+                ),
+            )
+            .await;
+            continue;
+        }
+
         verbose_print(
             print_tx,
             &format!(
@@ -890,21 +940,75 @@ async fn fulfill_request(
             remote_request_receiver,
         )
         .await;
-        if let EthResponse::Err(e) = response {
-            if let EthError::RpcMalformedResponse = e {
-                set_node_unusable(
-                    &providers,
-                    &chain_id,
-                    &node_provider.hns_update.name,
+
+        if let EthResponse::Err(e) = &response {
+            // Track the error
+            all_errors.push((node_provider.hns_update.name.clone(), format!("{:?}", e)));
+
+            // Mark node as offline and spawn health check
+            let mut spawn_health_check = false;
+            providers.entry(chain_id.clone()).and_modify(|aps| {
+                if let Some(provider) = aps.nodes.iter_mut()
+                    .find(|p| p.hns_update.name == node_provider.hns_update.name) {
+                    provider.online = false;
+                    provider.usable = false;
+
+                    // Only spawn health check if not recently checked
+                    if provider.last_health_check.is_none() ||
+                       provider.last_health_check.unwrap().elapsed() > Duration::from_secs(30) {
+                        spawn_health_check = true;
+                        provider.last_health_check = Some(Instant::now());
+                    }
+                }
+            });
+
+            // Spawn health check task if needed
+            if spawn_health_check {
+                use crate::eth::utils::spawn_health_check_for_node_provider;
+                spawn_health_check_for_node_provider(
+                    our.to_string(),
+                    providers.clone(),
+                    chain_id.clone(),
+                    node_provider.hns_update.name.clone(),
+                    send_to_loop.clone(),
+                    response_channels.clone(),
+                    print_tx.clone(),
+                );
+
+                verbose_print(
                     print_tx,
+                    &format!("eth: spawned health check for offline node provider {}",
+                            node_provider.hns_update.name),
                 )
                 .await;
             }
+
+            // Continue trying other providers instead of returning the error
+            continue;
         } else {
+            // Success! Return the response
             return response;
         }
     }
-    EthResponse::Err(EthError::NoRpcForChain)
+
+    // All providers failed, return comprehensive error
+    if all_errors.is_empty() {
+        EthResponse::Err(EthError::NoRpcForChain)
+    } else {
+        verbose_print(
+            print_tx,
+            &format!("eth: all providers failed for chain {}: {:?}", chain_id, all_errors),
+        )
+        .await;
+
+        // If we have a valid RPC error response from any provider, return that
+        // This gives the user more specific information about why the request failed
+        if let Some(rpc_error) = last_rpc_error {
+            EthResponse::Err(EthError::RpcError(rpc_error))
+        } else {
+            EthResponse::Err(EthError::NoRpcForChain)
+        }
+    }
 }
 
 /// take an EthAction and send it to a node provider, then await a response.

--- a/hyperdrive/src/eth/mod.rs
+++ b/hyperdrive/src/eth/mod.rs
@@ -41,6 +41,16 @@ struct ActiveProviders {
     pub nodes: Vec<NodeProvider>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct MethodFailures {
+    /// Category 1: Simple methods that failed (retry until success)
+    pub failed_methods: HashSet<String>,
+    /// Category 2: eth_sendRawTransaction failures (clear after 60m)
+    pub send_raw_tx_failed: Option<Instant>,
+    /// Category 3: eth_getLogs max failed block range
+    pub failed_logs_range: Option<u64>,
+}
+
 #[derive(Debug, Clone)]
 struct UrlProvider {
     pub trusted: bool,
@@ -52,6 +62,8 @@ struct UrlProvider {
     pub online: bool,
     /// last time we checked if offline provider is back online
     pub last_health_check: Option<Instant>,
+    /// method-specific failures
+    pub method_failures: MethodFailures,
 }
 
 #[derive(Debug, Clone)]
@@ -68,7 +80,110 @@ struct NodeProvider {
     pub online: bool,
     /// last time we checked if offline provider is back online
     pub last_health_check: Option<Instant>,
+    /// method-specific failures
+    pub method_failures: MethodFailures,
 }
+
+impl MethodFailures {
+    /// Check if a method should be skipped for this provider
+    fn should_skip_method(&self, method: &str, params: &serde_json::Value) -> bool {
+        // Check Category 2: eth_sendRawTransaction with 60m timeout
+        if method == "eth_sendRawTransaction" {
+            if let Some(failed_at) = self.send_raw_tx_failed {
+                if failed_at.elapsed() < Duration::from_secs(3600) {
+                    return true;
+                }
+            }
+        }
+
+        // Check Category 3: eth_getLogs with block range
+        if method == "eth_getLogs" {
+            if let Some(block_range) = extract_block_range(params) {
+                if let Some(failed_range) = self.failed_logs_range {
+                    // Skip if current range is >= failed range
+                    if block_range >= failed_range {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // Check Category 1: Simple methods
+        self.failed_methods.contains(method)
+    }
+
+    /// Mark a method as failed
+    fn mark_method_failed(&mut self, method: &str, params: &serde_json::Value) {
+        match method {
+            "eth_sendRawTransaction" => {
+                // Category 2: Mark with timestamp
+                self.send_raw_tx_failed = Some(Instant::now());
+            }
+            "eth_getLogs" => {
+                // Category 3: Update minimum failed block range
+                if let Some(block_range) = extract_block_range(params) {
+                    // Update to the minimum of current and new failed range
+                    self.failed_logs_range = Some(match self.failed_logs_range {
+                        Some(existing) => existing.min(block_range),
+                        None => block_range,
+                    });
+                }
+            }
+            _ => {
+                // Category 1: Simple methods
+                self.failed_methods.insert(method.to_string());
+            }
+        }
+    }
+
+    /// Clear a method failure (when it succeeds)
+    fn clear_method_failure(&mut self, method: &str) {
+        match method {
+            "eth_sendRawTransaction" => {
+                self.send_raw_tx_failed = None;
+            }
+            "eth_getLogs" => {
+                // Clear the failed range when getLogs succeeds
+                self.failed_logs_range = None;
+            }
+            _ => {
+                self.failed_methods.remove(method);
+            }
+        }
+    }
+}
+
+/// Extract block range from eth_getLogs params
+fn extract_block_range(params: &serde_json::Value) -> Option<u64> {
+    if let Some(arr) = params.as_array() {
+        if let Some(obj) = arr.first().and_then(|v| v.as_object()) {
+            let from_block = parse_block_number(obj.get("fromBlock")?)?;
+            let to_block = parse_block_number(obj.get("toBlock")?)?;
+            return Some(to_block.saturating_sub(from_block));
+        }
+    }
+    None
+}
+
+/// Parse block number from various formats (hex string, number, "latest", etc.)
+fn parse_block_number(value: &serde_json::Value) -> Option<u64> {
+    match value {
+        serde_json::Value::String(s) => {
+            if s.starts_with("0x") {
+                u64::from_str_radix(&s[2..], 16).ok()
+            } else {
+                match s.as_str() {
+                    "latest" | "pending" => Some(u64::MAX),
+                    "earliest" => Some(0),
+                    _ => s.parse().ok(),
+                }
+            }
+        }
+        serde_json::Value::Number(n) => n.as_u64(),
+        _ => None,
+    }
+}
+
 
 impl ActiveProviders {
     fn add_provider_config(&mut self, new: ProviderConfig) {
@@ -86,6 +201,7 @@ impl ActiveProviders {
                     auth: auth.clone(),
                     online: true, // Default to online
                     last_health_check: None,
+                    method_failures: MethodFailures::default(),
                 };
                 self.urls.insert(0, url_provider);
             }
@@ -102,6 +218,7 @@ impl ActiveProviders {
                     hns_update: hns_update.clone(),
                     online: true, // Default to online
                     last_health_check: None,
+                    method_failures: MethodFailures::default(),
                 };
                 self.nodes.insert(0, node_provider);
             }
@@ -798,6 +915,17 @@ async fn fulfill_request(
             .await;
             continue;
         }
+
+        // Check method-specific failures
+        if url_provider.method_failures.should_skip_method(method, params) {
+            verbose_print(
+                print_tx,
+                &format!("eth: skipping url provider {} due to previous {} failure",
+                        url_provider.url, method),
+            )
+            .await;
+            continue;
+        }
         let (pubsub, newly_activated) = match url_provider.pubsub.first() {
             Some(pubsub) => (pubsub, false),
             None => {
@@ -820,16 +948,18 @@ async fn fulfill_request(
         };
         match pubsub.raw_request(method.into(), params).await {
             Ok(value) => {
-                // Provider succeeded - just update the pubsub if newly activated
-                // DO NOT change the order of providers
-                if newly_activated {
-                    providers.entry(chain_id.clone()).and_modify(|aps| {
-                        if let Some(provider) = aps.urls.iter_mut()
-                            .find(|p| p.url == url_provider.url) {
+                // Provider succeeded - clear any method failures and update pubsub if needed
+                providers.entry(chain_id.clone()).and_modify(|aps| {
+                    if let Some(provider) = aps.urls.iter_mut()
+                        .find(|p| p.url == url_provider.url) {
+                        // Clear method failure since it succeeded
+                        provider.method_failures.clear_method_failure(method);
+
+                        if newly_activated {
                             provider.pubsub.push(url_provider.pubsub.pop().unwrap());
                         }
-                    });
-                }
+                    }
+                });
 
                 let response = EthResponse::Response(value);
                 let mut request_cache = request_cache.lock().await;
@@ -854,11 +984,50 @@ async fn fulfill_request(
                 all_errors.push((url_provider.url.clone(), format!("{:?}", rpc_error)));
 
                 // Store RPC error responses for later if all providers fail
-                if let RpcError::ErrorResp(err) = &rpc_error {
+                let is_rpc_error_resp = if let RpcError::ErrorResp(err) = &rpc_error {
                     last_rpc_error = Some(serde_json::to_value(err).unwrap_or_else(|_| serde_json::Value::Null));
+                    true
+                } else {
+                    false
+                };
+
+                // Determine what to mark as failed
+                if is_rpc_error_resp {
+                    // Valid RPC error response - mark the specific method as failed
+                    let mut should_spawn_retry = false;
+                    providers.entry(chain_id.clone()).and_modify(|aps| {
+                        let Some(provider) = aps.urls.iter_mut()
+                            .find(|p| p.url == url_provider.url) else {
+                            return;
+                        };
+                        // Check if this method wasn't already marked as failed
+                        if !provider.method_failures.should_skip_method(method, params) {
+                            provider.method_failures.mark_method_failed(method, params);
+                            should_spawn_retry = true;
+                        }
+                    });
+
+                    // Spawn method retry task if this is a new failure
+                    if should_spawn_retry && method != "eth_sendRawTransaction" {
+                        use crate::eth::utils::spawn_method_retry_for_url_provider;
+                        spawn_method_retry_for_url_provider(
+                            providers.clone(),
+                            chain_id.clone(),
+                            url_provider.url.clone(),
+                            method.to_string(),
+                            params.clone(),
+                            print_tx.clone(),
+                        );
+                        verbose_print(
+                            print_tx,
+                            &format!("eth: spawned method retry for {} on {}", method, url_provider.url),
+                        ).await;
+                    }
+                    // Continue to next provider without marking offline
+                    continue;
                 }
 
-                // Mark the provider as offline and spawn health check
+                // Transport/connection error - mark the provider as offline and spawn health check
                 let mut spawn_health_check = false;
                 providers.entry(chain_id.clone()).and_modify(|aps| {
                     let Some(index) = find_index(
@@ -922,6 +1091,17 @@ async fn fulfill_request(
             continue;
         }
 
+        // Check method-specific failures
+        if node_provider.method_failures.should_skip_method(method, params) {
+            verbose_print(
+                print_tx,
+                &format!("eth: skipping node provider {} due to previous {} failure",
+                        node_provider.hns_update.name, method),
+            )
+            .await;
+            continue;
+        }
+
         verbose_print(
             print_tx,
             &format!(
@@ -945,11 +1125,56 @@ async fn fulfill_request(
             // Track the error
             all_errors.push((node_provider.hns_update.name.clone(), format!("{:?}", e)));
 
-            // Mark node as offline and spawn health check
-            let mut spawn_health_check = false;
-            providers.entry(chain_id.clone()).and_modify(|aps| {
-                if let Some(provider) = aps.nodes.iter_mut()
-                    .find(|p| p.hns_update.name == node_provider.hns_update.name) {
+            // Check if it's an RPC error (method failure) vs transport error
+            let is_rpc_error = matches!(e, EthError::RpcError(_));
+
+            if is_rpc_error {
+                // Mark the specific method as failed
+                let mut should_spawn_retry = false;
+                providers.entry(chain_id.clone()).and_modify(|aps| {
+                    let Some(provider) = aps.nodes.iter_mut()
+                        .find(|p| p.hns_update.name == node_provider.hns_update.name) else {
+                        return;
+                    };
+                    // Check if this method wasn't already marked as failed
+                    if !provider.method_failures.should_skip_method(method, params) {
+                        provider.method_failures.mark_method_failed(method, params);
+                        should_spawn_retry = true;
+                    }
+                });
+                // Store the RPC error
+                if let EthError::RpcError(err_value) = e {
+                    last_rpc_error = Some(err_value.clone());
+                }
+
+                // Spawn method retry task if this is a new failure
+                if should_spawn_retry && method != "eth_sendRawTransaction" {
+                    use crate::eth::utils::spawn_method_retry_for_node_provider;
+                    spawn_method_retry_for_node_provider(
+                        our.to_string(),
+                        providers.clone(),
+                        chain_id.clone(),
+                        node_provider.hns_update.name.clone(),
+                        method.to_string(),
+                        params.clone(),
+                        send_to_loop.clone(),
+                        response_channels.clone(),
+                        print_tx.clone(),
+                    );
+                    verbose_print(
+                        print_tx,
+                        &format!("eth: spawned method retry for {} on node {}",
+                                method, node_provider.hns_update.name),
+                    ).await;
+                }
+            } else {
+                // Transport/timeout error - mark node as offline and spawn health check
+                let mut spawn_health_check = false;
+                providers.entry(chain_id.clone()).and_modify(|aps| {
+                    let Some(provider) = aps.nodes.iter_mut()
+                        .find(|p| p.hns_update.name == node_provider.hns_update.name) else {
+                        return;
+                    };
                     provider.online = false;
                     provider.usable = false;
 
@@ -959,8 +1184,7 @@ async fn fulfill_request(
                         spawn_health_check = true;
                         provider.last_health_check = Some(Instant::now());
                     }
-                }
-            });
+                });
 
             // Spawn health check task if needed
             if spawn_health_check {
@@ -983,10 +1207,17 @@ async fn fulfill_request(
                 .await;
             }
 
+            }
             // Continue trying other providers instead of returning the error
             continue;
         } else {
-            // Success! Return the response
+            // Success! Clear method failure and return the response
+            providers.entry(chain_id.clone()).and_modify(|aps| {
+                if let Some(provider) = aps.nodes.iter_mut()
+                    .find(|p| p.hns_update.name == node_provider.hns_update.name) {
+                    provider.method_failures.clear_method_failure(method);
+                }
+            });
             return response;
         }
     }

--- a/hyperdrive/src/eth/utils.rs
+++ b/hyperdrive/src/eth/utils.rs
@@ -1,10 +1,11 @@
-use crate::eth::{Providers, UrlProvider};
-use alloy::providers::ProviderBuilder;
+use crate::eth::{Providers, ResponseChannels, UrlProvider};
+use alloy::providers::{Provider, ProviderBuilder};
 use alloy::rpc::client::WsConnect;
 use anyhow::Result;
 use lib::types::core::*;
 use lib::types::eth::*;
 use serde::Serialize;
+use std::time::{Duration, Instant};
 use url::Url;
 
 pub async fn activate_url_provider(provider: &mut UrlProvider) -> Result<()> {
@@ -204,4 +205,173 @@ pub async fn set_node_unusable(
         .await;
     }
     is_replacement_successful
+}
+
+/// Check if an offline provider is back online by sending eth_blockNumber
+pub async fn check_url_provider_health(provider: &mut UrlProvider) -> bool {
+    // First try to activate the provider if not already activated
+    if provider.pubsub.is_empty() {
+        if let Err(_) = activate_url_provider(provider).await {
+            return false;
+        }
+    }
+
+    // Try to get the latest block number as a health check
+    if let Some(pubsub) = provider.pubsub.first() {
+        match tokio::time::timeout(
+            Duration::from_secs(10),
+            pubsub.get_block_number()
+        ).await {
+            Ok(Ok(_)) => true,
+            _ => {
+                // Provider failed, clear the connection
+                provider.pubsub.clear();
+                false
+            }
+        }
+    } else {
+        false
+    }
+}
+
+/// Spawn a health check task for an offline URL provider
+pub fn spawn_health_check_for_url_provider(
+    providers: Providers,
+    chain_id: u64,
+    url: String,
+    print_tx: PrintSender,
+) {
+    tokio::spawn(async move {
+        let mut backoff_mins = 1u64;
+
+        loop {
+            // Wait for the backoff period
+            tokio::time::sleep(Duration::from_secs(backoff_mins * 60)).await;
+
+            // Try to check health
+            let mut provider_online = false;
+
+            if let Some(mut aps) = providers.get_mut(&chain_id) {
+                if let Some(provider) = aps.urls.iter_mut().find(|p| p.url == url) {
+                    if check_url_provider_health(provider).await {
+                        provider.online = true;
+                        provider.last_health_check = Some(Instant::now());
+                        provider_online = true;
+
+                        verbose_print(
+                            &print_tx,
+                            &format!("eth: provider {} is back online", url),
+                        ).await;
+                    } else {
+                        provider.last_health_check = Some(Instant::now());
+                    }
+                }
+            }
+
+            if provider_online {
+                // Provider is back online, exit the health check loop
+                break;
+            }
+
+            // Double the backoff, max 60 minutes
+            backoff_mins = (backoff_mins * 2).min(60);
+        }
+    });
+}
+
+/// Spawn a health check task for an offline node provider
+pub fn spawn_health_check_for_node_provider(
+    our: String,
+    providers: Providers,
+    chain_id: u64,
+    node_name: String,
+    send_to_loop: MessageSender,
+    response_channels: ResponseChannels,
+    print_tx: PrintSender,
+) {
+    tokio::spawn(async move {
+        let mut backoff_mins = 1u64;
+
+        loop {
+            // Wait for the backoff period
+            tokio::time::sleep(Duration::from_secs(backoff_mins * 60)).await;
+
+            // Try to send eth_blockNumber to check health
+            let km_id = rand::random();
+            let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+
+            // Register our response channel
+            response_channels.insert(km_id, sender);
+
+            // Send eth_blockNumber request
+            kernel_message(
+                &our,
+                km_id,
+                Address {
+                    node: node_name.clone(),
+                    process: ETH_PROCESS_ID.clone(),
+                },
+                None,
+                true,
+                Some(10),
+                EthAction::Request {
+                    chain_id: chain_id,
+                    method: "eth_blockNumber".to_string(),
+                    params: serde_json::json!([]),
+                },
+                &send_to_loop,
+            ).await;
+
+            // Wait for response with timeout
+            let provider_online = match tokio::time::timeout(
+                Duration::from_secs(10),
+                receiver.recv()
+            ).await {
+                Ok(Some(Ok(km))) => {
+                    // Check if we got a successful response
+                    matches!(km.message, Message::Response(_))
+                }
+                _ => false,
+            };
+
+            // Clean up response channel
+            response_channels.remove(&km_id);
+
+            if provider_online {
+                // Mark the provider as online
+                if let Some(mut aps) = providers.get_mut(&chain_id) {
+                    if let Some(provider) = aps.nodes.iter_mut()
+                        .find(|p| p.hns_update.name == node_name) {
+                        provider.online = true;
+                        provider.usable = true;
+                        provider.last_health_check = Some(Instant::now());
+
+                        verbose_print(
+                            &print_tx,
+                            &format!("eth: node provider {} is back online", node_name),
+                        ).await;
+                    }
+                }
+                // Provider is back online, exit the health check loop
+                break;
+            } else {
+                // Provider is still offline, update last health check time
+                if let Some(mut aps) = providers.get_mut(&chain_id) {
+                    if let Some(provider) = aps.nodes.iter_mut()
+                        .find(|p| p.hns_update.name == node_name) {
+                        provider.last_health_check = Some(Instant::now());
+                    }
+                }
+
+                verbose_print(
+                    &print_tx,
+                    &format!("eth: health check failed for node provider {} (backoff: {} min)",
+                            node_name, backoff_mins),
+                ).await;
+            }
+
+            // Double the backoff, max 60 minutes
+            backoff_mins = (backoff_mins * 2).min(60);
+        }
+    });
 }


### PR DESCRIPTION
## Problem

1. ETH runtime module is brittle to RPC failure
2. hypermap-cacher is too closely built around Alchemy API settings (which just changed!)

## Solution

1. Improve ETH runtime module by making RPC entries definitely ordered and by tracking what methods an RPC has failed to serve (and skipping that RPC for those methods in future; and retrying on RPC failures to allow for un-marking of failure if it is intermittent)
2. Reduce that. Instead we now try to getLogs for the entire history of logs and halve the log range until it works

## Testing

- [x] Getting logs from scratch without any hypermap-cacher bootstrapping nodes
- [x] Falling back from one RPC to another
- [x] Proper setting of log range for range-limited RPC providers

## Docs Update

None

## Notes

Future work on/around ETH runtime module:

1. Script(s) to change ordering of ETH RPCs

@dolled-possum 