### PR TITLE
register-ui: increase pre-commit wait time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "clap",
  "fs-err",
  "kit",
+ "rayon",
  "serde",
  "serde_json",
  "tokio",
@@ -3517,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive"
-version = "1.8.1"
+version = "1.8.3"
 dependencies = [
  "aes-gcm",
  "alloy",
@@ -3577,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive_lib"
-version = "1.8.1"
+version = "1.8.3"
 dependencies = [
  "lib",
 ]
@@ -4265,7 +4266,7 @@ dependencies = [
 [[package]]
 name = "kit"
 version = "3.1.1"
-source = "git+https://github.com/hyperware-ai/kit?rev=275f02c#275f02c839e239083ba656871e10be845f4d85f5"
+source = "git+https://github.com/hyperware-ai/kit?rev=0d0469e#0d0469ec89ce5ff8f25223e3d968cd5760554251"
 dependencies = [
  "alloy",
  "alloy-sol-macro",
@@ -4334,7 +4335,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lib"
-version = "1.8.1"
+version = "1.8.3"
 dependencies = [
  "alloy",
  "anyhow",

--- a/hyperdrive/src/register-ui/src/pages/CommitDotOsName.tsx
+++ b/hyperdrive/src/register-ui/src/pages/CommitDotOsName.tsx
@@ -188,7 +188,7 @@ function CommitDotOsName({
     useEffect(() => {
         if (txConfirmed) {
             console.log("confirmed commit to .os name: ", name)
-            console.log("waiting 16 seconds to make commit valid...")
+            console.log("waiting 20 seconds to make commit valid...")
             setTimeout(() => {
                 setIsConfirmed(true);
                 setHnsName(`${name}.os`);
@@ -198,7 +198,7 @@ function CommitDotOsName({
                     setRouters(routersToUse);
                 }
                 navigate("/mint-os-name");
-            }, 16000)
+            }, 20000)
         }
     }, [txConfirmed, address, name, setHnsName, navigate, specifyRouters, customRouters, setRouters]);
 
@@ -210,7 +210,7 @@ function CommitDotOsName({
                         {isPending || isConfirming || (txConfirmed && !isConfirmed) ? (
                             <Loader msg={
                                 isConfirming ? 'Pre-committing to chosen name...' :
-                                    (txConfirmed && !isConfirmed) ? 'Waiting 15s for commit to become valid...' :
+                                    (txConfirmed && !isConfirmed) ? 'Waiting 20s for commit to become valid...' :
                                         'Please confirm the transaction in your wallet'
                             } />
                         ) : (

--- a/hyperdrive/src/register.rs
+++ b/hyperdrive/src/register.rs
@@ -501,8 +501,7 @@ async fn handle_boot(
                     };
 
                     let hash = boot.eip712_signing_hash(&domain);
-                    let sig =
-                        Signature::from_str(&info.signature).map_err(|_| warp::reject())?;
+                    let sig = Signature::from_str(&info.signature).map_err(|_| warp::reject())?;
 
                     let recovered_address = sig
                         .recover_address_from_prehash(&hash)


### PR DESCRIPTION
## Problem

We pre-commit to .os mints to avoid name stealing. For some reason it stopped working with a [`CommitTooNew`](https://4byte.sourcify.dev/?q=0x9e8ddd6d) (see [here](https://github.com/hyperware-ai/protocol/blob/77622e4b26021274b355edff3c9289a4bb9cd14b/src/interfaces/IHyperAccountCommittable.sol#L6) and [here](https://github.com/hyperware-ai/protocol/blob/77622e4b26021274b355edff3c9289a4bb9cd14b/src/account/HyperAccountCommitMinter.sol#L93)): our code did not change, perhaps something to do with base block times?

## Solution

Bump delay from 16s to 20s (the pre-commit time required onchain is 15s).

## Testing

Minting works again.

## Docs Update

None

## Notes

None