### PR TITLE
app-store: remove mobile bottom bar for public view

### DIFF
--- a/hyperdrive/packages/app-store/public-ui/src/App.tsx
+++ b/hyperdrive/packages/app-store/public-ui/src/App.tsx
@@ -35,7 +35,7 @@ function App() {
   };
 
   return (
-    <div className="bg-white dark:bg-stone grow self-stretch min-h-screen px-4 pb-32 md:pb-0 md:px-0 overflow-y-auto">
+    <div className="bg-white dark:bg-stone grow self-stretch min-h-screen px-4 md:px-0 overflow-y-auto">
       <Router basename={getBasename()}>
         <NavBar />
         <Routes>

--- a/hyperdrive/packages/app-store/public-ui/src/components/NavBar.tsx
+++ b/hyperdrive/packages/app-store/public-ui/src/components/NavBar.tsx
@@ -44,9 +44,6 @@ const NavBar: React.FC = () => {
             <nav className="hidden md:flex items-center gap-2 self-stretch flex-wrap">
                 {lesBoutons}
             </nav>
-            <nav className="fixed md:hidden bottom-0 left-0 right-0 p-2 bg-iris flex items-center gap-2 justify-center flex-wrap z-20">
-                {lesBoutons}
-            </nav>
         </header>
     );
 };


### PR DESCRIPTION
## Problem

Bottom bar takes lots of screen realestate for no benefit on public view

<img width="772" height="988" alt="image" src="https://github.com/user-attachments/assets/8eaf48dd-e26f-4f38-80c0-e9dd99349e2c" />


## Solution

Remove it